### PR TITLE
#113 Added v1_1 option to command line of reader

### DIFF
--- a/cpp/applications/openScenarioTester/src/TestReaderV1_0.cpp
+++ b/cpp/applications/openScenarioTester/src/TestReaderV1_0.cpp
@@ -108,7 +108,7 @@ namespace NET_ASAM_OPENSCENARIO
 			command += " Test ";
 			command += " > " + _executablePath + "/" + kInputDir + kResultFileName;
 			auto res = Assert( USAGE_RESULT == ExecuteSystemCommand( command ), ASSERT_LOCATION );
-			res = res && Assert( "OpenScenarioChecker [[{-i <filename>|-d <dirname>} [-p <paramfilename>]] | -v]" == GetLine( kResultFileName, 4 ), ASSERT_LOCATION );
+			res = res && Assert( "OpenScenarioChecker [[{-i <filename>|-d <dirname>} [-p <paramfilename>] [-v1_1]] | -v]" == GetLine( kResultFileName, 4 ), ASSERT_LOCATION );
 			return res;
 		}
 

--- a/cpp/applications/openScenarioTester/src/TestReaderV1_1.cpp
+++ b/cpp/applications/openScenarioTester/src/TestReaderV1_1.cpp
@@ -51,6 +51,7 @@ namespace NET_ASAM_OPENSCENARIO
 		{
 			std::string command( DOT_SLASH ); command.append( "OpenScenarioReader" );
 			command += " -i " + _executablePath + "/" + kInputDir + "simpleImport/simpleImport.xosc";
+			command += " -v1_1 ";
 			command += " > " + _executablePath + "/" + kInputDir + kResultFileName;
 			return Assert( SUCCESS_RESULT == ExecuteSystemCommand( command ), ASSERT_LOCATION );
 		}
@@ -59,6 +60,7 @@ namespace NET_ASAM_OPENSCENARIO
 		{
 			std::string command( DOT_SLASH ); command.append( "OpenScenarioReader" );
 			command += " -d " + _executablePath + "/" + kInputDir + "goodDirectory";
+			command += " -v1_1 ";
 			command += " > " + _executablePath + "/" + kInputDir + kResultFileName;
 			auto temp = ExecuteSystemCommand( command );
 			return Assert( SUCCESS_RESULT == ExecuteSystemCommand( command ), ASSERT_LOCATION );
@@ -68,6 +70,7 @@ namespace NET_ASAM_OPENSCENARIO
 		{
 			std::string command( DOT_SLASH ); command.append( "OpenScenarioReader" );
 			command += " -d " + _executablePath + "/" + kInputDir + "badDirectory";
+			command += " -v1_1 ";
 			command += " > " + _executablePath + "/" + kInputDir + kResultFileName;
 			return Assert( ERROR_RESULT == ExecuteSystemCommand( command ), ASSERT_LOCATION );
 		}
@@ -76,6 +79,7 @@ namespace NET_ASAM_OPENSCENARIO
 		{
 			std::string command( DOT_SLASH ); command.append( "OpenScenarioReader" );
 			command += " -i " "testFileNotFound";
+			command += " -v1_1 ";
 			command += " > " + _executablePath + "/" + kInputDir + kResultFileName;
 			auto res = Assert( ERROR_RESULT == ExecuteSystemCommand( command ), ASSERT_LOCATION );
 			res = res && Assert( "Scenario file not found 'testFileNotFound'" == GetLine( kResultFileName, 4 ), ASSERT_LOCATION );
@@ -86,6 +90,7 @@ namespace NET_ASAM_OPENSCENARIO
 		{
 			std::string command( DOT_SLASH ); command.append( "OpenScenarioReader" );
 			command += " -d " "testDirectoryNotFound";
+			command += " -v1_1 ";
 			command += " > " + _executablePath + "/" + kInputDir + kResultFileName;
 			auto res = Assert( ERROR_RESULT == ExecuteSystemCommand( command ), ASSERT_LOCATION );
 			res = res && Assert( "'testDirectoryNotFound' does not exists or is not a directory." == GetLine( kResultFileName, 4 ), ASSERT_LOCATION );
@@ -96,9 +101,10 @@ namespace NET_ASAM_OPENSCENARIO
 		{
 			std::string command( DOT_SLASH ); command.append( "OpenScenarioReader" );
 			command += " -i " + _executablePath + "/" + kInputDir + "DoubleLaneChangerParamsError.xosc";
+			command += " -v1_1 ";
 			command += " > " + _executablePath + "/" + kInputDir + kResultFileName;
 			auto res = Assert( ERROR_RESULT == ExecuteSystemCommand( command ), ASSERT_LOCATION );
-			res = res && Assert( "Validation failed with 3 errors and 0 warnings." == GetLine( kResultFileName, 11 ), ASSERT_LOCATION );
+			res = res && Assert( "Validation failed with 3 errors and 1 warnings." == GetLine( kResultFileName, 12 ), ASSERT_LOCATION );
 			return res;
 		}
 
@@ -108,7 +114,7 @@ namespace NET_ASAM_OPENSCENARIO
 			command += " Test ";
 			command += " > " + _executablePath + "/" + kInputDir + kResultFileName;
 			auto res = Assert( USAGE_RESULT == ExecuteSystemCommand( command ), ASSERT_LOCATION );
-			res = res && Assert( "OpenScenarioChecker [[{-i <filename>|-d <dirname>} [-p <paramfilename>]] | -v]" == GetLine( kResultFileName, 4 ), ASSERT_LOCATION );
+			res = res && Assert( "OpenScenarioChecker [[{-i <filename>|-d <dirname>} [-p <paramfilename>] [-v1_1]] | -v]" == GetLine( kResultFileName, 4 ), ASSERT_LOCATION );
 			return res;
 		}
 
@@ -117,6 +123,7 @@ namespace NET_ASAM_OPENSCENARIO
 			std::string command( DOT_SLASH ); command.append( "OpenScenarioReader" );
 			command += " -i " + _executablePath + "/" + kInputDir + "DoubleLaneChangerInjectedParams.xosc";
 			command += " -p " + _executablePath + "/" + kInputDir + "params.conf";
+			command += " -v1_1 ";
 			command += " > " + _executablePath + "/" + kInputDir + kResultFileName;
 			auto res = Assert( ERROR_RESULT == ExecuteSystemCommand( command ), ASSERT_LOCATION );
 			res = res && Assert( "\ttestBoolean\ttrue" == GetLine( kResultFileName, 5 ), ASSERT_LOCATION );
@@ -134,6 +141,7 @@ namespace NET_ASAM_OPENSCENARIO
 			std::string command( DOT_SLASH ); command.append( "OpenScenarioReader" );
 			command += " -i " + _executablePath + "/" + kInputDir + "DoubleLaneChangerInjectedParams.xosc";
 			command += " -p " + _executablePath + "/" + kInputDir + "paramsSyntaxError.conf";
+			command += " -v1_1 ";
 			command += " > " + _executablePath + "/" + kInputDir + kResultFileName;
 			auto res = Assert( ERROR_RESULT == ExecuteSystemCommand( command ), ASSERT_LOCATION );
 			res = res && Assert( "Syntax error in parameter file: line 8" == GetLine( kResultFileName, 4 ), ASSERT_LOCATION );
@@ -145,6 +153,7 @@ namespace NET_ASAM_OPENSCENARIO
 			std::string command( DOT_SLASH ); command.append( "OpenScenarioReader" );
 			command += " -i " + _executablePath + "/" + kInputDir + "DoubleLaneChangerInjectedParams.xosc";
 			command += " -p " + _executablePath + "/" + kInputDir + "paramsSyntaxError2.conf";
+			command += " -v1_1 ";
 			command += " > " + _executablePath + "/" + kInputDir + kResultFileName;
 			auto res = Assert( ERROR_RESULT == ExecuteSystemCommand( command ), ASSERT_LOCATION );
 			res = res && Assert( "Syntax error in parameter file: line 5" == GetLine( kResultFileName, 4 ), ASSERT_LOCATION );
@@ -156,6 +165,7 @@ namespace NET_ASAM_OPENSCENARIO
 			std::string command( DOT_SLASH ); command.append( "OpenScenarioReader" );
 			command += " -i " + _executablePath + "/" + kInputDir + "DoubleLaneChangerInjectedParams.xosc";
 			command += " -p paramsNotFound.conf";
+			command += " -v1_1 ";
 			command += " > " + _executablePath + "/" + kInputDir + kResultFileName;
 			auto res = Assert( ERROR_RESULT == ExecuteSystemCommand( command ), ASSERT_LOCATION );
 			res = res && Assert( "paramsfile not found" == GetLine( kResultFileName, 4 ), ASSERT_LOCATION );


### PR DESCRIPTION
Signed-off-by: ahege <a.hege@rac.de>

#### Reference to a related issue in the repository
See #113

**Some questions to ask**:
What is this change? See #113
What does it fix? See #113
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version? See #113
How has it been tested? Yes unit tests  in TestReaderV1_1.cpp are adjusted.

#### Mention a member
Add @mentions of the person or team responsible for reviewing proposed changes.

#### Check the checklist

- [x] My code follows the [contributors guidelines](https://github.com/ahege/openscenario.api.test/blob/master/doc/howtocontribute.rst) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/ahege/openscenario.api.test/blob/master/doc).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.
