### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The Linux and Windows (post) build steps are still under development and work in
 - cmake >= 3.8
 - SSD/HDD free space >= 1.5 GB
 - Main memory >= 8 GB
-If you have 8 GB then please change the last line in the script `generateLinux.sh` from `make -j8` to `make`. 
+If you have 8 GB then please change the last line in the script `generate_Linux.sh` from `make -j8` to `make`. 
 
 ##### Build steps:
 * Install `uuid-dev` (needed for building antlr4):
@@ -78,10 +78,10 @@ $ sudo apt install uuid-dev
 ```
 * Change your current directory to `cpp/build/generateLinux` and execute:
 ```bash
-$ ./generateLinux.sh Release make
+$ ./generate_Linux.sh Release make
 ```
 * This creates all necessary makefiles for building the openSCENARIO library as shared library and starts the compilation process by executing `make -j8` starting 8 build threads. If you have 8 GB then change the make command to `make` only as described above in the paragraph **"System requirements"**.
-* The general call to the script above is `./generateLinux.sh [Release|Debug] [static] [make]`.
+* The general call to the script above is `./generate_Linux.sh [Release|Debug] [static] [make]`.
 * To create a package containing all necessary include files and binaries (libraries) execute the bash script below. A file named `openSCENARIO_<date>.tgz` will be created.
 ```bash
 $ ./createLinuxBinPackage.sh


### PR DESCRIPTION
Fixed typo for generate script on Linux.
Signed-off-by: Dieter Finkenzeller <deakon@tri-nitro.com>

#### Reference to a related issue in the repository
-

#### Add a description
Fixed a typo in Linux bash script command from generateLinux.sh to generate_Linux.sh.

**Some questions to ask**:
What is this change?
- typo fix
What does it fix?
- a typo
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
- More a bug fix, no doesn't break anything.
How has it been tested?
- it's a typo and the command is correctly stated

#### Mention a member
@ahege 

#### Check the checklist

- [x] My code follows the [contributors guidelines](https://github.com/ahege/openscenario.api.test/blob/master/doc/howtocontribute.rst) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/ahege/openscenario.api.test/blob/master/doc).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests / travis ci pass locally with my changes.
