### PR TITLE
#111 change to set functions for every optional attribute

### DIFF
--- a/cpp/openScenarioLib/generated/v1_1/api/ApiClassInterfacesV1_1.h
+++ b/cpp/openScenarioLib/generated/v1_1/api/ApiClassInterfacesV1_1.h
@@ -294,6 +294,11 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property steadyState is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetSteadyState() const = 0;
 
         };
 
@@ -529,6 +534,11 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property stopTrigger is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetStopTrigger() const = 0;
 
         };
 
@@ -591,6 +601,21 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property globalAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetGlobalAction() const = 0;
+            /**
+            * Retrieves whether property userDefinedAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetUserDefinedAction() const = 0;
+            /**
+            * Retrieves whether property privateAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetPrivateAction() const = 0;
 
         };
 
@@ -635,18 +660,12 @@ namespace NET_ASAM_OPENSCENARIO
             * Retrieves whether property lateral is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetLateral() const
-            {
-                return false;
-            }
+            virtual bool IsSetLateral() const = 0;
             /**
             * Retrieves whether property longitudinal is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetLongitudinal() const
-            {
-                return false;
-            }
+            virtual bool IsSetLongitudinal() const = 0;
 
         };
 
@@ -702,6 +721,11 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property entityRefs is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetEntityRefs() const = 0;
 
         };
 
@@ -801,18 +825,22 @@ namespace NET_ASAM_OPENSCENARIO
             * Retrieves whether property activateLateral is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetActivateLateral() const
-            {
-                return false;
-            }
+            virtual bool IsSetActivateLateral() const = 0;
             /**
             * Retrieves whether property activateLongitudinal is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetActivateLongitudinal() const
-            {
-                return false;
-            }
+            virtual bool IsSetActivateLongitudinal() const = 0;
+            /**
+            * Retrieves whether property controller is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetController() const = 0;
+            /**
+            * Retrieves whether property catalogReference is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCatalogReference() const = 0;
 
         };
 
@@ -855,6 +883,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property route is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRoute() const = 0;
+            /**
+            * Retrieves whether property catalogReference is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCatalogReference() const = 0;
 
         };
 
@@ -995,6 +1033,11 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property additionalAxles is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetAdditionalAxles() const = 0;
 
         };
 
@@ -1231,6 +1274,41 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property parameterCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetParameterCondition() const = 0;
+            /**
+            * Retrieves whether property timeOfDayCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTimeOfDayCondition() const = 0;
+            /**
+            * Retrieves whether property simulationTimeCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetSimulationTimeCondition() const = 0;
+            /**
+            * Retrieves whether property storyboardElementStateCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetStoryboardElementStateCondition() const = 0;
+            /**
+            * Retrieves whether property userDefinedValueCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetUserDefinedValueCondition() const = 0;
+            /**
+            * Retrieves whether property trafficSignalCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrafficSignalCondition() const = 0;
+            /**
+            * Retrieves whether property trafficSignalControllerCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrafficSignalControllerCondition() const = 0;
 
         };
 
@@ -1469,6 +1547,51 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property name is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetName() const = 0;
+            /**
+            * Retrieves whether property vehicles is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetVehicles() const = 0;
+            /**
+            * Retrieves whether property controllers is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetControllers() const = 0;
+            /**
+            * Retrieves whether property pedestrians is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetPedestrians() const = 0;
+            /**
+            * Retrieves whether property miscObjects is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetMiscObjects() const = 0;
+            /**
+            * Retrieves whether property environments is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetEnvironments() const = 0;
+            /**
+            * Retrieves whether property maneuvers is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetManeuvers() const = 0;
+            /**
+            * Retrieves whether property trajectories is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrajectories() const = 0;
+            /**
+            * Retrieves whether property routes is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRoutes() const = 0;
 
         };
 
@@ -1604,6 +1727,46 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property vehicleCatalog is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetVehicleCatalog() const = 0;
+            /**
+            * Retrieves whether property controllerCatalog is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetControllerCatalog() const = 0;
+            /**
+            * Retrieves whether property pedestrianCatalog is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetPedestrianCatalog() const = 0;
+            /**
+            * Retrieves whether property miscObjectCatalog is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetMiscObjectCatalog() const = 0;
+            /**
+            * Retrieves whether property environmentCatalog is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetEnvironmentCatalog() const = 0;
+            /**
+            * Retrieves whether property maneuverCatalog is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetManeuverCatalog() const = 0;
+            /**
+            * Retrieves whether property trajectoryCatalog is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrajectoryCatalog() const = 0;
+            /**
+            * Retrieves whether property routeCatalog is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRouteCatalog() const = 0;
 
         };
 
@@ -1683,6 +1846,11 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property parameterAssignments is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetParameterAssignments() const = 0;
 
         };
 
@@ -1866,34 +2034,22 @@ namespace NET_ASAM_OPENSCENARIO
             * Retrieves whether property curvatureDot is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetCurvatureDot() const
-            {
-                return false;
-            }
+            virtual bool IsSetCurvatureDot() const = 0;
             /**
             * Retrieves whether property curvaturePrime is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetCurvaturePrime() const
-            {
-                return false;
-            }
+            virtual bool IsSetCurvaturePrime() const = 0;
             /**
             * Retrieves whether property startTime is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetStartTime() const
-            {
-                return false;
-            }
+            virtual bool IsSetStartTime() const = 0;
             /**
             * Retrieves whether property stopTime is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetStopTime() const
-            {
-                return false;
-            }
+            virtual bool IsSetStopTime() const = 0;
 
         };
 
@@ -1935,6 +2091,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property entityRef is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetEntityRef() const = 0;
+            /**
+            * Retrieves whether property byType is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetByType() const = 0;
 
         };
 
@@ -2011,6 +2177,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property byEntityCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetByEntityCondition() const = 0;
+            /**
+            * Retrieves whether property byValueCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetByValueCondition() const = 0;
 
         };
 
@@ -2112,18 +2288,12 @@ namespace NET_ASAM_OPENSCENARIO
             * Retrieves whether property time is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetTime() const
-            {
-                return false;
-            }
+            virtual bool IsSetTime() const = 0;
             /**
             * Retrieves whether property weight is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetWeight() const
-            {
-                return false;
-            }
+            virtual bool IsSetWeight() const = 0;
 
         };
 
@@ -2190,6 +2360,11 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property parameterDeclarations is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetParameterDeclarations() const = 0;
 
         };
 
@@ -2242,6 +2417,21 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property assignControllerAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetAssignControllerAction() const = 0;
+            /**
+            * Retrieves whether property overrideControllerValueAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetOverrideControllerValueAction() const = 0;
+            /**
+            * Retrieves whether property activateControllerAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetActivateControllerAction() const = 0;
 
         };
 
@@ -2366,6 +2556,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property controller is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetController() const = 0;
+            /**
+            * Retrieves whether property catalogReference is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCatalogReference() const = 0;
 
         };
 
@@ -2469,6 +2669,11 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property deterministicParameterDistributions is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetDeterministicParameterDistributions() const = 0;
 
         };
 
@@ -2842,10 +3047,17 @@ namespace NET_ASAM_OPENSCENARIO
             * Retrieves whether property alongRoute is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetAlongRoute() const
-            {
-                return false;
-            }
+            virtual bool IsSetAlongRoute() const = 0;
+            /**
+            * Retrieves whether property coordinateSystem is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCoordinateSystem() const = 0;
+            /**
+            * Retrieves whether property relativeDistanceType is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRelativeDistanceType() const = 0;
 
         };
 
@@ -3059,26 +3271,17 @@ namespace NET_ASAM_OPENSCENARIO
             * Retrieves whether property maxAcceleration is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetMaxAcceleration() const
-            {
-                return false;
-            }
+            virtual bool IsSetMaxAcceleration() const = 0;
             /**
             * Retrieves whether property maxDeceleration is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetMaxDeceleration() const
-            {
-                return false;
-            }
+            virtual bool IsSetMaxDeceleration() const = 0;
             /**
             * Retrieves whether property maxSpeed is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetMaxSpeed() const
-            {
-                return false;
-            }
+            virtual bool IsSetMaxSpeed() const = 0;
 
         };
 
@@ -3178,6 +3381,16 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property scenarioObjects is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetScenarioObjects() const = 0;
+            /**
+            * Retrieves whether property entitySelections is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetEntitySelections() const = 0;
 
         };
 
@@ -3229,6 +3442,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property addEntityAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetAddEntityAction() const = 0;
+            /**
+            * Retrieves whether property deleteEntityAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetDeleteEntityAction() const = 0;
 
         };
 
@@ -3390,6 +3613,71 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property endOfRoadCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetEndOfRoadCondition() const = 0;
+            /**
+            * Retrieves whether property collisionCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCollisionCondition() const = 0;
+            /**
+            * Retrieves whether property offroadCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetOffroadCondition() const = 0;
+            /**
+            * Retrieves whether property timeHeadwayCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTimeHeadwayCondition() const = 0;
+            /**
+            * Retrieves whether property timeToCollisionCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTimeToCollisionCondition() const = 0;
+            /**
+            * Retrieves whether property accelerationCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetAccelerationCondition() const = 0;
+            /**
+            * Retrieves whether property standStillCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetStandStillCondition() const = 0;
+            /**
+            * Retrieves whether property speedCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetSpeedCondition() const = 0;
+            /**
+            * Retrieves whether property relativeSpeedCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRelativeSpeedCondition() const = 0;
+            /**
+            * Retrieves whether property traveledDistanceCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTraveledDistanceCondition() const = 0;
+            /**
+            * Retrieves whether property reachPositionCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetReachPositionCondition() const = 0;
+            /**
+            * Retrieves whether property distanceCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetDistanceCondition() const = 0;
+            /**
+            * Retrieves whether property relativeDistanceCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRelativeDistanceCondition() const = 0;
 
         };
 
@@ -3463,6 +3751,31 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property catalogReference is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCatalogReference() const = 0;
+            /**
+            * Retrieves whether property vehicle is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetVehicle() const = 0;
+            /**
+            * Retrieves whether property pedestrian is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetPedestrian() const = 0;
+            /**
+            * Retrieves whether property miscObject is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetMiscObject() const = 0;
+            /**
+            * Retrieves whether property externalObjectReference is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetExternalObjectReference() const = 0;
 
         };
 
@@ -3622,6 +3935,26 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property parameterDeclarations is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetParameterDeclarations() const = 0;
+            /**
+            * Retrieves whether property timeOfDay is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTimeOfDay() const = 0;
+            /**
+            * Retrieves whether property weather is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetWeather() const = 0;
+            /**
+            * Retrieves whether property roadCondition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRoadCondition() const = 0;
 
         };
 
@@ -3663,6 +3996,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property environment is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetEnvironment() const = 0;
+            /**
+            * Retrieves whether property catalogReference is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCatalogReference() const = 0;
 
         };
 
@@ -3782,6 +4125,16 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property maximumExecutionCount is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetMaximumExecutionCount() const = 0;
+            /**
+            * Retrieves whether property startTrigger is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetStartTrigger() const = 0;
 
         };
 
@@ -3925,6 +4278,11 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property license is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetLicense() const = 0;
 
         };
 
@@ -3965,6 +4323,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property absoluteSpeed is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetAbsoluteSpeed() const = 0;
+            /**
+            * Retrieves whether property relativeSpeedToMaster is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRelativeSpeedToMaster() const = 0;
 
         };
 
@@ -4005,6 +4373,11 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property boundingBox is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetBoundingBox() const = 0;
 
         };
 
@@ -4096,6 +4469,26 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property initialDistanceOffset is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetInitialDistanceOffset() const = 0;
+            /**
+            * Retrieves whether property trajectory is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrajectory() const = 0;
+            /**
+            * Retrieves whether property catalogReference is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCatalogReference() const = 0;
+            /**
+            * Retrieves whether property trajectoryRef is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrajectoryRef() const = 0;
 
         };
 
@@ -4162,6 +4555,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property height is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetHeight() const = 0;
+            /**
+            * Retrieves whether property orientation is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetOrientation() const = 0;
 
         };
 
@@ -4235,6 +4638,31 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property environmentAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetEnvironmentAction() const = 0;
+            /**
+            * Retrieves whether property entityAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetEntityAction() const = 0;
+            /**
+            * Retrieves whether property parameterAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetParameterAction() const = 0;
+            /**
+            * Retrieves whether property infrastructureAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetInfrastructureAction() const = 0;
+            /**
+            * Retrieves whether property trafficAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrafficAction() const = 0;
 
         };
 
@@ -4373,6 +4801,21 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property fromCurrentEntity is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetFromCurrentEntity() const = 0;
+            /**
+            * Retrieves whether property fromRoadCoordinates is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetFromRoadCoordinates() const = 0;
+            /**
+            * Retrieves whether property fromLaneCoordinates is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetFromLaneCoordinates() const = 0;
 
         };
 
@@ -4528,6 +4971,21 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property globalActions is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetGlobalActions() const = 0;
+            /**
+            * Retrieves whether property userDefinedActions is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetUserDefinedActions() const = 0;
+            /**
+            * Retrieves whether property privates is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetPrivates() const = 0;
 
         };
 
@@ -4613,6 +5071,11 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property targetLaneOffset is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTargetLaneOffset() const = 0;
 
         };
 
@@ -4653,6 +5116,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property relativeTargetLane is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRelativeTargetLane() const = 0;
+            /**
+            * Retrieves whether property absoluteTargetLane is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetAbsoluteTargetLane() const = 0;
 
         };
 
@@ -4757,10 +5230,7 @@ namespace NET_ASAM_OPENSCENARIO
             * Retrieves whether property maxLateralAcc is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetMaxLateralAcc() const
-            {
-                return false;
-            }
+            virtual bool IsSetMaxLateralAcc() const = 0;
 
         };
 
@@ -4801,6 +5271,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property relativeTargetLaneOffset is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRelativeTargetLaneOffset() const = 0;
+            /**
+            * Retrieves whether property absoluteTargetLaneOffset is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetAbsoluteTargetLaneOffset() const = 0;
 
         };
 
@@ -4875,6 +5355,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property offset is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetOffset() const = 0;
+            /**
+            * Retrieves whether property orientation is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetOrientation() const = 0;
 
         };
 
@@ -4926,6 +5416,21 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property laneChangeAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetLaneChangeAction() const = 0;
+            /**
+            * Retrieves whether property laneOffsetAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetLaneOffsetAction() const = 0;
+            /**
+            * Retrieves whether property lateralDistanceAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetLateralDistanceAction() const = 0;
 
         };
 
@@ -5028,6 +5533,26 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property coordinateSystem is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCoordinateSystem() const = 0;
+            /**
+            * Retrieves whether property displacement is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetDisplacement() const = 0;
+            /**
+            * Retrieves whether property distance is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetDistance() const = 0;
+            /**
+            * Retrieves whether property dynamicConstraints is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetDynamicConstraints() const = 0;
 
         };
 
@@ -5093,21 +5618,20 @@ namespace NET_ASAM_OPENSCENARIO
 
 
             /**
+            * Retrieves whether property text is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetText() const = 0;
+            /**
             * Retrieves whether property resource is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetResource() const
-            {
-                return false;
-            }
+            virtual bool IsSetResource() const = 0;
             /**
             * Retrieves whether property spdxId is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetSpdxId() const
-            {
-                return false;
-            }
+            virtual bool IsSetSpdxId() const = 0;
 
         };
 
@@ -5148,6 +5672,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property speedAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetSpeedAction() const = 0;
+            /**
+            * Retrieves whether property longitudinalDistanceAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetLongitudinalDistanceAction() const = 0;
 
         };
 
@@ -5259,21 +5793,30 @@ namespace NET_ASAM_OPENSCENARIO
 
 
             /**
+            * Retrieves whether property coordinateSystem is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCoordinateSystem() const = 0;
+            /**
+            * Retrieves whether property displacement is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetDisplacement() const = 0;
+            /**
             * Retrieves whether property distance is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetDistance() const
-            {
-                return false;
-            }
+            virtual bool IsSetDistance() const = 0;
             /**
             * Retrieves whether property timeGap is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetTimeGap() const
-            {
-                return false;
-            }
+            virtual bool IsSetTimeGap() const = 0;
+            /**
+            * Retrieves whether property dynamicConstraints is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetDynamicConstraints() const = 0;
 
         };
 
@@ -5355,6 +5898,11 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property parameterDeclarations is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetParameterDeclarations() const = 0;
 
         };
 
@@ -5488,6 +6036,16 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property catalogReferences is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCatalogReferences() const = 0;
+            /**
+            * Retrieves whether property maneuvers is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetManeuvers() const = 0;
 
         };
 
@@ -5602,10 +6160,12 @@ namespace NET_ASAM_OPENSCENARIO
             * Retrieves whether property model3d is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetModel3d() const
-            {
-                return false;
-            }
+            virtual bool IsSetModel3d() const = 0;
+            /**
+            * Retrieves whether property parameterDeclarations is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetParameterDeclarations() const = 0;
 
         };
 
@@ -5676,6 +6236,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property addValue is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetAddValue() const = 0;
+            /**
+            * Retrieves whether property multiplyByValue is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetMultiplyByValue() const = 0;
 
         };
 
@@ -5745,6 +6315,11 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property range is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRange() const = 0;
 
         };
 
@@ -5870,6 +6445,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property catalogReference is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCatalogReference() const = 0;
+            /**
+            * Retrieves whether property controller is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetController() const = 0;
 
         };
 
@@ -6053,6 +6638,26 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property h is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetH() const = 0;
+            /**
+            * Retrieves whether property p is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetP() const = 0;
+            /**
+            * Retrieves whether property r is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetR() const = 0;
+            /**
+            * Retrieves whether property type is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetType() const = 0;
 
         };
 
@@ -6217,6 +6822,36 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property throttle is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetThrottle() const = 0;
+            /**
+            * Retrieves whether property brake is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetBrake() const = 0;
+            /**
+            * Retrieves whether property clutch is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetClutch() const = 0;
+            /**
+            * Retrieves whether property parkingBrake is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetParkingBrake() const = 0;
+            /**
+            * Retrieves whether property steeringWheel is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetSteeringWheel() const = 0;
+            /**
+            * Retrieves whether property gear is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetGear() const = 0;
 
         };
 
@@ -6428,6 +7063,16 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property setAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetSetAction() const = 0;
+            /**
+            * Retrieves whether property modifyAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetModifyAction() const = 0;
 
         };
 
@@ -6632,6 +7277,11 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property constraintGroups is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetConstraintGroups() const = 0;
 
         };
 
@@ -6957,18 +7607,17 @@ namespace NET_ASAM_OPENSCENARIO
             * Retrieves whether property model is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetModel() const
-            {
-                return false;
-            }
+            virtual bool IsSetModel() const = 0;
             /**
             * Retrieves whether property model3d is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetModel3d() const
-            {
-                return false;
-            }
+            virtual bool IsSetModel3d() const = 0;
+            /**
+            * Retrieves whether property parameterDeclarations is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetParameterDeclarations() const = 0;
 
         };
 
@@ -7117,6 +7766,11 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property trafficSignalStates is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrafficSignalStates() const = 0;
 
         };
 
@@ -7157,6 +7811,11 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property range is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRange() const = 0;
 
         };
 
@@ -7330,6 +7989,56 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property worldPosition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetWorldPosition() const = 0;
+            /**
+            * Retrieves whether property relativeWorldPosition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRelativeWorldPosition() const = 0;
+            /**
+            * Retrieves whether property relativeObjectPosition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRelativeObjectPosition() const = 0;
+            /**
+            * Retrieves whether property roadPosition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRoadPosition() const = 0;
+            /**
+            * Retrieves whether property relativeRoadPosition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRelativeRoadPosition() const = 0;
+            /**
+            * Retrieves whether property lanePosition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetLanePosition() const = 0;
+            /**
+            * Retrieves whether property relativeLanePosition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRelativeLanePosition() const = 0;
+            /**
+            * Retrieves whether property routePosition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRoutePosition() const = 0;
+            /**
+            * Retrieves whether property geoPosition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetGeoPosition() const = 0;
+            /**
+            * Retrieves whether property trajectoryPosition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrajectoryPosition() const = 0;
 
         };
 
@@ -7382,6 +8091,11 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property laneOffset is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetLaneOffset() const = 0;
 
         };
 
@@ -7508,18 +8222,12 @@ namespace NET_ASAM_OPENSCENARIO
             * Retrieves whether property intensity is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetIntensity() const
-            {
-                return false;
-            }
+            virtual bool IsSetIntensity() const = 0;
             /**
             * Retrieves whether property precipitationIntensity is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetPrecipitationIntensity() const
-            {
-                return false;
-            }
+            virtual bool IsSetPrecipitationIntensity() const = 0;
 
         };
 
@@ -7685,6 +8393,46 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property longitudinalAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetLongitudinalAction() const = 0;
+            /**
+            * Retrieves whether property lateralAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetLateralAction() const = 0;
+            /**
+            * Retrieves whether property visibilityAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetVisibilityAction() const = 0;
+            /**
+            * Retrieves whether property synchronizeAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetSynchronizeAction() const = 0;
+            /**
+            * Retrieves whether property activateControllerAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetActivateControllerAction() const = 0;
+            /**
+            * Retrieves whether property controllerAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetControllerAction() const = 0;
+            /**
+            * Retrieves whether property teleportAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTeleportAction() const = 0;
+            /**
+            * Retrieves whether property routingAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRoutingAction() const = 0;
 
         };
 
@@ -7843,6 +8591,16 @@ namespace NET_ASAM_OPENSCENARIO
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property properties is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetProperties() const = 0;
+            /**
+            * Retrieves whether property files is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetFiles() const = 0;
 
         };
 
@@ -8048,6 +8806,11 @@ namespace NET_ASAM_OPENSCENARIO
             }
 
 
+            /**
+            * Retrieves whether property coordinateSystem is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCoordinateSystem() const = 0;
 
         };
 
@@ -8161,18 +8924,22 @@ Alternatively
             * Retrieves whether property ds is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetDs() const
-            {
-                return false;
-            }
+            virtual bool IsSetDs() const = 0;
             /**
             * Retrieves whether property dsLane is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetDsLane() const
-            {
-                return false;
-            }
+            virtual bool IsSetDsLane() const = 0;
+            /**
+            * Retrieves whether property offset is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetOffset() const = 0;
+            /**
+            * Retrieves whether property orientation is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetOrientation() const = 0;
 
         };
 
@@ -8249,6 +9016,16 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property dz is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetDz() const = 0;
+            /**
+            * Retrieves whether property orientation is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetOrientation() const = 0;
 
         };
 
@@ -8311,6 +9088,11 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property orientation is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetOrientation() const = 0;
 
         };
 
@@ -8414,6 +9196,11 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property steadyState is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetSteadyState() const = 0;
 
         };
 
@@ -8636,6 +9423,16 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property dz is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetDz() const = 0;
+            /**
+            * Retrieves whether property orientation is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetOrientation() const = 0;
 
         };
 
@@ -8676,6 +9473,11 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property properties is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetProperties() const = 0;
 
         };
 
@@ -8757,6 +9559,26 @@ Alternatively
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property logicFile is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetLogicFile() const = 0;
+            /**
+            * Retrieves whether property sceneGraphFile is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetSceneGraphFile() const = 0;
+            /**
+            * Retrieves whether property trafficSignals is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrafficSignals() const = 0;
+            /**
+            * Retrieves whether property usedArea is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetUsedArea() const = 0;
 
         };
 
@@ -8821,6 +9643,11 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property orientation is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetOrientation() const = 0;
 
         };
 
@@ -8914,6 +9741,11 @@ Alternatively
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property parameterDeclarations is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetParameterDeclarations() const = 0;
 
         };
 
@@ -8997,6 +9829,11 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property orientation is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetOrientation() const = 0;
 
         };
 
@@ -9037,6 +9874,16 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property route is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRoute() const = 0;
+            /**
+            * Retrieves whether property catalogReference is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCatalogReference() const = 0;
 
         };
 
@@ -9090,6 +9937,21 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property assignRouteAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetAssignRouteAction() const = 0;
+            /**
+            * Retrieves whether property followTrajectoryAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetFollowTrajectoryAction() const = 0;
+            /**
+            * Retrieves whether property acquirePositionAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetAcquirePositionAction() const = 0;
 
         };
 
@@ -9181,6 +10043,11 @@ Alternatively
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property parameterDeclarations is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetParameterDeclarations() const = 0;
 
         };
 
@@ -9233,6 +10100,11 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property objectController is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetObjectController() const = 0;
 
         };
 
@@ -9303,6 +10175,16 @@ Alternatively
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property entityRef is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetEntityRef() const = 0;
+            /**
+            * Retrieves whether property byType is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetByType() const = 0;
 
         };
 
@@ -9354,6 +10236,21 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property polyline is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetPolyline() const = 0;
+            /**
+            * Retrieves whether property clothoid is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetClothoid() const = 0;
+            /**
+            * Retrieves whether property nurbs is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetNurbs() const = 0;
 
         };
 
@@ -9476,6 +10373,16 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property relativeTargetSpeed is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRelativeTargetSpeed() const = 0;
+            /**
+            * Retrieves whether property absoluteTargetSpeed is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetAbsoluteTargetSpeed() const = 0;
 
         };
 
@@ -9657,10 +10564,7 @@ Alternatively
             * Retrieves whether property randomSeed is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetRandomSeed() const
-            {
-                return false;
-            }
+            virtual bool IsSetRandomSeed() const = 0;
 
         };
 
@@ -9866,6 +10770,11 @@ Alternatively
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property parameterDeclarations is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetParameterDeclarations() const = 0;
 
         };
 
@@ -10127,18 +11036,17 @@ Alternatively
             * Retrieves whether property targetTolerance is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetTargetTolerance() const
-            {
-                return false;
-            }
+            virtual bool IsSetTargetTolerance() const = 0;
             /**
             * Retrieves whether property targetToleranceMaster is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetTargetToleranceMaster() const
-            {
-                return false;
-            }
+            virtual bool IsSetTargetToleranceMaster() const = 0;
+            /**
+            * Retrieves whether property finalSpeed is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetFinalSpeed() const = 0;
 
         };
 
@@ -10334,10 +11242,17 @@ Alternatively
             * Retrieves whether property alongRoute is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetAlongRoute() const
-            {
-                return false;
-            }
+            virtual bool IsSetAlongRoute() const = 0;
+            /**
+            * Retrieves whether property coordinateSystem is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCoordinateSystem() const = 0;
+            /**
+            * Retrieves whether property relativeDistanceType is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRelativeDistanceType() const = 0;
 
         };
 
@@ -10461,6 +11376,16 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property none is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetNone() const = 0;
+            /**
+            * Retrieves whether property timing is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTiming() const = 0;
 
         };
 
@@ -10571,10 +11496,17 @@ Alternatively
             * Retrieves whether property alongRoute is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetAlongRoute() const
-            {
-                return false;
-            }
+            virtual bool IsSetAlongRoute() const = 0;
+            /**
+            * Retrieves whether property coordinateSystem is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetCoordinateSystem() const = 0;
+            /**
+            * Retrieves whether property relativeDistanceType is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetRelativeDistanceType() const = 0;
 
         };
 
@@ -10616,6 +11548,16 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property position is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetPosition() const = 0;
+            /**
+            * Retrieves whether property entityRef is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetEntityRef() const = 0;
 
         };
 
@@ -10745,10 +11687,27 @@ Alternatively
             * Retrieves whether property trafficName is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetTrafficName() const
-            {
-                return false;
-            }
+            virtual bool IsSetTrafficName() const = 0;
+            /**
+            * Retrieves whether property trafficSourceAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrafficSourceAction() const = 0;
+            /**
+            * Retrieves whether property trafficSinkAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrafficSinkAction() const = 0;
+            /**
+            * Retrieves whether property trafficSwarmAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrafficSwarmAction() const = 0;
+            /**
+            * Retrieves whether property trafficStopAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrafficStopAction() const = 0;
 
         };
 
@@ -10840,6 +11799,16 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property trafficSignalControllerAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrafficSignalControllerAction() const = 0;
+            /**
+            * Retrieves whether property trafficSignalStateAction is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrafficSignalStateAction() const = 0;
 
         };
 
@@ -10964,13 +11933,20 @@ Alternatively
             }
 
             /**
+            * Retrieves whether property delay is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetDelay() const = 0;
+            /**
             * Retrieves whether property reference is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetReference() const
-            {
-                return false;
-            }
+            virtual bool IsSetReference() const = 0;
+            /**
+            * Retrieves whether property phases is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetPhases() const = 0;
 
         };
 
@@ -11038,6 +12014,11 @@ Alternatively
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property phaseRef is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetPhaseRef() const = 0;
 
         };
 
@@ -11106,6 +12087,11 @@ Alternatively
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property phaseRef is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetPhaseRef() const = 0;
 
         };
 
@@ -11253,10 +12239,12 @@ Alternatively
             * Retrieves whether property rate is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetRate() const
-            {
-                return false;
-            }
+            virtual bool IsSetRate() const = 0;
+            /**
+            * Retrieves whether property trafficDefinition is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetTrafficDefinition() const = 0;
 
         };
 
@@ -11330,6 +12318,11 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property velocity is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetVelocity() const = 0;
 
         };
 
@@ -11463,6 +12456,11 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property velocity is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetVelocity() const = 0;
 
         };
 
@@ -11540,6 +12538,11 @@ Alternatively
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property parameterDeclarations is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetParameterDeclarations() const = 0;
 
         };
 
@@ -11665,6 +12668,16 @@ Alternatively
             }
 
 
+            /**
+            * Retrieves whether property t is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetT() const = 0;
+            /**
+            * Retrieves whether property orientation is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetOrientation() const = 0;
 
         };
 
@@ -11834,6 +12847,11 @@ Alternatively
                 return nullptr;
             }
 
+            /**
+            * Retrieves whether property conditionGroups is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetConditionGroups() const = 0;
 
         };
 
@@ -12359,18 +13377,17 @@ Multiple constraint groups are
             * Retrieves whether property mass is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetMass() const
-            {
-                return false;
-            }
+            virtual bool IsSetMass() const = 0;
             /**
             * Retrieves whether property model3d is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetModel3d() const
-            {
-                return false;
-            }
+            virtual bool IsSetModel3d() const = 0;
+            /**
+            * Retrieves whether property parameterDeclarations is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetParameterDeclarations() const = 0;
 
         };
 
@@ -12530,10 +13547,7 @@ Multiple constraint groups are
             * Retrieves whether property time is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetTime() const
-            {
-                return false;
-            }
+            virtual bool IsSetTime() const = 0;
 
         };
 
@@ -12731,26 +13745,37 @@ Multiple constraint groups are
             * Retrieves whether property atmosphericPressure is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetAtmosphericPressure() const
-            {
-                return false;
-            }
+            virtual bool IsSetAtmosphericPressure() const = 0;
             /**
             * Retrieves whether property cloudState is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetCloudState() const
-            {
-                return false;
-            }
+            virtual bool IsSetCloudState() const = 0;
             /**
             * Retrieves whether property temperature is set
             * @return true when the optional property is set
             */
-            virtual bool IsSetTemperature() const
-            {
-                return false;
-            }
+            virtual bool IsSetTemperature() const = 0;
+            /**
+            * Retrieves whether property sun is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetSun() const = 0;
+            /**
+            * Retrieves whether property fog is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetFog() const = 0;
+            /**
+            * Retrieves whether property precipitation is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetPrecipitation() const = 0;
+            /**
+            * Retrieves whether property wind is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetWind() const = 0;
 
         };
 
@@ -12880,6 +13905,26 @@ Multiple constraint groups are
             }
 
 
+            /**
+            * Retrieves whether property h is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetH() const = 0;
+            /**
+            * Retrieves whether property p is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetP() const = 0;
+            /**
+            * Retrieves whether property r is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetR() const = 0;
+            /**
+            * Retrieves whether property z is set
+            * @return true when the optional property is set
+            */
+            virtual bool IsSetZ() const = 0;
 
         };
 

--- a/cpp/openScenarioLib/generated/v1_1/api/writer/ApiClassWriterInterfacesV1_1.h
+++ b/cpp/openScenarioLib/generated/v1_1/api/writer/ApiClassWriterInterfacesV1_1.h
@@ -324,6 +324,11 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<ISteadyStateWriter> GetWriterSteadyState() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetSteadyState() will return false);
+            */
+            virtual void ResetSteadyState() = 0;
+            
         };
 
 
@@ -686,6 +691,11 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property maneuverGroups
             */
             virtual std::vector<std::shared_ptr<IManeuverGroupWriter>> GetWriterManeuverGroups() const = 0;
+            /**
+            * Resets the optional property (IsSetStopTrigger() will return false);
+            */
+            virtual void ResetStopTrigger() = 0;
+            
         };
 
 
@@ -781,6 +791,21 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IPrivateActionWriter> GetWriterPrivateAction() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetGlobalAction() will return false);
+            */
+            virtual void ResetGlobalAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetUserDefinedAction() will return false);
+            */
+            virtual void ResetUserDefinedAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetPrivateAction() will return false);
+            */
+            virtual void ResetPrivateAction() = 0;
+            
         };
 
 
@@ -932,6 +957,11 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property entityRefs
             */
             virtual std::vector<std::shared_ptr<IEntityRefWriter>> GetWriterEntityRefs() const = 0;
+            /**
+            * Resets the optional property (IsSetEntityRefs() will return false);
+            */
+            virtual void ResetEntityRefs() = 0;
+            
         };
 
 
@@ -1091,6 +1121,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual void ResetActivateLongitudinal() = 0;
             
+            /**
+            * Resets the optional property (IsSetController() will return false);
+            */
+            virtual void ResetController() = 0;
+            
+            /**
+            * Resets the optional property (IsSetCatalogReference() will return false);
+            */
+            virtual void ResetCatalogReference() = 0;
+            
         };
 
 
@@ -1147,6 +1187,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<ICatalogReferenceWriter> GetWriterCatalogReference() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetRoute() will return false);
+            */
+            virtual void ResetRoute() = 0;
+            
+            /**
+            * Resets the optional property (IsSetCatalogReference() will return false);
+            */
+            virtual void ResetCatalogReference() = 0;
+            
         };
 
 
@@ -1371,6 +1421,11 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property additionalAxles
             */
             virtual std::vector<std::shared_ptr<IAxleWriter>> GetWriterAdditionalAxles() const = 0;
+            /**
+            * Resets the optional property (IsSetAdditionalAxles() will return false);
+            */
+            virtual void ResetAdditionalAxles() = 0;
+            
         };
 
 
@@ -1712,6 +1767,41 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<ITrafficSignalControllerConditionWriter> GetWriterTrafficSignalControllerCondition() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetParameterCondition() will return false);
+            */
+            virtual void ResetParameterCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTimeOfDayCondition() will return false);
+            */
+            virtual void ResetTimeOfDayCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetSimulationTimeCondition() will return false);
+            */
+            virtual void ResetSimulationTimeCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetStoryboardElementStateCondition() will return false);
+            */
+            virtual void ResetStoryboardElementStateCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetUserDefinedValueCondition() will return false);
+            */
+            virtual void ResetUserDefinedValueCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTrafficSignalCondition() will return false);
+            */
+            virtual void ResetTrafficSignalCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTrafficSignalControllerCondition() will return false);
+            */
+            virtual void ResetTrafficSignalControllerCondition() = 0;
+            
         };
 
 
@@ -1883,6 +1973,51 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property routes
             */
             virtual std::vector<std::shared_ptr<IRouteWriter>> GetWriterRoutes() const = 0;
+            /**
+            * Resets the optional property (IsSetName() will return false);
+            */
+            virtual void ResetName() = 0;
+            
+            /**
+            * Resets the optional property (IsSetVehicles() will return false);
+            */
+            virtual void ResetVehicles() = 0;
+            
+            /**
+            * Resets the optional property (IsSetControllers() will return false);
+            */
+            virtual void ResetControllers() = 0;
+            
+            /**
+            * Resets the optional property (IsSetPedestrians() will return false);
+            */
+            virtual void ResetPedestrians() = 0;
+            
+            /**
+            * Resets the optional property (IsSetMiscObjects() will return false);
+            */
+            virtual void ResetMiscObjects() = 0;
+            
+            /**
+            * Resets the optional property (IsSetEnvironments() will return false);
+            */
+            virtual void ResetEnvironments() = 0;
+            
+            /**
+            * Resets the optional property (IsSetManeuvers() will return false);
+            */
+            virtual void ResetManeuvers() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTrajectories() will return false);
+            */
+            virtual void ResetTrajectories() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRoutes() will return false);
+            */
+            virtual void ResetRoutes() = 0;
+            
         };
 
 
@@ -2066,6 +2201,46 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IRouteCatalogLocationWriter> GetWriterRouteCatalog() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetVehicleCatalog() will return false);
+            */
+            virtual void ResetVehicleCatalog() = 0;
+            
+            /**
+            * Resets the optional property (IsSetControllerCatalog() will return false);
+            */
+            virtual void ResetControllerCatalog() = 0;
+            
+            /**
+            * Resets the optional property (IsSetPedestrianCatalog() will return false);
+            */
+            virtual void ResetPedestrianCatalog() = 0;
+            
+            /**
+            * Resets the optional property (IsSetMiscObjectCatalog() will return false);
+            */
+            virtual void ResetMiscObjectCatalog() = 0;
+            
+            /**
+            * Resets the optional property (IsSetEnvironmentCatalog() will return false);
+            */
+            virtual void ResetEnvironmentCatalog() = 0;
+            
+            /**
+            * Resets the optional property (IsSetManeuverCatalog() will return false);
+            */
+            virtual void ResetManeuverCatalog() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTrajectoryCatalog() will return false);
+            */
+            virtual void ResetTrajectoryCatalog() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRouteCatalog() will return false);
+            */
+            virtual void ResetRouteCatalog() = 0;
+            
         };
 
 
@@ -2167,6 +2342,11 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property parameterAssignments
             */
             virtual std::vector<std::shared_ptr<IParameterAssignmentWriter>> GetWriterParameterAssignments() const = 0;
+            /**
+            * Resets the optional property (IsSetParameterAssignments() will return false);
+            */
+            virtual void ResetParameterAssignments() = 0;
+            
         };
 
 
@@ -2594,6 +2774,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IByObjectTypeWriter> GetWriterByType() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetEntityRef() will return false);
+            */
+            virtual void ResetEntityRef() = 0;
+            
+            /**
+            * Resets the optional property (IsSetByType() will return false);
+            */
+            virtual void ResetByType() = 0;
+            
         };
 
 
@@ -2729,6 +2919,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IByValueConditionWriter> GetWriterByValueCondition() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetByEntityCondition() will return false);
+            */
+            virtual void ResetByEntityCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetByValueCondition() will return false);
+            */
+            virtual void ResetByValueCondition() = 0;
+            
         };
 
 
@@ -2951,6 +3151,11 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property parameterDeclarations
             */
             virtual std::vector<std::shared_ptr<IParameterDeclarationWriter>> GetWriterParameterDeclarations() const = 0;
+            /**
+            * Resets the optional property (IsSetParameterDeclarations() will return false);
+            */
+            virtual void ResetParameterDeclarations() = 0;
+            
         };
 
 
@@ -3022,6 +3227,21 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IActivateControllerActionWriter> GetWriterActivateControllerAction() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetAssignControllerAction() will return false);
+            */
+            virtual void ResetAssignControllerAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetOverrideControllerValueAction() will return false);
+            */
+            virtual void ResetOverrideControllerValueAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetActivateControllerAction() will return false);
+            */
+            virtual void ResetActivateControllerAction() = 0;
+            
         };
 
 
@@ -3180,6 +3400,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<ICatalogReferenceWriter> GetWriterCatalogReference() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetController() will return false);
+            */
+            virtual void ResetController() = 0;
+            
+            /**
+            * Resets the optional property (IsSetCatalogReference() will return false);
+            */
+            virtual void ResetCatalogReference() = 0;
+            
         };
 
 
@@ -3319,6 +3549,11 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property deterministicParameterDistributions
             */
             virtual std::vector<std::shared_ptr<IDeterministicParameterDistributionWriter>> GetWriterDeterministicParameterDistributions() const = 0;
+            /**
+            * Resets the optional property (IsSetDeterministicParameterDistributions() will return false);
+            */
+            virtual void ResetDeterministicParameterDistributions() = 0;
+            
         };
 
 
@@ -3942,6 +4177,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual void ResetAlongRoute() = 0;
             
+            /**
+            * Resets the optional property (IsSetCoordinateSystem() will return false);
+            */
+            virtual void ResetCoordinateSystem() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRelativeDistanceType() will return false);
+            */
+            virtual void ResetRelativeDistanceType() = 0;
+            
         };
 
 
@@ -4376,6 +4621,16 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property entitySelections
             */
             virtual std::vector<std::shared_ptr<IEntitySelectionWriter>> GetWriterEntitySelections() const = 0;
+            /**
+            * Resets the optional property (IsSetScenarioObjects() will return false);
+            */
+            virtual void ResetScenarioObjects() = 0;
+            
+            /**
+            * Resets the optional property (IsSetEntitySelections() will return false);
+            */
+            virtual void ResetEntitySelections() = 0;
+            
         };
 
 
@@ -4456,6 +4711,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IDeleteEntityActionWriter> GetWriterDeleteEntityAction() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetAddEntityAction() will return false);
+            */
+            virtual void ResetAddEntityAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetDeleteEntityAction() will return false);
+            */
+            virtual void ResetDeleteEntityAction() = 0;
+            
         };
 
 
@@ -4675,6 +4940,71 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IRelativeDistanceConditionWriter> GetWriterRelativeDistanceCondition() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetEndOfRoadCondition() will return false);
+            */
+            virtual void ResetEndOfRoadCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetCollisionCondition() will return false);
+            */
+            virtual void ResetCollisionCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetOffroadCondition() will return false);
+            */
+            virtual void ResetOffroadCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTimeHeadwayCondition() will return false);
+            */
+            virtual void ResetTimeHeadwayCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTimeToCollisionCondition() will return false);
+            */
+            virtual void ResetTimeToCollisionCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetAccelerationCondition() will return false);
+            */
+            virtual void ResetAccelerationCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetStandStillCondition() will return false);
+            */
+            virtual void ResetStandStillCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetSpeedCondition() will return false);
+            */
+            virtual void ResetSpeedCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRelativeSpeedCondition() will return false);
+            */
+            virtual void ResetRelativeSpeedCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTraveledDistanceCondition() will return false);
+            */
+            virtual void ResetTraveledDistanceCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetReachPositionCondition() will return false);
+            */
+            virtual void ResetReachPositionCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetDistanceCondition() will return false);
+            */
+            virtual void ResetDistanceCondition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRelativeDistanceCondition() will return false);
+            */
+            virtual void ResetRelativeDistanceCondition() = 0;
+            
         };
 
 
@@ -4774,6 +5104,31 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IExternalObjectReferenceWriter> GetWriterExternalObjectReference() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetCatalogReference() will return false);
+            */
+            virtual void ResetCatalogReference() = 0;
+            
+            /**
+            * Resets the optional property (IsSetVehicle() will return false);
+            */
+            virtual void ResetVehicle() = 0;
+            
+            /**
+            * Resets the optional property (IsSetPedestrian() will return false);
+            */
+            virtual void ResetPedestrian() = 0;
+            
+            /**
+            * Resets the optional property (IsSetMiscObject() will return false);
+            */
+            virtual void ResetMiscObject() = 0;
+            
+            /**
+            * Resets the optional property (IsSetExternalObjectReference() will return false);
+            */
+            virtual void ResetExternalObjectReference() = 0;
+            
         };
 
 
@@ -5001,6 +5356,26 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property parameterDeclarations
             */
             virtual std::vector<std::shared_ptr<IParameterDeclarationWriter>> GetWriterParameterDeclarations() const = 0;
+            /**
+            * Resets the optional property (IsSetParameterDeclarations() will return false);
+            */
+            virtual void ResetParameterDeclarations() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTimeOfDay() will return false);
+            */
+            virtual void ResetTimeOfDay() = 0;
+            
+            /**
+            * Resets the optional property (IsSetWeather() will return false);
+            */
+            virtual void ResetWeather() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRoadCondition() will return false);
+            */
+            virtual void ResetRoadCondition() = 0;
+            
         };
 
 
@@ -5056,6 +5431,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<ICatalogReferenceWriter> GetWriterCatalogReference() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetEnvironment() will return false);
+            */
+            virtual void ResetEnvironment() = 0;
+            
+            /**
+            * Resets the optional property (IsSetCatalogReference() will return false);
+            */
+            virtual void ResetCatalogReference() = 0;
+            
         };
 
 
@@ -5230,6 +5615,16 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property actions
             */
             virtual std::vector<std::shared_ptr<IActionWriter>> GetWriterActions() const = 0;
+            /**
+            * Resets the optional property (IsSetMaximumExecutionCount() will return false);
+            */
+            virtual void ResetMaximumExecutionCount() = 0;
+            
+            /**
+            * Resets the optional property (IsSetStartTrigger() will return false);
+            */
+            virtual void ResetStartTrigger() = 0;
+            
         };
 
 
@@ -5500,6 +5895,11 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<ILicenseWriter> GetWriterLicense() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetLicense() will return false);
+            */
+            virtual void ResetLicense() = 0;
+            
         };
 
 
@@ -5554,6 +5954,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IRelativeSpeedToMasterWriter> GetWriterRelativeSpeedToMaster() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetAbsoluteSpeed() will return false);
+            */
+            virtual void ResetAbsoluteSpeed() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRelativeSpeedToMaster() will return false);
+            */
+            virtual void ResetRelativeSpeedToMaster() = 0;
+            
         };
 
 
@@ -5619,6 +6029,11 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IBoundingBoxWriter> GetWriterBoundingBox() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetBoundingBox() will return false);
+            */
+            virtual void ResetBoundingBox() = 0;
+            
         };
 
 
@@ -5753,6 +6168,26 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<ITrajectoryRefWriter> GetWriterTrajectoryRef() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetInitialDistanceOffset() will return false);
+            */
+            virtual void ResetInitialDistanceOffset() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTrajectory() will return false);
+            */
+            virtual void ResetTrajectory() = 0;
+            
+            /**
+            * Resets the optional property (IsSetCatalogReference() will return false);
+            */
+            virtual void ResetCatalogReference() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTrajectoryRef() will return false);
+            */
+            virtual void ResetTrajectoryRef() = 0;
+            
         };
 
 
@@ -5875,6 +6310,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IOrientationWriter> GetWriterOrientation() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetHeight() will return false);
+            */
+            virtual void ResetHeight() = 0;
+            
+            /**
+            * Resets the optional property (IsSetOrientation() will return false);
+            */
+            virtual void ResetOrientation() = 0;
+            
         };
 
 
@@ -5974,6 +6419,31 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<ITrafficActionWriter> GetWriterTrafficAction() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetEnvironmentAction() will return false);
+            */
+            virtual void ResetEnvironmentAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetEntityAction() will return false);
+            */
+            virtual void ResetEntityAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetParameterAction() will return false);
+            */
+            virtual void ResetParameterAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetInfrastructureAction() will return false);
+            */
+            virtual void ResetInfrastructureAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTrafficAction() will return false);
+            */
+            virtual void ResetTrafficAction() = 0;
+            
         };
 
 
@@ -6150,6 +6620,21 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IPositionInLaneCoordinatesWriter> GetWriterFromLaneCoordinates() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetFromCurrentEntity() will return false);
+            */
+            virtual void ResetFromCurrentEntity() = 0;
+            
+            /**
+            * Resets the optional property (IsSetFromRoadCoordinates() will return false);
+            */
+            virtual void ResetFromRoadCoordinates() = 0;
+            
+            /**
+            * Resets the optional property (IsSetFromLaneCoordinates() will return false);
+            */
+            virtual void ResetFromLaneCoordinates() = 0;
+            
         };
 
 
@@ -6298,6 +6783,21 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property privates
             */
             virtual std::vector<std::shared_ptr<IPrivateWriter>> GetWriterPrivates() const = 0;
+            /**
+            * Resets the optional property (IsSetGlobalActions() will return false);
+            */
+            virtual void ResetGlobalActions() = 0;
+            
+            /**
+            * Resets the optional property (IsSetUserDefinedActions() will return false);
+            */
+            virtual void ResetUserDefinedActions() = 0;
+            
+            /**
+            * Resets the optional property (IsSetPrivates() will return false);
+            */
+            virtual void ResetPrivates() = 0;
+            
         };
 
 
@@ -6433,6 +6933,11 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<ILaneChangeTargetWriter> GetWriterLaneChangeTarget() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetTargetLaneOffset() will return false);
+            */
+            virtual void ResetTargetLaneOffset() = 0;
+            
         };
 
 
@@ -6487,6 +6992,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IAbsoluteTargetLaneWriter> GetWriterAbsoluteTargetLane() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetRelativeTargetLane() will return false);
+            */
+            virtual void ResetRelativeTargetLane() = 0;
+            
+            /**
+            * Resets the optional property (IsSetAbsoluteTargetLane() will return false);
+            */
+            virtual void ResetAbsoluteTargetLane() = 0;
+            
         };
 
 
@@ -6712,6 +7227,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IAbsoluteTargetLaneOffsetWriter> GetWriterAbsoluteTargetLaneOffset() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetRelativeTargetLaneOffset() will return false);
+            */
+            virtual void ResetRelativeTargetLaneOffset() = 0;
+            
+            /**
+            * Resets the optional property (IsSetAbsoluteTargetLaneOffset() will return false);
+            */
+            virtual void ResetAbsoluteTargetLaneOffset() = 0;
+            
         };
 
 
@@ -6857,6 +7382,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IOrientationWriter> GetWriterOrientation() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetOffset() will return false);
+            */
+            virtual void ResetOffset() = 0;
+            
+            /**
+            * Resets the optional property (IsSetOrientation() will return false);
+            */
+            virtual void ResetOrientation() = 0;
+            
         };
 
 
@@ -6926,6 +7461,21 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<ILateralDistanceActionWriter> GetWriterLateralDistanceAction() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetLaneChangeAction() will return false);
+            */
+            virtual void ResetLaneChangeAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetLaneOffsetAction() will return false);
+            */
+            virtual void ResetLaneOffsetAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetLateralDistanceAction() will return false);
+            */
+            virtual void ResetLateralDistanceAction() = 0;
+            
         };
 
 
@@ -7129,6 +7679,26 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IDynamicConstraintsWriter> GetWriterDynamicConstraints() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetCoordinateSystem() will return false);
+            */
+            virtual void ResetCoordinateSystem() = 0;
+            
+            /**
+            * Resets the optional property (IsSetDisplacement() will return false);
+            */
+            virtual void ResetDisplacement() = 0;
+            
+            /**
+            * Resets the optional property (IsSetDistance() will return false);
+            */
+            virtual void ResetDistance() = 0;
+            
+            /**
+            * Resets the optional property (IsSetDynamicConstraints() will return false);
+            */
+            virtual void ResetDynamicConstraints() = 0;
+            
         };
 
 
@@ -7260,6 +7830,11 @@ namespace NET_ASAM_OPENSCENARIO
             // children
 
             /**
+            * Resets the optional property (IsSetText() will return false);
+            */
+            virtual void ResetText() = 0;
+            
+            /**
             * Resets the optional property (IsSetResource() will return false);
             */
             virtual void ResetResource() = 0;
@@ -7323,6 +7898,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<ILongitudinalDistanceActionWriter> GetWriterLongitudinalDistanceAction() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetSpeedAction() will return false);
+            */
+            virtual void ResetSpeedAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetLongitudinalDistanceAction() will return false);
+            */
+            virtual void ResetLongitudinalDistanceAction() = 0;
+            
         };
 
 
@@ -7550,6 +8135,16 @@ namespace NET_ASAM_OPENSCENARIO
             virtual std::shared_ptr<IDynamicConstraintsWriter> GetWriterDynamicConstraints() const  = 0;
 
             /**
+            * Resets the optional property (IsSetCoordinateSystem() will return false);
+            */
+            virtual void ResetCoordinateSystem() = 0;
+            
+            /**
+            * Resets the optional property (IsSetDisplacement() will return false);
+            */
+            virtual void ResetDisplacement() = 0;
+            
+            /**
             * Resets the optional property (IsSetDistance() will return false);
             */
             virtual void ResetDistance() = 0;
@@ -7558,6 +8153,11 @@ namespace NET_ASAM_OPENSCENARIO
             * Resets the optional property (IsSetTimeGap() will return false);
             */
             virtual void ResetTimeGap() = 0;
+            
+            /**
+            * Resets the optional property (IsSetDynamicConstraints() will return false);
+            */
+            virtual void ResetDynamicConstraints() = 0;
             
         };
 
@@ -7639,6 +8239,11 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property events
             */
             virtual std::vector<std::shared_ptr<IEventWriter>> GetWriterEvents() const = 0;
+            /**
+            * Resets the optional property (IsSetParameterDeclarations() will return false);
+            */
+            virtual void ResetParameterDeclarations() = 0;
+            
         };
 
 
@@ -7800,6 +8405,16 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property maneuvers
             */
             virtual std::vector<std::shared_ptr<IManeuverWriter>> GetWriterManeuvers() const = 0;
+            /**
+            * Resets the optional property (IsSetCatalogReferences() will return false);
+            */
+            virtual void ResetCatalogReferences() = 0;
+            
+            /**
+            * Resets the optional property (IsSetManeuvers() will return false);
+            */
+            virtual void ResetManeuvers() = 0;
+            
         };
 
 
@@ -7978,6 +8593,11 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual void ResetModel3d() = 0;
             
+            /**
+            * Resets the optional property (IsSetParameterDeclarations() will return false);
+            */
+            virtual void ResetParameterDeclarations() = 0;
+            
         };
 
 
@@ -8072,6 +8692,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IParameterMultiplyByValueRuleWriter> GetWriterMultiplyByValue() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetAddValue() will return false);
+            */
+            virtual void ResetAddValue() = 0;
+            
+            /**
+            * Resets the optional property (IsSetMultiplyByValue() will return false);
+            */
+            virtual void ResetMultiplyByValue() = 0;
+            
         };
 
 
@@ -8186,6 +8816,11 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IRangeWriter> GetWriterRange() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetRange() will return false);
+            */
+            virtual void ResetRange() = 0;
+            
         };
 
 
@@ -8327,6 +8962,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IControllerWriter> GetWriterController() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetCatalogReference() will return false);
+            */
+            virtual void ResetCatalogReference() = 0;
+            
+            /**
+            * Resets the optional property (IsSetController() will return false);
+            */
+            virtual void ResetController() = 0;
+            
         };
 
 
@@ -8629,6 +9274,26 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
 
+            /**
+            * Resets the optional property (IsSetH() will return false);
+            */
+            virtual void ResetH() = 0;
+            
+            /**
+            * Resets the optional property (IsSetP() will return false);
+            */
+            virtual void ResetP() = 0;
+            
+            /**
+            * Resets the optional property (IsSetR() will return false);
+            */
+            virtual void ResetR() = 0;
+            
+            /**
+            * Resets the optional property (IsSetType() will return false);
+            */
+            virtual void ResetType() = 0;
+            
         };
 
 
@@ -8895,6 +9560,36 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IOverrideGearActionWriter> GetWriterGear() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetThrottle() will return false);
+            */
+            virtual void ResetThrottle() = 0;
+            
+            /**
+            * Resets the optional property (IsSetBrake() will return false);
+            */
+            virtual void ResetBrake() = 0;
+            
+            /**
+            * Resets the optional property (IsSetClutch() will return false);
+            */
+            virtual void ResetClutch() = 0;
+            
+            /**
+            * Resets the optional property (IsSetParkingBrake() will return false);
+            */
+            virtual void ResetParkingBrake() = 0;
+            
+            /**
+            * Resets the optional property (IsSetSteeringWheel() will return false);
+            */
+            virtual void ResetSteeringWheel() = 0;
+            
+            /**
+            * Resets the optional property (IsSetGear() will return false);
+            */
+            virtual void ResetGear() = 0;
+            
         };
 
 
@@ -9279,6 +9974,16 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IParameterModifyActionWriter> GetWriterModifyAction() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetSetAction() will return false);
+            */
+            virtual void ResetSetAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetModifyAction() will return false);
+            */
+            virtual void ResetModifyAction() = 0;
+            
         };
 
 
@@ -9597,6 +10302,11 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property constraintGroups
             */
             virtual std::vector<std::shared_ptr<IValueConstraintGroupWriter>> GetWriterConstraintGroups() const = 0;
+            /**
+            * Resets the optional property (IsSetConstraintGroups() will return false);
+            */
+            virtual void ResetConstraintGroups() = 0;
+            
         };
 
 
@@ -10077,6 +10787,11 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual void ResetModel3d() = 0;
             
+            /**
+            * Resets the optional property (IsSetParameterDeclarations() will return false);
+            */
+            virtual void ResetParameterDeclarations() = 0;
+            
         };
 
 
@@ -10312,6 +11027,11 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property trafficSignalStates
             */
             virtual std::vector<std::shared_ptr<ITrafficSignalStateWriter>> GetWriterTrafficSignalStates() const = 0;
+            /**
+            * Resets the optional property (IsSetTrafficSignalStates() will return false);
+            */
+            virtual void ResetTrafficSignalStates() = 0;
+            
         };
 
 
@@ -10377,6 +11097,11 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IRangeWriter> GetWriterRange() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetRange() will return false);
+            */
+            virtual void ResetRange() = 0;
+            
         };
 
 
@@ -10592,6 +11317,56 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<ITrajectoryPositionWriter> GetWriterTrajectoryPosition() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetWorldPosition() will return false);
+            */
+            virtual void ResetWorldPosition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRelativeWorldPosition() will return false);
+            */
+            virtual void ResetRelativeWorldPosition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRelativeObjectPosition() will return false);
+            */
+            virtual void ResetRelativeObjectPosition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRoadPosition() will return false);
+            */
+            virtual void ResetRoadPosition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRelativeRoadPosition() will return false);
+            */
+            virtual void ResetRelativeRoadPosition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetLanePosition() will return false);
+            */
+            virtual void ResetLanePosition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRelativeLanePosition() will return false);
+            */
+            virtual void ResetRelativeLanePosition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRoutePosition() will return false);
+            */
+            virtual void ResetRoutePosition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetGeoPosition() will return false);
+            */
+            virtual void ResetGeoPosition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTrajectoryPosition() will return false);
+            */
+            virtual void ResetTrajectoryPosition() = 0;
+            
         };
 
 
@@ -10695,6 +11470,11 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
 
+            /**
+            * Resets the optional property (IsSetLaneOffset() will return false);
+            */
+            virtual void ResetLaneOffset() = 0;
+            
         };
 
 
@@ -11151,6 +11931,46 @@ namespace NET_ASAM_OPENSCENARIO
             */
             virtual std::shared_ptr<IRoutingActionWriter> GetWriterRoutingAction() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetLongitudinalAction() will return false);
+            */
+            virtual void ResetLongitudinalAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetLateralAction() will return false);
+            */
+            virtual void ResetLateralAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetVisibilityAction() will return false);
+            */
+            virtual void ResetVisibilityAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetSynchronizeAction() will return false);
+            */
+            virtual void ResetSynchronizeAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetActivateControllerAction() will return false);
+            */
+            virtual void ResetActivateControllerAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetControllerAction() will return false);
+            */
+            virtual void ResetControllerAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTeleportAction() will return false);
+            */
+            virtual void ResetTeleportAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRoutingAction() will return false);
+            */
+            virtual void ResetRoutingAction() = 0;
+            
         };
 
 
@@ -11326,6 +12146,16 @@ namespace NET_ASAM_OPENSCENARIO
              * @return a list of writers for model property files
             */
             virtual std::vector<std::shared_ptr<IFileWriter>> GetWriterFiles() const = 0;
+            /**
+            * Resets the optional property (IsSetProperties() will return false);
+            */
+            virtual void ResetProperties() = 0;
+            
+            /**
+            * Resets the optional property (IsSetFiles() will return false);
+            */
+            virtual void ResetFiles() = 0;
+            
         };
 
 
@@ -11724,6 +12554,11 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
 
+            /**
+            * Resets the optional property (IsSetCoordinateSystem() will return false);
+            */
+            virtual void ResetCoordinateSystem() = 0;
+            
         };
 
 
@@ -11929,6 +12764,16 @@ Alternatively
             */
             virtual void ResetDsLane() = 0;
             
+            /**
+            * Resets the optional property (IsSetOffset() will return false);
+            */
+            virtual void ResetOffset() = 0;
+            
+            /**
+            * Resets the optional property (IsSetOrientation() will return false);
+            */
+            virtual void ResetOrientation() = 0;
+            
         };
 
 
@@ -12076,6 +12921,16 @@ Alternatively
             */
             virtual std::shared_ptr<IOrientationWriter> GetWriterOrientation() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetDz() will return false);
+            */
+            virtual void ResetDz() = 0;
+            
+            /**
+            * Resets the optional property (IsSetOrientation() will return false);
+            */
+            virtual void ResetOrientation() = 0;
+            
         };
 
 
@@ -12193,6 +13048,11 @@ Alternatively
             */
             virtual std::shared_ptr<IOrientationWriter> GetWriterOrientation() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetOrientation() will return false);
+            */
+            virtual void ResetOrientation() = 0;
+            
         };
 
 
@@ -12387,6 +13247,11 @@ Alternatively
             */
             virtual std::shared_ptr<ISteadyStateWriter> GetWriterSteadyState() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetSteadyState() will return false);
+            */
+            virtual void ResetSteadyState() = 0;
+            
         };
 
 
@@ -12818,6 +13683,16 @@ Alternatively
             */
             virtual std::shared_ptr<IOrientationWriter> GetWriterOrientation() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetDz() will return false);
+            */
+            virtual void ResetDz() = 0;
+            
+            /**
+            * Resets the optional property (IsSetOrientation() will return false);
+            */
+            virtual void ResetOrientation() = 0;
+            
         };
 
 
@@ -12883,6 +13758,11 @@ Alternatively
             */
             virtual std::shared_ptr<IPropertiesWriter> GetWriterProperties() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetProperties() will return false);
+            */
+            virtual void ResetProperties() = 0;
+            
         };
 
 
@@ -12972,6 +13852,26 @@ Alternatively
              * @return a list of writers for model property trafficSignals
             */
             virtual std::vector<std::shared_ptr<ITrafficSignalControllerWriter>> GetWriterTrafficSignals() const = 0;
+            /**
+            * Resets the optional property (IsSetLogicFile() will return false);
+            */
+            virtual void ResetLogicFile() = 0;
+            
+            /**
+            * Resets the optional property (IsSetSceneGraphFile() will return false);
+            */
+            virtual void ResetSceneGraphFile() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTrafficSignals() will return false);
+            */
+            virtual void ResetTrafficSignals() = 0;
+            
+            /**
+            * Resets the optional property (IsSetUsedArea() will return false);
+            */
+            virtual void ResetUsedArea() = 0;
+            
         };
 
 
@@ -13092,6 +13992,11 @@ Alternatively
             */
             virtual std::shared_ptr<IOrientationWriter> GetWriterOrientation() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetOrientation() will return false);
+            */
+            virtual void ResetOrientation() = 0;
+            
         };
 
 
@@ -13199,6 +14104,11 @@ Alternatively
              * @return a list of writers for model property waypoints
             */
             virtual std::vector<std::shared_ptr<IWaypointWriter>> GetWriterWaypoints() const = 0;
+            /**
+            * Resets the optional property (IsSetParameterDeclarations() will return false);
+            */
+            virtual void ResetParameterDeclarations() = 0;
+            
         };
 
 
@@ -13312,6 +14222,11 @@ Alternatively
             */
             virtual std::shared_ptr<IInRoutePositionWriter> GetWriterInRoutePosition() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetOrientation() will return false);
+            */
+            virtual void ResetOrientation() = 0;
+            
         };
 
 
@@ -13366,6 +14281,16 @@ Alternatively
             */
             virtual std::shared_ptr<ICatalogReferenceWriter> GetWriterCatalogReference() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetRoute() will return false);
+            */
+            virtual void ResetRoute() = 0;
+            
+            /**
+            * Resets the optional property (IsSetCatalogReference() will return false);
+            */
+            virtual void ResetCatalogReference() = 0;
+            
         };
 
 
@@ -13438,6 +14363,21 @@ Alternatively
             */
             virtual std::shared_ptr<IAcquirePositionActionWriter> GetWriterAcquirePositionAction() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetAssignRouteAction() will return false);
+            */
+            virtual void ResetAssignRouteAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetFollowTrajectoryAction() will return false);
+            */
+            virtual void ResetFollowTrajectoryAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetAcquirePositionAction() will return false);
+            */
+            virtual void ResetAcquirePositionAction() = 0;
+            
         };
 
 
@@ -13543,6 +14483,11 @@ Alternatively
              * @return a list of writers for model property parameterDeclarations
             */
             virtual std::vector<std::shared_ptr<IParameterDeclarationWriter>> GetWriterParameterDeclarations() const = 0;
+            /**
+            * Resets the optional property (IsSetParameterDeclarations() will return false);
+            */
+            virtual void ResetParameterDeclarations() = 0;
+            
         };
 
 
@@ -13624,6 +14569,11 @@ Alternatively
             */
             virtual std::shared_ptr<IObjectControllerWriter> GetWriterObjectController() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetObjectController() will return false);
+            */
+            virtual void ResetObjectController() = 0;
+            
         };
 
 
@@ -13678,6 +14628,16 @@ Alternatively
              * @return a list of writers for model property byType
             */
             virtual std::vector<std::shared_ptr<IByTypeWriter>> GetWriterByType() const = 0;
+            /**
+            * Resets the optional property (IsSetEntityRef() will return false);
+            */
+            virtual void ResetEntityRef() = 0;
+            
+            /**
+            * Resets the optional property (IsSetByType() will return false);
+            */
+            virtual void ResetByType() = 0;
+            
         };
 
 
@@ -13747,6 +14707,21 @@ Alternatively
             */
             virtual std::shared_ptr<INurbsWriter> GetWriterNurbs() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetPolyline() will return false);
+            */
+            virtual void ResetPolyline() = 0;
+            
+            /**
+            * Resets the optional property (IsSetClothoid() will return false);
+            */
+            virtual void ResetClothoid() = 0;
+            
+            /**
+            * Resets the optional property (IsSetNurbs() will return false);
+            */
+            virtual void ResetNurbs() = 0;
+            
         };
 
 
@@ -13933,6 +14908,16 @@ Alternatively
             */
             virtual std::shared_ptr<IAbsoluteTargetSpeedWriter> GetWriterAbsoluteTargetSpeed() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetRelativeTargetSpeed() will return false);
+            */
+            virtual void ResetRelativeTargetSpeed() = 0;
+            
+            /**
+            * Resets the optional property (IsSetAbsoluteTargetSpeed() will return false);
+            */
+            virtual void ResetAbsoluteTargetSpeed() = 0;
+            
         };
 
 
@@ -14470,6 +15455,11 @@ Alternatively
              * @return a list of writers for model property acts
             */
             virtual std::vector<std::shared_ptr<IActWriter>> GetWriterActs() const = 0;
+            /**
+            * Resets the optional property (IsSetParameterDeclarations() will return false);
+            */
+            virtual void ResetParameterDeclarations() = 0;
+            
         };
 
 
@@ -14905,6 +15895,11 @@ Alternatively
             */
             virtual void ResetTargetToleranceMaster() = 0;
             
+            /**
+            * Resets the optional property (IsSetFinalSpeed() will return false);
+            */
+            virtual void ResetFinalSpeed() = 0;
+            
         };
 
 
@@ -15264,6 +16259,16 @@ Alternatively
             */
             virtual void ResetAlongRoute() = 0;
             
+            /**
+            * Resets the optional property (IsSetCoordinateSystem() will return false);
+            */
+            virtual void ResetCoordinateSystem() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRelativeDistanceType() will return false);
+            */
+            virtual void ResetRelativeDistanceType() = 0;
+            
         };
 
 
@@ -15474,6 +16479,16 @@ Alternatively
             */
             virtual std::shared_ptr<ITimingWriter> GetWriterTiming() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetNone() will return false);
+            */
+            virtual void ResetNone() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTiming() will return false);
+            */
+            virtual void ResetTiming() = 0;
+            
         };
 
 
@@ -15685,6 +16700,16 @@ Alternatively
             */
             virtual void ResetAlongRoute() = 0;
             
+            /**
+            * Resets the optional property (IsSetCoordinateSystem() will return false);
+            */
+            virtual void ResetCoordinateSystem() = 0;
+            
+            /**
+            * Resets the optional property (IsSetRelativeDistanceType() will return false);
+            */
+            virtual void ResetRelativeDistanceType() = 0;
+            
         };
 
 
@@ -15740,6 +16765,16 @@ Alternatively
             */
             virtual std::shared_ptr<IEntityRefWriter> GetWriterEntityRef() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetPosition() will return false);
+            */
+            virtual void ResetPosition() = 0;
+            
+            /**
+            * Resets the optional property (IsSetEntityRef() will return false);
+            */
+            virtual void ResetEntityRef() = 0;
+            
         };
 
 
@@ -15958,6 +16993,26 @@ Alternatively
             */
             virtual void ResetTrafficName() = 0;
             
+            /**
+            * Resets the optional property (IsSetTrafficSourceAction() will return false);
+            */
+            virtual void ResetTrafficSourceAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTrafficSinkAction() will return false);
+            */
+            virtual void ResetTrafficSinkAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTrafficSwarmAction() will return false);
+            */
+            virtual void ResetTrafficSwarmAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTrafficStopAction() will return false);
+            */
+            virtual void ResetTrafficStopAction() = 0;
+            
         };
 
 
@@ -16092,6 +17147,16 @@ Alternatively
             */
             virtual std::shared_ptr<ITrafficSignalStateActionWriter> GetWriterTrafficSignalStateAction() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetTrafficSignalControllerAction() will return false);
+            */
+            virtual void ResetTrafficSignalControllerAction() = 0;
+            
+            /**
+            * Resets the optional property (IsSetTrafficSignalStateAction() will return false);
+            */
+            virtual void ResetTrafficSignalStateAction() = 0;
+            
         };
 
 
@@ -16292,9 +17357,19 @@ Alternatively
             */
             virtual std::vector<std::shared_ptr<IPhaseWriter>> GetWriterPhases() const = 0;
             /**
+            * Resets the optional property (IsSetDelay() will return false);
+            */
+            virtual void ResetDelay() = 0;
+            
+            /**
             * Resets the optional property (IsSetReference() will return false);
             */
             virtual void ResetReference() = 0;
+            
+            /**
+            * Resets the optional property (IsSetPhases() will return false);
+            */
+            virtual void ResetPhases() = 0;
             
         };
 
@@ -16381,6 +17456,11 @@ Alternatively
 
             // children
 
+            /**
+            * Resets the optional property (IsSetPhaseRef() will return false);
+            */
+            virtual void ResetPhaseRef() = 0;
+            
         };
 
 
@@ -16467,6 +17547,11 @@ Alternatively
 
             // children
 
+            /**
+            * Resets the optional property (IsSetPhaseRef() will return false);
+            */
+            virtual void ResetPhaseRef() = 0;
+            
         };
 
 
@@ -16731,6 +17816,11 @@ Alternatively
             */
             virtual void ResetRate() = 0;
             
+            /**
+            * Resets the optional property (IsSetTrafficDefinition() will return false);
+            */
+            virtual void ResetTrafficDefinition() = 0;
+            
         };
 
 
@@ -16863,6 +17953,11 @@ Alternatively
             */
             virtual std::shared_ptr<ITrafficDefinitionWriter> GetWriterTrafficDefinition() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetVelocity() will return false);
+            */
+            virtual void ResetVelocity() = 0;
+            
         };
 
 
@@ -17105,6 +18200,11 @@ Alternatively
             */
             virtual std::shared_ptr<ITrafficDefinitionWriter> GetWriterTrafficDefinition() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetVelocity() will return false);
+            */
+            virtual void ResetVelocity() = 0;
+            
         };
 
 
@@ -17211,6 +18311,11 @@ Alternatively
              * @return a list of writers for model property parameterDeclarations
             */
             virtual std::vector<std::shared_ptr<IParameterDeclarationWriter>> GetWriterParameterDeclarations() const = 0;
+            /**
+            * Resets the optional property (IsSetParameterDeclarations() will return false);
+            */
+            virtual void ResetParameterDeclarations() = 0;
+            
         };
 
 
@@ -17412,6 +18517,16 @@ Alternatively
             */
             virtual std::shared_ptr<ITrajectoryRefWriter> GetWriterTrajectoryRef() const  = 0;
 
+            /**
+            * Resets the optional property (IsSetT() will return false);
+            */
+            virtual void ResetT() = 0;
+            
+            /**
+            * Resets the optional property (IsSetOrientation() will return false);
+            */
+            virtual void ResetOrientation() = 0;
+            
         };
 
 
@@ -17662,6 +18777,11 @@ Alternatively
              * @return a list of writers for model property conditionGroups
             */
             virtual std::vector<std::shared_ptr<IConditionGroupWriter>> GetWriterConditionGroups() const = 0;
+            /**
+            * Resets the optional property (IsSetConditionGroups() will return false);
+            */
+            virtual void ResetConditionGroups() = 0;
+            
         };
 
 
@@ -18402,6 +19522,11 @@ Multiple constraint groups are
             */
             virtual void ResetModel3d() = 0;
             
+            /**
+            * Resets the optional property (IsSetParameterDeclarations() will return false);
+            */
+            virtual void ResetParameterDeclarations() = 0;
+            
         };
 
 
@@ -18979,6 +20104,26 @@ Multiple constraint groups are
             */
             virtual void ResetTemperature() = 0;
             
+            /**
+            * Resets the optional property (IsSetSun() will return false);
+            */
+            virtual void ResetSun() = 0;
+            
+            /**
+            * Resets the optional property (IsSetFog() will return false);
+            */
+            virtual void ResetFog() = 0;
+            
+            /**
+            * Resets the optional property (IsSetPrecipitation() will return false);
+            */
+            virtual void ResetPrecipitation() = 0;
+            
+            /**
+            * Resets the optional property (IsSetWind() will return false);
+            */
+            virtual void ResetWind() = 0;
+            
         };
 
 
@@ -19240,6 +20385,26 @@ Multiple constraint groups are
 
             // children
 
+            /**
+            * Resets the optional property (IsSetH() will return false);
+            */
+            virtual void ResetH() = 0;
+            
+            /**
+            * Resets the optional property (IsSetP() will return false);
+            */
+            virtual void ResetP() = 0;
+            
+            /**
+            * Resets the optional property (IsSetR() will return false);
+            */
+            virtual void ResetR() = 0;
+            
+            /**
+            * Resets the optional property (IsSetZ() will return false);
+            */
+            virtual void ResetZ() = 0;
+            
         };
 
     }

--- a/cpp/openScenarioLib/generated/v1_1/impl/ApiClassImplV1_1.cpp
+++ b/cpp/openScenarioLib/generated/v1_1/impl/ApiClassImplV1_1.cpp
@@ -50,6 +50,8 @@ namespace NET_ASAM_OPENSCENARIO
         void AbsoluteSpeedImpl::SetSteadyState(std::shared_ptr<ISteadyStateWriter> steadyState)
         {
             _steadyState = steadyState;
+			// set the indicator to true
+            isSetSteadyState = true;          
         }
 
         std::shared_ptr<void> AbsoluteSpeedImpl::GetAdapter(const std::string classifier)
@@ -275,6 +277,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void AbsoluteSpeedImpl::ResetSteadyState()
+	   {
+	   		isSetSteadyState = false; 
+			_steadyState = {};
+			
+	   }
+       bool AbsoluteSpeedImpl::IsSetSteadyState() const
+	   {
+			return isSetSteadyState;
+	   }
 
         IOpenScenarioFlexElement* AbsoluteTargetLaneImpl::GetOpenScenarioFlexElement()
         {
@@ -1447,6 +1459,8 @@ namespace NET_ASAM_OPENSCENARIO
         void ActImpl::SetStopTrigger(std::shared_ptr<ITriggerWriter> stopTrigger)
         {
             _stopTrigger = stopTrigger;
+			// set the indicator to true
+            isSetStopTrigger = true;          
         }
 
         std::shared_ptr<void> ActImpl::GetAdapter(const std::string classifier)
@@ -1727,6 +1741,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void ActImpl::ResetStopTrigger()
+	   {
+	   		isSetStopTrigger = false; 
+			_stopTrigger = {};
+			
+	   }
+       bool ActImpl::IsSetStopTrigger() const
+	   {
+			return isSetStopTrigger;
+	   }
 
         IOpenScenarioFlexElement* ActionImpl::GetOpenScenarioFlexElement()
         {
@@ -1761,6 +1785,8 @@ namespace NET_ASAM_OPENSCENARIO
             _globalAction = globalAction;
             _userDefinedAction = {};
             _privateAction = {};
+			// set the indicator to true
+            isSetGlobalAction = true;          
         }
 
         void ActionImpl::SetUserDefinedAction(std::shared_ptr<IUserDefinedActionWriter> userDefinedAction)
@@ -1768,6 +1794,8 @@ namespace NET_ASAM_OPENSCENARIO
             _userDefinedAction = userDefinedAction;
             _globalAction = {};
             _privateAction = {};
+			// set the indicator to true
+            isSetUserDefinedAction = true;          
         }
 
         void ActionImpl::SetPrivateAction(std::shared_ptr<IPrivateActionWriter> privateAction)
@@ -1775,6 +1803,8 @@ namespace NET_ASAM_OPENSCENARIO
             _privateAction = privateAction;
             _globalAction = {};
             _userDefinedAction = {};
+			// set the indicator to true
+            isSetPrivateAction = true;          
         }
 
         std::shared_ptr<void> ActionImpl::GetAdapter(const std::string classifier)
@@ -2044,6 +2074,36 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void ActionImpl::ResetGlobalAction()
+	   {
+	   		isSetGlobalAction = false; 
+			_globalAction = {};
+			
+	   }
+       bool ActionImpl::IsSetGlobalAction() const
+	   {
+			return isSetGlobalAction;
+	   }
+       void ActionImpl::ResetUserDefinedAction()
+	   {
+	   		isSetUserDefinedAction = false; 
+			_userDefinedAction = {};
+			
+	   }
+       bool ActionImpl::IsSetUserDefinedAction() const
+	   {
+			return isSetUserDefinedAction;
+	   }
+       void ActionImpl::ResetPrivateAction()
+	   {
+	   		isSetPrivateAction = false; 
+			_privateAction = {};
+			
+	   }
+       bool ActionImpl::IsSetPrivateAction() const
+	   {
+			return isSetPrivateAction;
+	   }
 
         IOpenScenarioFlexElement* ActivateControllerActionImpl::GetOpenScenarioFlexElement()
         {
@@ -2380,6 +2440,8 @@ namespace NET_ASAM_OPENSCENARIO
         void ActorsImpl::SetEntityRefs(std::vector<std::shared_ptr<IEntityRefWriter>>& entityRefs)
         {
             _entityRefs = entityRefs;
+			// set the indicator to true
+            isSetEntityRefs = true;          
         }
 
         std::shared_ptr<void> ActorsImpl::GetAdapter(const std::string classifier)
@@ -2612,6 +2674,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void ActorsImpl::ResetEntityRefs()
+	   {
+	   		isSetEntityRefs = false; 
+			_entityRefs = {};
+			
+	   }
+       bool ActorsImpl::IsSetEntityRefs() const
+	   {
+			return isSetEntityRefs;
+	   }
 
         IOpenScenarioFlexElement* AddEntityActionImpl::GetOpenScenarioFlexElement()
         {
@@ -2844,12 +2916,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _controller = controller;
             _catalogReference = {};
+			// set the indicator to true
+            isSetController = true;          
         }
 
         void AssignControllerActionImpl::SetCatalogReference(std::shared_ptr<ICatalogReferenceWriter> catalogReference)
         {
             _catalogReference = catalogReference;
             _controller = {};
+			// set the indicator to true
+            isSetCatalogReference = true;          
         }
 
         std::shared_ptr<void> AssignControllerActionImpl::GetAdapter(const std::string classifier)
@@ -3160,6 +3236,26 @@ namespace NET_ASAM_OPENSCENARIO
 	   {
 			return isSetActivateLongitudinal;
 	   }
+       void AssignControllerActionImpl::ResetController()
+	   {
+	   		isSetController = false; 
+			_controller = {};
+			
+	   }
+       bool AssignControllerActionImpl::IsSetController() const
+	   {
+			return isSetController;
+	   }
+       void AssignControllerActionImpl::ResetCatalogReference()
+	   {
+	   		isSetCatalogReference = false; 
+			_catalogReference = {};
+			
+	   }
+       bool AssignControllerActionImpl::IsSetCatalogReference() const
+	   {
+			return isSetCatalogReference;
+	   }
 
         IOpenScenarioFlexElement* AssignRouteActionImpl::GetOpenScenarioFlexElement()
         {
@@ -3179,12 +3275,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _route = route;
             _catalogReference = {};
+			// set the indicator to true
+            isSetRoute = true;          
         }
 
         void AssignRouteActionImpl::SetCatalogReference(std::shared_ptr<ICatalogReferenceWriter> catalogReference)
         {
             _catalogReference = catalogReference;
             _route = {};
+			// set the indicator to true
+            isSetCatalogReference = true;          
         }
 
         std::shared_ptr<void> AssignRouteActionImpl::GetAdapter(const std::string classifier)
@@ -3382,6 +3482,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void AssignRouteActionImpl::ResetRoute()
+	   {
+	   		isSetRoute = false; 
+			_route = {};
+			
+	   }
+       bool AssignRouteActionImpl::IsSetRoute() const
+	   {
+			return isSetRoute;
+	   }
+       void AssignRouteActionImpl::ResetCatalogReference()
+	   {
+	   		isSetCatalogReference = false; 
+			_catalogReference = {};
+			
+	   }
+       bool AssignRouteActionImpl::IsSetCatalogReference() const
+	   {
+			return isSetCatalogReference;
+	   }
 
         IOpenScenarioFlexElement* AxleImpl::GetOpenScenarioFlexElement()
         {
@@ -3853,6 +3973,8 @@ namespace NET_ASAM_OPENSCENARIO
         void AxlesImpl::SetAdditionalAxles(std::vector<std::shared_ptr<IAxleWriter>>& additionalAxles)
         {
             _additionalAxles = additionalAxles;
+			// set the indicator to true
+            isSetAdditionalAxles = true;          
         }
 
         std::shared_ptr<void> AxlesImpl::GetAdapter(const std::string classifier)
@@ -4083,6 +4205,16 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void AxlesImpl::ResetAdditionalAxles()
+	   {
+	   		isSetAdditionalAxles = false; 
+			_additionalAxles = {};
+			
+	   }
+       bool AxlesImpl::IsSetAdditionalAxles() const
+	   {
+			return isSetAdditionalAxles;
+	   }
 
         IOpenScenarioFlexElement* BoundingBoxImpl::GetOpenScenarioFlexElement()
         {
@@ -5003,6 +5135,8 @@ namespace NET_ASAM_OPENSCENARIO
             _userDefinedValueCondition = {};
             _trafficSignalCondition = {};
             _trafficSignalControllerCondition = {};
+			// set the indicator to true
+            isSetParameterCondition = true;          
         }
 
         void ByValueConditionImpl::SetTimeOfDayCondition(std::shared_ptr<ITimeOfDayConditionWriter> timeOfDayCondition)
@@ -5014,6 +5148,8 @@ namespace NET_ASAM_OPENSCENARIO
             _userDefinedValueCondition = {};
             _trafficSignalCondition = {};
             _trafficSignalControllerCondition = {};
+			// set the indicator to true
+            isSetTimeOfDayCondition = true;          
         }
 
         void ByValueConditionImpl::SetSimulationTimeCondition(std::shared_ptr<ISimulationTimeConditionWriter> simulationTimeCondition)
@@ -5025,6 +5161,8 @@ namespace NET_ASAM_OPENSCENARIO
             _userDefinedValueCondition = {};
             _trafficSignalCondition = {};
             _trafficSignalControllerCondition = {};
+			// set the indicator to true
+            isSetSimulationTimeCondition = true;          
         }
 
         void ByValueConditionImpl::SetStoryboardElementStateCondition(std::shared_ptr<IStoryboardElementStateConditionWriter> storyboardElementStateCondition)
@@ -5036,6 +5174,8 @@ namespace NET_ASAM_OPENSCENARIO
             _userDefinedValueCondition = {};
             _trafficSignalCondition = {};
             _trafficSignalControllerCondition = {};
+			// set the indicator to true
+            isSetStoryboardElementStateCondition = true;          
         }
 
         void ByValueConditionImpl::SetUserDefinedValueCondition(std::shared_ptr<IUserDefinedValueConditionWriter> userDefinedValueCondition)
@@ -5047,6 +5187,8 @@ namespace NET_ASAM_OPENSCENARIO
             _storyboardElementStateCondition = {};
             _trafficSignalCondition = {};
             _trafficSignalControllerCondition = {};
+			// set the indicator to true
+            isSetUserDefinedValueCondition = true;          
         }
 
         void ByValueConditionImpl::SetTrafficSignalCondition(std::shared_ptr<ITrafficSignalConditionWriter> trafficSignalCondition)
@@ -5058,6 +5200,8 @@ namespace NET_ASAM_OPENSCENARIO
             _storyboardElementStateCondition = {};
             _userDefinedValueCondition = {};
             _trafficSignalControllerCondition = {};
+			// set the indicator to true
+            isSetTrafficSignalCondition = true;          
         }
 
         void ByValueConditionImpl::SetTrafficSignalControllerCondition(std::shared_ptr<ITrafficSignalControllerConditionWriter> trafficSignalControllerCondition)
@@ -5069,6 +5213,8 @@ namespace NET_ASAM_OPENSCENARIO
             _storyboardElementStateCondition = {};
             _userDefinedValueCondition = {};
             _trafficSignalCondition = {};
+			// set the indicator to true
+            isSetTrafficSignalControllerCondition = true;          
         }
 
         std::shared_ptr<void> ByValueConditionImpl::GetAdapter(const std::string classifier)
@@ -5376,6 +5522,76 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void ByValueConditionImpl::ResetParameterCondition()
+	   {
+	   		isSetParameterCondition = false; 
+			_parameterCondition = {};
+			
+	   }
+       bool ByValueConditionImpl::IsSetParameterCondition() const
+	   {
+			return isSetParameterCondition;
+	   }
+       void ByValueConditionImpl::ResetTimeOfDayCondition()
+	   {
+	   		isSetTimeOfDayCondition = false; 
+			_timeOfDayCondition = {};
+			
+	   }
+       bool ByValueConditionImpl::IsSetTimeOfDayCondition() const
+	   {
+			return isSetTimeOfDayCondition;
+	   }
+       void ByValueConditionImpl::ResetSimulationTimeCondition()
+	   {
+	   		isSetSimulationTimeCondition = false; 
+			_simulationTimeCondition = {};
+			
+	   }
+       bool ByValueConditionImpl::IsSetSimulationTimeCondition() const
+	   {
+			return isSetSimulationTimeCondition;
+	   }
+       void ByValueConditionImpl::ResetStoryboardElementStateCondition()
+	   {
+	   		isSetStoryboardElementStateCondition = false; 
+			_storyboardElementStateCondition = {};
+			
+	   }
+       bool ByValueConditionImpl::IsSetStoryboardElementStateCondition() const
+	   {
+			return isSetStoryboardElementStateCondition;
+	   }
+       void ByValueConditionImpl::ResetUserDefinedValueCondition()
+	   {
+	   		isSetUserDefinedValueCondition = false; 
+			_userDefinedValueCondition = {};
+			
+	   }
+       bool ByValueConditionImpl::IsSetUserDefinedValueCondition() const
+	   {
+			return isSetUserDefinedValueCondition;
+	   }
+       void ByValueConditionImpl::ResetTrafficSignalCondition()
+	   {
+	   		isSetTrafficSignalCondition = false; 
+			_trafficSignalCondition = {};
+			
+	   }
+       bool ByValueConditionImpl::IsSetTrafficSignalCondition() const
+	   {
+			return isSetTrafficSignalCondition;
+	   }
+       void ByValueConditionImpl::ResetTrafficSignalControllerCondition()
+	   {
+	   		isSetTrafficSignalControllerCondition = false; 
+			_trafficSignalControllerCondition = {};
+			
+	   }
+       bool ByValueConditionImpl::IsSetTrafficSignalControllerCondition() const
+	   {
+			return isSetTrafficSignalControllerCondition;
+	   }
 
         IOpenScenarioFlexElement* CatalogImpl::GetOpenScenarioFlexElement()
         {
@@ -5591,46 +5807,64 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _name = name;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__NAME);
+			// set the indicator to true
+            isSetName = true;          
         }
 
         void CatalogImpl::SetVehicles(std::vector<std::shared_ptr<IVehicleWriter>>& vehicles)
         {
             _vehicles = vehicles;
+			// set the indicator to true
+            isSetVehicles = true;          
         }
 
         void CatalogImpl::SetControllers(std::vector<std::shared_ptr<IControllerWriter>>& controllers)
         {
             _controllers = controllers;
+			// set the indicator to true
+            isSetControllers = true;          
         }
 
         void CatalogImpl::SetPedestrians(std::vector<std::shared_ptr<IPedestrianWriter>>& pedestrians)
         {
             _pedestrians = pedestrians;
+			// set the indicator to true
+            isSetPedestrians = true;          
         }
 
         void CatalogImpl::SetMiscObjects(std::vector<std::shared_ptr<IMiscObjectWriter>>& miscObjects)
         {
             _miscObjects = miscObjects;
+			// set the indicator to true
+            isSetMiscObjects = true;          
         }
 
         void CatalogImpl::SetEnvironments(std::vector<std::shared_ptr<IEnvironmentWriter>>& environments)
         {
             _environments = environments;
+			// set the indicator to true
+            isSetEnvironments = true;          
         }
 
         void CatalogImpl::SetManeuvers(std::vector<std::shared_ptr<IManeuverWriter>>& maneuvers)
         {
             _maneuvers = maneuvers;
+			// set the indicator to true
+            isSetManeuvers = true;          
         }
 
         void CatalogImpl::SetTrajectories(std::vector<std::shared_ptr<ITrajectoryWriter>>& trajectories)
         {
             _trajectories = trajectories;
+			// set the indicator to true
+            isSetTrajectories = true;          
         }
 
         void CatalogImpl::SetRoutes(std::vector<std::shared_ptr<IRouteWriter>>& routes)
         {
             _routes = routes;
+			// set the indicator to true
+            isSetRoutes = true;          
         }
 
         std::shared_ptr<void> CatalogImpl::GetAdapter(const std::string classifier)
@@ -5844,6 +6078,7 @@ namespace NET_ASAM_OPENSCENARIO
             // Simple type
             clonedObject->_name = GetName();
             // clone indicators
+            	clonedObject->isSetName = isSetName;
             // clone children
             const auto kVehicles =  GetWriterVehicles();
             if (!kVehicles.empty())
@@ -6059,6 +6294,96 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void CatalogImpl::ResetName()
+	   {
+	   		isSetName = false; 
+			_name = {};
+			
+	   }
+       bool CatalogImpl::IsSetName() const
+	   {
+			return isSetName;
+	   }
+       void CatalogImpl::ResetVehicles()
+	   {
+	   		isSetVehicles = false; 
+			_vehicles = {};
+			
+	   }
+       bool CatalogImpl::IsSetVehicles() const
+	   {
+			return isSetVehicles;
+	   }
+       void CatalogImpl::ResetControllers()
+	   {
+	   		isSetControllers = false; 
+			_controllers = {};
+			
+	   }
+       bool CatalogImpl::IsSetControllers() const
+	   {
+			return isSetControllers;
+	   }
+       void CatalogImpl::ResetPedestrians()
+	   {
+	   		isSetPedestrians = false; 
+			_pedestrians = {};
+			
+	   }
+       bool CatalogImpl::IsSetPedestrians() const
+	   {
+			return isSetPedestrians;
+	   }
+       void CatalogImpl::ResetMiscObjects()
+	   {
+	   		isSetMiscObjects = false; 
+			_miscObjects = {};
+			
+	   }
+       bool CatalogImpl::IsSetMiscObjects() const
+	   {
+			return isSetMiscObjects;
+	   }
+       void CatalogImpl::ResetEnvironments()
+	   {
+	   		isSetEnvironments = false; 
+			_environments = {};
+			
+	   }
+       bool CatalogImpl::IsSetEnvironments() const
+	   {
+			return isSetEnvironments;
+	   }
+       void CatalogImpl::ResetManeuvers()
+	   {
+	   		isSetManeuvers = false; 
+			_maneuvers = {};
+			
+	   }
+       bool CatalogImpl::IsSetManeuvers() const
+	   {
+			return isSetManeuvers;
+	   }
+       void CatalogImpl::ResetTrajectories()
+	   {
+	   		isSetTrajectories = false; 
+			_trajectories = {};
+			
+	   }
+       bool CatalogImpl::IsSetTrajectories() const
+	   {
+			return isSetTrajectories;
+	   }
+       void CatalogImpl::ResetRoutes()
+	   {
+	   		isSetRoutes = false; 
+			_routes = {};
+			
+	   }
+       bool CatalogImpl::IsSetRoutes() const
+	   {
+			return isSetRoutes;
+	   }
 
         IOpenScenarioFlexElement* CatalogDefinitionImpl::GetOpenScenarioFlexElement()
         {
@@ -6290,41 +6615,57 @@ namespace NET_ASAM_OPENSCENARIO
         void CatalogLocationsImpl::SetVehicleCatalog(std::shared_ptr<IVehicleCatalogLocationWriter> vehicleCatalog)
         {
             _vehicleCatalog = vehicleCatalog;
+			// set the indicator to true
+            isSetVehicleCatalog = true;          
         }
 
         void CatalogLocationsImpl::SetControllerCatalog(std::shared_ptr<IControllerCatalogLocationWriter> controllerCatalog)
         {
             _controllerCatalog = controllerCatalog;
+			// set the indicator to true
+            isSetControllerCatalog = true;          
         }
 
         void CatalogLocationsImpl::SetPedestrianCatalog(std::shared_ptr<IPedestrianCatalogLocationWriter> pedestrianCatalog)
         {
             _pedestrianCatalog = pedestrianCatalog;
+			// set the indicator to true
+            isSetPedestrianCatalog = true;          
         }
 
         void CatalogLocationsImpl::SetMiscObjectCatalog(std::shared_ptr<IMiscObjectCatalogLocationWriter> miscObjectCatalog)
         {
             _miscObjectCatalog = miscObjectCatalog;
+			// set the indicator to true
+            isSetMiscObjectCatalog = true;          
         }
 
         void CatalogLocationsImpl::SetEnvironmentCatalog(std::shared_ptr<IEnvironmentCatalogLocationWriter> environmentCatalog)
         {
             _environmentCatalog = environmentCatalog;
+			// set the indicator to true
+            isSetEnvironmentCatalog = true;          
         }
 
         void CatalogLocationsImpl::SetManeuverCatalog(std::shared_ptr<IManeuverCatalogLocationWriter> maneuverCatalog)
         {
             _maneuverCatalog = maneuverCatalog;
+			// set the indicator to true
+            isSetManeuverCatalog = true;          
         }
 
         void CatalogLocationsImpl::SetTrajectoryCatalog(std::shared_ptr<ITrajectoryCatalogLocationWriter> trajectoryCatalog)
         {
             _trajectoryCatalog = trajectoryCatalog;
+			// set the indicator to true
+            isSetTrajectoryCatalog = true;          
         }
 
         void CatalogLocationsImpl::SetRouteCatalog(std::shared_ptr<IRouteCatalogLocationWriter> routeCatalog)
         {
             _routeCatalog = routeCatalog;
+			// set the indicator to true
+            isSetRouteCatalog = true;          
         }
 
         std::shared_ptr<void> CatalogLocationsImpl::GetAdapter(const std::string classifier)
@@ -6654,6 +6995,86 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void CatalogLocationsImpl::ResetVehicleCatalog()
+	   {
+	   		isSetVehicleCatalog = false; 
+			_vehicleCatalog = {};
+			
+	   }
+       bool CatalogLocationsImpl::IsSetVehicleCatalog() const
+	   {
+			return isSetVehicleCatalog;
+	   }
+       void CatalogLocationsImpl::ResetControllerCatalog()
+	   {
+	   		isSetControllerCatalog = false; 
+			_controllerCatalog = {};
+			
+	   }
+       bool CatalogLocationsImpl::IsSetControllerCatalog() const
+	   {
+			return isSetControllerCatalog;
+	   }
+       void CatalogLocationsImpl::ResetPedestrianCatalog()
+	   {
+	   		isSetPedestrianCatalog = false; 
+			_pedestrianCatalog = {};
+			
+	   }
+       bool CatalogLocationsImpl::IsSetPedestrianCatalog() const
+	   {
+			return isSetPedestrianCatalog;
+	   }
+       void CatalogLocationsImpl::ResetMiscObjectCatalog()
+	   {
+	   		isSetMiscObjectCatalog = false; 
+			_miscObjectCatalog = {};
+			
+	   }
+       bool CatalogLocationsImpl::IsSetMiscObjectCatalog() const
+	   {
+			return isSetMiscObjectCatalog;
+	   }
+       void CatalogLocationsImpl::ResetEnvironmentCatalog()
+	   {
+	   		isSetEnvironmentCatalog = false; 
+			_environmentCatalog = {};
+			
+	   }
+       bool CatalogLocationsImpl::IsSetEnvironmentCatalog() const
+	   {
+			return isSetEnvironmentCatalog;
+	   }
+       void CatalogLocationsImpl::ResetManeuverCatalog()
+	   {
+	   		isSetManeuverCatalog = false; 
+			_maneuverCatalog = {};
+			
+	   }
+       bool CatalogLocationsImpl::IsSetManeuverCatalog() const
+	   {
+			return isSetManeuverCatalog;
+	   }
+       void CatalogLocationsImpl::ResetTrajectoryCatalog()
+	   {
+	   		isSetTrajectoryCatalog = false; 
+			_trajectoryCatalog = {};
+			
+	   }
+       bool CatalogLocationsImpl::IsSetTrajectoryCatalog() const
+	   {
+			return isSetTrajectoryCatalog;
+	   }
+       void CatalogLocationsImpl::ResetRouteCatalog()
+	   {
+	   		isSetRouteCatalog = false; 
+			_routeCatalog = {};
+			
+	   }
+       bool CatalogLocationsImpl::IsSetRouteCatalog() const
+	   {
+			return isSetRouteCatalog;
+	   }
 
         IOpenScenarioFlexElement* CatalogReferenceImpl::GetOpenScenarioFlexElement()
         {
@@ -6713,6 +7134,8 @@ namespace NET_ASAM_OPENSCENARIO
         void CatalogReferenceImpl::SetParameterAssignments(std::vector<std::shared_ptr<IParameterAssignmentWriter>>& parameterAssignments)
         {
             _parameterAssignments = parameterAssignments;
+			// set the indicator to true
+            isSetParameterAssignments = true;          
         }
 
         void CatalogReferenceImpl::SetRef(const std::shared_ptr<ICatalogElement> ref)
@@ -6991,6 +7414,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void CatalogReferenceImpl::ResetParameterAssignments()
+	   {
+	   		isSetParameterAssignments = false; 
+			_parameterAssignments = {};
+			
+	   }
+       bool CatalogReferenceImpl::IsSetParameterAssignments() const
+	   {
+			return isSetParameterAssignments;
+	   }
 
         IOpenScenarioFlexElement* CenterImpl::GetOpenScenarioFlexElement()
         {
@@ -8103,12 +8536,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _entityRef = entityRef;
             _byType = {};
+			// set the indicator to true
+            isSetEntityRef = true;          
         }
 
         void CollisionConditionImpl::SetByType(std::shared_ptr<IByObjectTypeWriter> byType)
         {
             _byType = byType;
             _entityRef = {};
+			// set the indicator to true
+            isSetByType = true;          
         }
 
         std::shared_ptr<void> CollisionConditionImpl::GetAdapter(const std::string classifier)
@@ -8306,6 +8743,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void CollisionConditionImpl::ResetEntityRef()
+	   {
+	   		isSetEntityRef = false; 
+			_entityRef = {};
+			
+	   }
+       bool CollisionConditionImpl::IsSetEntityRef() const
+	   {
+			return isSetEntityRef;
+	   }
+       void CollisionConditionImpl::ResetByType()
+	   {
+	   		isSetByType = false; 
+			_byType = {};
+			
+	   }
+       bool CollisionConditionImpl::IsSetByType() const
+	   {
+			return isSetByType;
+	   }
 
         IOpenScenarioFlexElement* ConditionImpl::GetOpenScenarioFlexElement()
         {
@@ -8355,12 +8812,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _byEntityCondition = byEntityCondition;
             _byValueCondition = {};
+			// set the indicator to true
+            isSetByEntityCondition = true;          
         }
 
         void ConditionImpl::SetByValueCondition(std::shared_ptr<IByValueConditionWriter> byValueCondition)
         {
             _byValueCondition = byValueCondition;
             _byEntityCondition = {};
+			// set the indicator to true
+            isSetByValueCondition = true;          
         }
 
         std::shared_ptr<void> ConditionImpl::GetAdapter(const std::string classifier)
@@ -8712,6 +9173,26 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void ConditionImpl::ResetByEntityCondition()
+	   {
+	   		isSetByEntityCondition = false; 
+			_byEntityCondition = {};
+			
+	   }
+       bool ConditionImpl::IsSetByEntityCondition() const
+	   {
+			return isSetByEntityCondition;
+	   }
+       void ConditionImpl::ResetByValueCondition()
+	   {
+	   		isSetByValueCondition = false; 
+			_byValueCondition = {};
+			
+	   }
+       bool ConditionImpl::IsSetByValueCondition() const
+	   {
+			return isSetByValueCondition;
+	   }
 
         IOpenScenarioFlexElement* ConditionGroupImpl::GetOpenScenarioFlexElement()
         {
@@ -9304,6 +9785,8 @@ namespace NET_ASAM_OPENSCENARIO
         void ControllerImpl::SetParameterDeclarations(std::vector<std::shared_ptr<IParameterDeclarationWriter>>& parameterDeclarations)
         {
             _parameterDeclarations = parameterDeclarations;
+			// set the indicator to true
+            isSetParameterDeclarations = true;          
         }
 
         void ControllerImpl::SetProperties(std::shared_ptr<IPropertiesWriter> properties)
@@ -9586,6 +10069,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void ControllerImpl::ResetParameterDeclarations()
+	   {
+	   		isSetParameterDeclarations = false; 
+			_parameterDeclarations = {};
+			
+	   }
+       bool ControllerImpl::IsSetParameterDeclarations() const
+	   {
+			return isSetParameterDeclarations;
+	   }
 
         IOpenScenarioFlexElement* ControllerActionImpl::GetOpenScenarioFlexElement()
         {
@@ -9608,16 +10101,22 @@ namespace NET_ASAM_OPENSCENARIO
         void ControllerActionImpl::SetAssignControllerAction(std::shared_ptr<IAssignControllerActionWriter> assignControllerAction)
         {
             _assignControllerAction = assignControllerAction;
+			// set the indicator to true
+            isSetAssignControllerAction = true;          
         }
 
         void ControllerActionImpl::SetOverrideControllerValueAction(std::shared_ptr<IOverrideControllerValueActionWriter> overrideControllerValueAction)
         {
             _overrideControllerValueAction = overrideControllerValueAction;
+			// set the indicator to true
+            isSetOverrideControllerValueAction = true;          
         }
 
         void ControllerActionImpl::SetActivateControllerAction(std::shared_ptr<IActivateControllerActionWriter> activateControllerAction)
         {
             _activateControllerAction = activateControllerAction;
+			// set the indicator to true
+            isSetActivateControllerAction = true;          
         }
 
         std::shared_ptr<void> ControllerActionImpl::GetAdapter(const std::string classifier)
@@ -9837,6 +10336,36 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void ControllerActionImpl::ResetAssignControllerAction()
+	   {
+	   		isSetAssignControllerAction = false; 
+			_assignControllerAction = {};
+			
+	   }
+       bool ControllerActionImpl::IsSetAssignControllerAction() const
+	   {
+			return isSetAssignControllerAction;
+	   }
+       void ControllerActionImpl::ResetOverrideControllerValueAction()
+	   {
+	   		isSetOverrideControllerValueAction = false; 
+			_overrideControllerValueAction = {};
+			
+	   }
+       bool ControllerActionImpl::IsSetOverrideControllerValueAction() const
+	   {
+			return isSetOverrideControllerValueAction;
+	   }
+       void ControllerActionImpl::ResetActivateControllerAction()
+	   {
+	   		isSetActivateControllerAction = false; 
+			_activateControllerAction = {};
+			
+	   }
+       bool ControllerActionImpl::IsSetActivateControllerAction() const
+	   {
+			return isSetActivateControllerAction;
+	   }
 
         IOpenScenarioFlexElement* ControllerCatalogLocationImpl::GetOpenScenarioFlexElement()
         {
@@ -10272,12 +10801,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _controller = controller;
             _catalogReference = {};
+			// set the indicator to true
+            isSetController = true;          
         }
 
         void ControllerDistributionEntryImpl::SetCatalogReference(std::shared_ptr<ICatalogReferenceWriter> catalogReference)
         {
             _catalogReference = catalogReference;
             _controller = {};
+			// set the indicator to true
+            isSetCatalogReference = true;          
         }
 
         std::shared_ptr<void> ControllerDistributionEntryImpl::GetAdapter(const std::string classifier)
@@ -10525,6 +11058,26 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void ControllerDistributionEntryImpl::ResetController()
+	   {
+	   		isSetController = false; 
+			_controller = {};
+			
+	   }
+       bool ControllerDistributionEntryImpl::IsSetController() const
+	   {
+			return isSetController;
+	   }
+       void ControllerDistributionEntryImpl::ResetCatalogReference()
+	   {
+	   		isSetCatalogReference = false; 
+			_catalogReference = {};
+			
+	   }
+       bool ControllerDistributionEntryImpl::IsSetCatalogReference() const
+	   {
+			return isSetCatalogReference;
+	   }
 
         IOpenScenarioFlexElement* CustomCommandActionImpl::GetOpenScenarioFlexElement()
         {
@@ -10978,6 +11531,8 @@ namespace NET_ASAM_OPENSCENARIO
         void DeterministicImpl::SetDeterministicParameterDistributions(std::vector<std::shared_ptr<IDeterministicParameterDistributionWriter>>& deterministicParameterDistributions)
         {
             _deterministicParameterDistributions = deterministicParameterDistributions;
+			// set the indicator to true
+            isSetDeterministicParameterDistributions = true;          
         }
 
         std::shared_ptr<void> DeterministicImpl::GetAdapter(const std::string classifier)
@@ -11160,6 +11715,16 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void DeterministicImpl::ResetDeterministicParameterDistributions()
+	   {
+	   		isSetDeterministicParameterDistributions = false; 
+			_deterministicParameterDistributions = {};
+			
+	   }
+       bool DeterministicImpl::IsSetDeterministicParameterDistributions() const
+	   {
+			return isSetDeterministicParameterDistributions;
+	   }
 
         IOpenScenarioFlexElement* DeterministicMultiParameterDistributionImpl::GetOpenScenarioFlexElement()
         {
@@ -12843,6 +13408,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _coordinateSystem = coordinateSystem;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM);
+			// set the indicator to true
+            isSetCoordinateSystem = true;          
         }
 
         void DistanceConditionImpl::SetFreespace(const bool freespace)
@@ -12855,6 +13422,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _relativeDistanceType = relativeDistanceType;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__RELATIVE_DISTANCE_TYPE);
+			// set the indicator to true
+            isSetRelativeDistanceType = true;          
         }
 
         void DistanceConditionImpl::SetRule(const Rule rule)
@@ -13247,6 +13816,8 @@ namespace NET_ASAM_OPENSCENARIO
             clonedObject->_value = GetValue();
             // clone indicators
             	clonedObject->isSetAlongRoute = isSetAlongRoute;
+            	clonedObject->isSetCoordinateSystem = isSetCoordinateSystem;
+            	clonedObject->isSetRelativeDistanceType = isSetRelativeDistanceType;
             // clone children
             const auto kPosition =  GetWriterPosition();
             if (kPosition)
@@ -13350,6 +13921,26 @@ namespace NET_ASAM_OPENSCENARIO
        bool DistanceConditionImpl::IsSetAlongRoute() const
 	   {
 			return isSetAlongRoute;
+	   }
+       void DistanceConditionImpl::ResetCoordinateSystem()
+	   {
+	   		isSetCoordinateSystem = false; 
+			_coordinateSystem = {CoordinateSystem::CoordinateSystemEnum::ENTITY};
+			
+	   }
+       bool DistanceConditionImpl::IsSetCoordinateSystem() const
+	   {
+			return isSetCoordinateSystem;
+	   }
+       void DistanceConditionImpl::ResetRelativeDistanceType()
+	   {
+	   		isSetRelativeDistanceType = false; 
+			_relativeDistanceType = {RelativeDistanceType::RelativeDistanceTypeEnum::EUCLIDIAN_DISTANCE};
+			
+	   }
+       bool DistanceConditionImpl::IsSetRelativeDistanceType() const
+	   {
+			return isSetRelativeDistanceType;
 	   }
 
         IOpenScenarioFlexElement* DistributionDefinitionImpl::GetOpenScenarioFlexElement()
@@ -14882,11 +15473,15 @@ namespace NET_ASAM_OPENSCENARIO
         void EntitiesImpl::SetScenarioObjects(std::vector<std::shared_ptr<IScenarioObjectWriter>>& scenarioObjects)
         {
             _scenarioObjects = scenarioObjects;
+			// set the indicator to true
+            isSetScenarioObjects = true;          
         }
 
         void EntitiesImpl::SetEntitySelections(std::vector<std::shared_ptr<IEntitySelectionWriter>>& entitySelections)
         {
             _entitySelections = entitySelections;
+			// set the indicator to true
+            isSetEntitySelections = true;          
         }
 
         std::shared_ptr<void> EntitiesImpl::GetAdapter(const std::string classifier)
@@ -15097,6 +15692,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void EntitiesImpl::ResetScenarioObjects()
+	   {
+	   		isSetScenarioObjects = false; 
+			_scenarioObjects = {};
+			
+	   }
+       bool EntitiesImpl::IsSetScenarioObjects() const
+	   {
+			return isSetScenarioObjects;
+	   }
+       void EntitiesImpl::ResetEntitySelections()
+	   {
+	   		isSetEntitySelections = false; 
+			_entitySelections = {};
+			
+	   }
+       bool EntitiesImpl::IsSetEntitySelections() const
+	   {
+			return isSetEntitySelections;
+	   }
 
         IOpenScenarioFlexElement* EntityActionImpl::GetOpenScenarioFlexElement()
         {
@@ -15126,12 +15741,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _addEntityAction = addEntityAction;
             _deleteEntityAction = {};
+			// set the indicator to true
+            isSetAddEntityAction = true;          
         }
 
         void EntityActionImpl::SetDeleteEntityAction(std::shared_ptr<IDeleteEntityActionWriter> deleteEntityAction)
         {
             _deleteEntityAction = deleteEntityAction;
             _addEntityAction = {};
+			// set the indicator to true
+            isSetDeleteEntityAction = true;          
         }
 
         std::shared_ptr<void> EntityActionImpl::GetAdapter(const std::string classifier)
@@ -15386,6 +16005,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void EntityActionImpl::ResetAddEntityAction()
+	   {
+	   		isSetAddEntityAction = false; 
+			_addEntityAction = {};
+			
+	   }
+       bool EntityActionImpl::IsSetAddEntityAction() const
+	   {
+			return isSetAddEntityAction;
+	   }
+       void EntityActionImpl::ResetDeleteEntityAction()
+	   {
+	   		isSetDeleteEntityAction = false; 
+			_deleteEntityAction = {};
+			
+	   }
+       bool EntityActionImpl::IsSetDeleteEntityAction() const
+	   {
+			return isSetDeleteEntityAction;
+	   }
 
         IOpenScenarioFlexElement* EntityConditionImpl::GetOpenScenarioFlexElement()
         {
@@ -15460,6 +16099,8 @@ namespace NET_ASAM_OPENSCENARIO
             _reachPositionCondition = {};
             _distanceCondition = {};
             _relativeDistanceCondition = {};
+			// set the indicator to true
+            isSetEndOfRoadCondition = true;          
         }
 
         void EntityConditionImpl::SetCollisionCondition(std::shared_ptr<ICollisionConditionWriter> collisionCondition)
@@ -15477,6 +16118,8 @@ namespace NET_ASAM_OPENSCENARIO
             _reachPositionCondition = {};
             _distanceCondition = {};
             _relativeDistanceCondition = {};
+			// set the indicator to true
+            isSetCollisionCondition = true;          
         }
 
         void EntityConditionImpl::SetOffroadCondition(std::shared_ptr<IOffroadConditionWriter> offroadCondition)
@@ -15494,6 +16137,8 @@ namespace NET_ASAM_OPENSCENARIO
             _reachPositionCondition = {};
             _distanceCondition = {};
             _relativeDistanceCondition = {};
+			// set the indicator to true
+            isSetOffroadCondition = true;          
         }
 
         void EntityConditionImpl::SetTimeHeadwayCondition(std::shared_ptr<ITimeHeadwayConditionWriter> timeHeadwayCondition)
@@ -15511,6 +16156,8 @@ namespace NET_ASAM_OPENSCENARIO
             _reachPositionCondition = {};
             _distanceCondition = {};
             _relativeDistanceCondition = {};
+			// set the indicator to true
+            isSetTimeHeadwayCondition = true;          
         }
 
         void EntityConditionImpl::SetTimeToCollisionCondition(std::shared_ptr<ITimeToCollisionConditionWriter> timeToCollisionCondition)
@@ -15528,6 +16175,8 @@ namespace NET_ASAM_OPENSCENARIO
             _reachPositionCondition = {};
             _distanceCondition = {};
             _relativeDistanceCondition = {};
+			// set the indicator to true
+            isSetTimeToCollisionCondition = true;          
         }
 
         void EntityConditionImpl::SetAccelerationCondition(std::shared_ptr<IAccelerationConditionWriter> accelerationCondition)
@@ -15545,6 +16194,8 @@ namespace NET_ASAM_OPENSCENARIO
             _reachPositionCondition = {};
             _distanceCondition = {};
             _relativeDistanceCondition = {};
+			// set the indicator to true
+            isSetAccelerationCondition = true;          
         }
 
         void EntityConditionImpl::SetStandStillCondition(std::shared_ptr<IStandStillConditionWriter> standStillCondition)
@@ -15562,6 +16213,8 @@ namespace NET_ASAM_OPENSCENARIO
             _reachPositionCondition = {};
             _distanceCondition = {};
             _relativeDistanceCondition = {};
+			// set the indicator to true
+            isSetStandStillCondition = true;          
         }
 
         void EntityConditionImpl::SetSpeedCondition(std::shared_ptr<ISpeedConditionWriter> speedCondition)
@@ -15579,6 +16232,8 @@ namespace NET_ASAM_OPENSCENARIO
             _reachPositionCondition = {};
             _distanceCondition = {};
             _relativeDistanceCondition = {};
+			// set the indicator to true
+            isSetSpeedCondition = true;          
         }
 
         void EntityConditionImpl::SetRelativeSpeedCondition(std::shared_ptr<IRelativeSpeedConditionWriter> relativeSpeedCondition)
@@ -15596,6 +16251,8 @@ namespace NET_ASAM_OPENSCENARIO
             _reachPositionCondition = {};
             _distanceCondition = {};
             _relativeDistanceCondition = {};
+			// set the indicator to true
+            isSetRelativeSpeedCondition = true;          
         }
 
         void EntityConditionImpl::SetTraveledDistanceCondition(std::shared_ptr<ITraveledDistanceConditionWriter> traveledDistanceCondition)
@@ -15613,6 +16270,8 @@ namespace NET_ASAM_OPENSCENARIO
             _reachPositionCondition = {};
             _distanceCondition = {};
             _relativeDistanceCondition = {};
+			// set the indicator to true
+            isSetTraveledDistanceCondition = true;          
         }
 
         void EntityConditionImpl::SetReachPositionCondition(std::shared_ptr<IReachPositionConditionWriter> reachPositionCondition)
@@ -15630,6 +16289,8 @@ namespace NET_ASAM_OPENSCENARIO
             _traveledDistanceCondition = {};
             _distanceCondition = {};
             _relativeDistanceCondition = {};
+			// set the indicator to true
+            isSetReachPositionCondition = true;          
         }
 
         void EntityConditionImpl::SetDistanceCondition(std::shared_ptr<IDistanceConditionWriter> distanceCondition)
@@ -15647,6 +16308,8 @@ namespace NET_ASAM_OPENSCENARIO
             _traveledDistanceCondition = {};
             _reachPositionCondition = {};
             _relativeDistanceCondition = {};
+			// set the indicator to true
+            isSetDistanceCondition = true;          
         }
 
         void EntityConditionImpl::SetRelativeDistanceCondition(std::shared_ptr<IRelativeDistanceConditionWriter> relativeDistanceCondition)
@@ -15664,6 +16327,8 @@ namespace NET_ASAM_OPENSCENARIO
             _traveledDistanceCondition = {};
             _reachPositionCondition = {};
             _distanceCondition = {};
+			// set the indicator to true
+            isSetRelativeDistanceCondition = true;          
         }
 
         std::shared_ptr<void> EntityConditionImpl::GetAdapter(const std::string classifier)
@@ -16103,6 +16768,136 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void EntityConditionImpl::ResetEndOfRoadCondition()
+	   {
+	   		isSetEndOfRoadCondition = false; 
+			_endOfRoadCondition = {};
+			
+	   }
+       bool EntityConditionImpl::IsSetEndOfRoadCondition() const
+	   {
+			return isSetEndOfRoadCondition;
+	   }
+       void EntityConditionImpl::ResetCollisionCondition()
+	   {
+	   		isSetCollisionCondition = false; 
+			_collisionCondition = {};
+			
+	   }
+       bool EntityConditionImpl::IsSetCollisionCondition() const
+	   {
+			return isSetCollisionCondition;
+	   }
+       void EntityConditionImpl::ResetOffroadCondition()
+	   {
+	   		isSetOffroadCondition = false; 
+			_offroadCondition = {};
+			
+	   }
+       bool EntityConditionImpl::IsSetOffroadCondition() const
+	   {
+			return isSetOffroadCondition;
+	   }
+       void EntityConditionImpl::ResetTimeHeadwayCondition()
+	   {
+	   		isSetTimeHeadwayCondition = false; 
+			_timeHeadwayCondition = {};
+			
+	   }
+       bool EntityConditionImpl::IsSetTimeHeadwayCondition() const
+	   {
+			return isSetTimeHeadwayCondition;
+	   }
+       void EntityConditionImpl::ResetTimeToCollisionCondition()
+	   {
+	   		isSetTimeToCollisionCondition = false; 
+			_timeToCollisionCondition = {};
+			
+	   }
+       bool EntityConditionImpl::IsSetTimeToCollisionCondition() const
+	   {
+			return isSetTimeToCollisionCondition;
+	   }
+       void EntityConditionImpl::ResetAccelerationCondition()
+	   {
+	   		isSetAccelerationCondition = false; 
+			_accelerationCondition = {};
+			
+	   }
+       bool EntityConditionImpl::IsSetAccelerationCondition() const
+	   {
+			return isSetAccelerationCondition;
+	   }
+       void EntityConditionImpl::ResetStandStillCondition()
+	   {
+	   		isSetStandStillCondition = false; 
+			_standStillCondition = {};
+			
+	   }
+       bool EntityConditionImpl::IsSetStandStillCondition() const
+	   {
+			return isSetStandStillCondition;
+	   }
+       void EntityConditionImpl::ResetSpeedCondition()
+	   {
+	   		isSetSpeedCondition = false; 
+			_speedCondition = {};
+			
+	   }
+       bool EntityConditionImpl::IsSetSpeedCondition() const
+	   {
+			return isSetSpeedCondition;
+	   }
+       void EntityConditionImpl::ResetRelativeSpeedCondition()
+	   {
+	   		isSetRelativeSpeedCondition = false; 
+			_relativeSpeedCondition = {};
+			
+	   }
+       bool EntityConditionImpl::IsSetRelativeSpeedCondition() const
+	   {
+			return isSetRelativeSpeedCondition;
+	   }
+       void EntityConditionImpl::ResetTraveledDistanceCondition()
+	   {
+	   		isSetTraveledDistanceCondition = false; 
+			_traveledDistanceCondition = {};
+			
+	   }
+       bool EntityConditionImpl::IsSetTraveledDistanceCondition() const
+	   {
+			return isSetTraveledDistanceCondition;
+	   }
+       void EntityConditionImpl::ResetReachPositionCondition()
+	   {
+	   		isSetReachPositionCondition = false; 
+			_reachPositionCondition = {};
+			
+	   }
+       bool EntityConditionImpl::IsSetReachPositionCondition() const
+	   {
+			return isSetReachPositionCondition;
+	   }
+       void EntityConditionImpl::ResetDistanceCondition()
+	   {
+	   		isSetDistanceCondition = false; 
+			_distanceCondition = {};
+			
+	   }
+       bool EntityConditionImpl::IsSetDistanceCondition() const
+	   {
+			return isSetDistanceCondition;
+	   }
+       void EntityConditionImpl::ResetRelativeDistanceCondition()
+	   {
+	   		isSetRelativeDistanceCondition = false; 
+			_relativeDistanceCondition = {};
+			
+	   }
+       bool EntityConditionImpl::IsSetRelativeDistanceCondition() const
+	   {
+			return isSetRelativeDistanceCondition;
+	   }
 
         IOpenScenarioFlexElement* EntityObjectImpl::GetOpenScenarioFlexElement()
         {
@@ -16137,6 +16932,8 @@ namespace NET_ASAM_OPENSCENARIO
             _pedestrian = {};
             _miscObject = {};
             _externalObjectReference = {};
+			// set the indicator to true
+            isSetCatalogReference = true;          
         }
 
         void EntityObjectImpl::SetVehicle(std::shared_ptr<IVehicleWriter> vehicle)
@@ -16146,6 +16943,8 @@ namespace NET_ASAM_OPENSCENARIO
             _pedestrian = {};
             _miscObject = {};
             _externalObjectReference = {};
+			// set the indicator to true
+            isSetVehicle = true;          
         }
 
         void EntityObjectImpl::SetPedestrian(std::shared_ptr<IPedestrianWriter> pedestrian)
@@ -16155,6 +16954,8 @@ namespace NET_ASAM_OPENSCENARIO
             _vehicle = {};
             _miscObject = {};
             _externalObjectReference = {};
+			// set the indicator to true
+            isSetPedestrian = true;          
         }
 
         void EntityObjectImpl::SetMiscObject(std::shared_ptr<IMiscObjectWriter> miscObject)
@@ -16164,6 +16965,8 @@ namespace NET_ASAM_OPENSCENARIO
             _vehicle = {};
             _pedestrian = {};
             _externalObjectReference = {};
+			// set the indicator to true
+            isSetMiscObject = true;          
         }
 
         void EntityObjectImpl::SetExternalObjectReference(std::shared_ptr<IExternalObjectReferenceWriter> externalObjectReference)
@@ -16173,6 +16976,8 @@ namespace NET_ASAM_OPENSCENARIO
             _vehicle = {};
             _pedestrian = {};
             _miscObject = {};
+			// set the indicator to true
+            isSetExternalObjectReference = true;          
         }
 
         std::shared_ptr<void> EntityObjectImpl::GetAdapter(const std::string classifier)
@@ -16436,6 +17241,56 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void EntityObjectImpl::ResetCatalogReference()
+	   {
+	   		isSetCatalogReference = false; 
+			_catalogReference = {};
+			
+	   }
+       bool EntityObjectImpl::IsSetCatalogReference() const
+	   {
+			return isSetCatalogReference;
+	   }
+       void EntityObjectImpl::ResetVehicle()
+	   {
+	   		isSetVehicle = false; 
+			_vehicle = {};
+			
+	   }
+       bool EntityObjectImpl::IsSetVehicle() const
+	   {
+			return isSetVehicle;
+	   }
+       void EntityObjectImpl::ResetPedestrian()
+	   {
+	   		isSetPedestrian = false; 
+			_pedestrian = {};
+			
+	   }
+       bool EntityObjectImpl::IsSetPedestrian() const
+	   {
+			return isSetPedestrian;
+	   }
+       void EntityObjectImpl::ResetMiscObject()
+	   {
+	   		isSetMiscObject = false; 
+			_miscObject = {};
+			
+	   }
+       bool EntityObjectImpl::IsSetMiscObject() const
+	   {
+			return isSetMiscObject;
+	   }
+       void EntityObjectImpl::ResetExternalObjectReference()
+	   {
+	   		isSetExternalObjectReference = false; 
+			_externalObjectReference = {};
+			
+	   }
+       bool EntityObjectImpl::IsSetExternalObjectReference() const
+	   {
+			return isSetExternalObjectReference;
+	   }
 
         IOpenScenarioFlexElement* EntityRefImpl::GetOpenScenarioFlexElement()
         {
@@ -16963,21 +17818,29 @@ namespace NET_ASAM_OPENSCENARIO
         void EnvironmentImpl::SetParameterDeclarations(std::vector<std::shared_ptr<IParameterDeclarationWriter>>& parameterDeclarations)
         {
             _parameterDeclarations = parameterDeclarations;
+			// set the indicator to true
+            isSetParameterDeclarations = true;          
         }
 
         void EnvironmentImpl::SetTimeOfDay(std::shared_ptr<ITimeOfDayWriter> timeOfDay)
         {
             _timeOfDay = timeOfDay;
+			// set the indicator to true
+            isSetTimeOfDay = true;          
         }
 
         void EnvironmentImpl::SetWeather(std::shared_ptr<IWeatherWriter> weather)
         {
             _weather = weather;
+			// set the indicator to true
+            isSetWeather = true;          
         }
 
         void EnvironmentImpl::SetRoadCondition(std::shared_ptr<IRoadConditionWriter> roadCondition)
         {
             _roadCondition = roadCondition;
+			// set the indicator to true
+            isSetRoadCondition = true;          
         }
 
         std::shared_ptr<void> EnvironmentImpl::GetAdapter(const std::string classifier)
@@ -17299,6 +18162,46 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void EnvironmentImpl::ResetParameterDeclarations()
+	   {
+	   		isSetParameterDeclarations = false; 
+			_parameterDeclarations = {};
+			
+	   }
+       bool EnvironmentImpl::IsSetParameterDeclarations() const
+	   {
+			return isSetParameterDeclarations;
+	   }
+       void EnvironmentImpl::ResetTimeOfDay()
+	   {
+	   		isSetTimeOfDay = false; 
+			_timeOfDay = {};
+			
+	   }
+       bool EnvironmentImpl::IsSetTimeOfDay() const
+	   {
+			return isSetTimeOfDay;
+	   }
+       void EnvironmentImpl::ResetWeather()
+	   {
+	   		isSetWeather = false; 
+			_weather = {};
+			
+	   }
+       bool EnvironmentImpl::IsSetWeather() const
+	   {
+			return isSetWeather;
+	   }
+       void EnvironmentImpl::ResetRoadCondition()
+	   {
+	   		isSetRoadCondition = false; 
+			_roadCondition = {};
+			
+	   }
+       bool EnvironmentImpl::IsSetRoadCondition() const
+	   {
+			return isSetRoadCondition;
+	   }
 
         IOpenScenarioFlexElement* EnvironmentActionImpl::GetOpenScenarioFlexElement()
         {
@@ -17318,12 +18221,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _environment = environment;
             _catalogReference = {};
+			// set the indicator to true
+            isSetEnvironment = true;          
         }
 
         void EnvironmentActionImpl::SetCatalogReference(std::shared_ptr<ICatalogReferenceWriter> catalogReference)
         {
             _catalogReference = catalogReference;
             _environment = {};
+			// set the indicator to true
+            isSetCatalogReference = true;          
         }
 
         std::shared_ptr<void> EnvironmentActionImpl::GetAdapter(const std::string classifier)
@@ -17521,6 +18428,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void EnvironmentActionImpl::ResetEnvironment()
+	   {
+	   		isSetEnvironment = false; 
+			_environment = {};
+			
+	   }
+       bool EnvironmentActionImpl::IsSetEnvironment() const
+	   {
+			return isSetEnvironment;
+	   }
+       void EnvironmentActionImpl::ResetCatalogReference()
+	   {
+	   		isSetCatalogReference = false; 
+			_catalogReference = {};
+			
+	   }
+       bool EnvironmentActionImpl::IsSetCatalogReference() const
+	   {
+			return isSetCatalogReference;
+	   }
 
         IOpenScenarioFlexElement* EnvironmentCatalogLocationImpl::GetOpenScenarioFlexElement()
         {
@@ -17762,6 +18689,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _maximumExecutionCount = maximumExecutionCount;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__MAXIMUM_EXECUTION_COUNT);
+			// set the indicator to true
+            isSetMaximumExecutionCount = true;          
         }
 
         void EventImpl::SetName(const std::string name)
@@ -17784,6 +18713,8 @@ namespace NET_ASAM_OPENSCENARIO
         void EventImpl::SetStartTrigger(std::shared_ptr<ITriggerWriter> startTrigger)
         {
             _startTrigger = startTrigger;
+			// set the indicator to true
+            isSetStartTrigger = true;          
         }
 
         std::shared_ptr<void> EventImpl::GetAdapter(const std::string classifier)
@@ -18034,6 +18965,7 @@ namespace NET_ASAM_OPENSCENARIO
                 clonedObject->_priority = Priority::GetFromLiteral(kPriority.GetLiteral());
             }
             // clone indicators
+            	clonedObject->isSetMaximumExecutionCount = isSetMaximumExecutionCount;
             // clone children
             const auto kActions =  GetWriterActions();
             if (!kActions.empty())
@@ -18146,6 +19078,26 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void EventImpl::ResetMaximumExecutionCount()
+	   {
+	   		isSetMaximumExecutionCount = false; 
+			_maximumExecutionCount = {1};
+			
+	   }
+       bool EventImpl::IsSetMaximumExecutionCount() const
+	   {
+			return isSetMaximumExecutionCount;
+	   }
+       void EventImpl::ResetStartTrigger()
+	   {
+	   		isSetStartTrigger = false; 
+			_startTrigger = {};
+			
+	   }
+       bool EventImpl::IsSetStartTrigger() const
+	   {
+			return isSetStartTrigger;
+	   }
 
         IOpenScenarioFlexElement* ExternalObjectReferenceImpl::GetOpenScenarioFlexElement()
         {
@@ -18638,6 +19590,8 @@ namespace NET_ASAM_OPENSCENARIO
         void FileHeaderImpl::SetLicense(std::shared_ptr<ILicenseWriter> license)
         {
             _license = license;
+			// set the indicator to true
+            isSetLicense = true;          
         }
 
         std::shared_ptr<void> FileHeaderImpl::GetAdapter(const std::string classifier)
@@ -19046,6 +20000,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void FileHeaderImpl::ResetLicense()
+	   {
+	   		isSetLicense = false; 
+			_license = {};
+			
+	   }
+       bool FileHeaderImpl::IsSetLicense() const
+	   {
+			return isSetLicense;
+	   }
 
         IOpenScenarioFlexElement* FinalSpeedImpl::GetOpenScenarioFlexElement()
         {
@@ -19065,12 +20029,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _absoluteSpeed = absoluteSpeed;
             _relativeSpeedToMaster = {};
+			// set the indicator to true
+            isSetAbsoluteSpeed = true;          
         }
 
         void FinalSpeedImpl::SetRelativeSpeedToMaster(std::shared_ptr<IRelativeSpeedToMasterWriter> relativeSpeedToMaster)
         {
             _relativeSpeedToMaster = relativeSpeedToMaster;
             _absoluteSpeed = {};
+			// set the indicator to true
+            isSetRelativeSpeedToMaster = true;          
         }
 
         std::shared_ptr<void> FinalSpeedImpl::GetAdapter(const std::string classifier)
@@ -19268,6 +20236,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void FinalSpeedImpl::ResetAbsoluteSpeed()
+	   {
+	   		isSetAbsoluteSpeed = false; 
+			_absoluteSpeed = {};
+			
+	   }
+       bool FinalSpeedImpl::IsSetAbsoluteSpeed() const
+	   {
+			return isSetAbsoluteSpeed;
+	   }
+       void FinalSpeedImpl::ResetRelativeSpeedToMaster()
+	   {
+	   		isSetRelativeSpeedToMaster = false; 
+			_relativeSpeedToMaster = {};
+			
+	   }
+       bool FinalSpeedImpl::IsSetRelativeSpeedToMaster() const
+	   {
+			return isSetRelativeSpeedToMaster;
+	   }
 
         IOpenScenarioFlexElement* FogImpl::GetOpenScenarioFlexElement()
         {
@@ -19292,6 +20280,8 @@ namespace NET_ASAM_OPENSCENARIO
         void FogImpl::SetBoundingBox(std::shared_ptr<IBoundingBoxWriter> boundingBox)
         {
             _boundingBox = boundingBox;
+			// set the indicator to true
+            isSetBoundingBox = true;          
         }
 
         std::shared_ptr<void> FogImpl::GetAdapter(const std::string classifier)
@@ -19517,6 +20507,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void FogImpl::ResetBoundingBox()
+	   {
+	   		isSetBoundingBox = false; 
+			_boundingBox = {};
+			
+	   }
+       bool FogImpl::IsSetBoundingBox() const
+	   {
+			return isSetBoundingBox;
+	   }
 
         IOpenScenarioFlexElement* FollowTrajectoryActionImpl::GetOpenScenarioFlexElement()
         {
@@ -19552,16 +20552,22 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _initialDistanceOffset = initialDistanceOffset;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__INITIAL_DISTANCE_OFFSET);
+			// set the indicator to true
+            isSetInitialDistanceOffset = true;          
         }
 
         void FollowTrajectoryActionImpl::SetTrajectory(std::shared_ptr<ITrajectoryWriter> trajectory)
         {
             _trajectory = trajectory;
+			// set the indicator to true
+            isSetTrajectory = true;          
         }
 
         void FollowTrajectoryActionImpl::SetCatalogReference(std::shared_ptr<ICatalogReferenceWriter> catalogReference)
         {
             _catalogReference = catalogReference;
+			// set the indicator to true
+            isSetCatalogReference = true;          
         }
 
         void FollowTrajectoryActionImpl::SetTimeReference(std::shared_ptr<ITimeReferenceWriter> timeReference)
@@ -19577,6 +20583,8 @@ namespace NET_ASAM_OPENSCENARIO
         void FollowTrajectoryActionImpl::SetTrajectoryRef(std::shared_ptr<ITrajectoryRefWriter> trajectoryRef)
         {
             _trajectoryRef = trajectoryRef;
+			// set the indicator to true
+            isSetTrajectoryRef = true;          
         }
 
         std::shared_ptr<void> FollowTrajectoryActionImpl::GetAdapter(const std::string classifier)
@@ -19780,6 +20788,7 @@ namespace NET_ASAM_OPENSCENARIO
             // Simple type
             clonedObject->_initialDistanceOffset = GetInitialDistanceOffset();
             // clone indicators
+            	clonedObject->isSetInitialDistanceOffset = isSetInitialDistanceOffset;
             // clone children
             const auto kTrajectory =  GetWriterTrajectory();
             if (kTrajectory)
@@ -19890,6 +20899,46 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void FollowTrajectoryActionImpl::ResetInitialDistanceOffset()
+	   {
+	   		isSetInitialDistanceOffset = false; 
+			_initialDistanceOffset = {0};
+			
+	   }
+       bool FollowTrajectoryActionImpl::IsSetInitialDistanceOffset() const
+	   {
+			return isSetInitialDistanceOffset;
+	   }
+       void FollowTrajectoryActionImpl::ResetTrajectory()
+	   {
+	   		isSetTrajectory = false; 
+			_trajectory = {};
+			
+	   }
+       bool FollowTrajectoryActionImpl::IsSetTrajectory() const
+	   {
+			return isSetTrajectory;
+	   }
+       void FollowTrajectoryActionImpl::ResetCatalogReference()
+	   {
+	   		isSetCatalogReference = false; 
+			_catalogReference = {};
+			
+	   }
+       bool FollowTrajectoryActionImpl::IsSetCatalogReference() const
+	   {
+			return isSetCatalogReference;
+	   }
+       void FollowTrajectoryActionImpl::ResetTrajectoryRef()
+	   {
+	   		isSetTrajectoryRef = false; 
+			_trajectoryRef = {};
+			
+	   }
+       bool FollowTrajectoryActionImpl::IsSetTrajectoryRef() const
+	   {
+			return isSetTrajectoryRef;
+	   }
 
         IOpenScenarioFlexElement* GeoPositionImpl::GetOpenScenarioFlexElement()
         {
@@ -19917,6 +20966,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _height = height;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__HEIGHT);
+			// set the indicator to true
+            isSetHeight = true;          
         }
 
         void GeoPositionImpl::SetLatitude(const double latitude)
@@ -19934,6 +20985,8 @@ namespace NET_ASAM_OPENSCENARIO
         void GeoPositionImpl::SetOrientation(std::shared_ptr<IOrientationWriter> orientation)
         {
             _orientation = orientation;
+			// set the indicator to true
+            isSetOrientation = true;          
         }
 
         std::shared_ptr<void> GeoPositionImpl::GetAdapter(const std::string classifier)
@@ -20171,6 +21224,7 @@ namespace NET_ASAM_OPENSCENARIO
             // Simple type
             clonedObject->_longitude = GetLongitude();
             // clone indicators
+            	clonedObject->isSetHeight = isSetHeight;
             // clone children
             const auto kOrientation =  GetWriterOrientation();
             if (kOrientation)
@@ -20241,6 +21295,26 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void GeoPositionImpl::ResetHeight()
+	   {
+	   		isSetHeight = false; 
+			_height = {0};
+			
+	   }
+       bool GeoPositionImpl::IsSetHeight() const
+	   {
+			return isSetHeight;
+	   }
+       void GeoPositionImpl::ResetOrientation()
+	   {
+	   		isSetOrientation = false; 
+			_orientation = {};
+			
+	   }
+       bool GeoPositionImpl::IsSetOrientation() const
+	   {
+			return isSetOrientation;
+	   }
 
         IOpenScenarioFlexElement* GlobalActionImpl::GetOpenScenarioFlexElement()
         {
@@ -20275,6 +21349,8 @@ namespace NET_ASAM_OPENSCENARIO
             _parameterAction = {};
             _infrastructureAction = {};
             _trafficAction = {};
+			// set the indicator to true
+            isSetEnvironmentAction = true;          
         }
 
         void GlobalActionImpl::SetEntityAction(std::shared_ptr<IEntityActionWriter> entityAction)
@@ -20284,6 +21360,8 @@ namespace NET_ASAM_OPENSCENARIO
             _parameterAction = {};
             _infrastructureAction = {};
             _trafficAction = {};
+			// set the indicator to true
+            isSetEntityAction = true;          
         }
 
         void GlobalActionImpl::SetParameterAction(std::shared_ptr<IParameterActionWriter> parameterAction)
@@ -20293,6 +21371,8 @@ namespace NET_ASAM_OPENSCENARIO
             _entityAction = {};
             _infrastructureAction = {};
             _trafficAction = {};
+			// set the indicator to true
+            isSetParameterAction = true;          
         }
 
         void GlobalActionImpl::SetInfrastructureAction(std::shared_ptr<IInfrastructureActionWriter> infrastructureAction)
@@ -20302,6 +21382,8 @@ namespace NET_ASAM_OPENSCENARIO
             _entityAction = {};
             _parameterAction = {};
             _trafficAction = {};
+			// set the indicator to true
+            isSetInfrastructureAction = true;          
         }
 
         void GlobalActionImpl::SetTrafficAction(std::shared_ptr<ITrafficActionWriter> trafficAction)
@@ -20311,6 +21393,8 @@ namespace NET_ASAM_OPENSCENARIO
             _entityAction = {};
             _parameterAction = {};
             _infrastructureAction = {};
+			// set the indicator to true
+            isSetTrafficAction = true;          
         }
 
         std::shared_ptr<void> GlobalActionImpl::GetAdapter(const std::string classifier)
@@ -20574,6 +21658,56 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void GlobalActionImpl::ResetEnvironmentAction()
+	   {
+	   		isSetEnvironmentAction = false; 
+			_environmentAction = {};
+			
+	   }
+       bool GlobalActionImpl::IsSetEnvironmentAction() const
+	   {
+			return isSetEnvironmentAction;
+	   }
+       void GlobalActionImpl::ResetEntityAction()
+	   {
+	   		isSetEntityAction = false; 
+			_entityAction = {};
+			
+	   }
+       bool GlobalActionImpl::IsSetEntityAction() const
+	   {
+			return isSetEntityAction;
+	   }
+       void GlobalActionImpl::ResetParameterAction()
+	   {
+	   		isSetParameterAction = false; 
+			_parameterAction = {};
+			
+	   }
+       bool GlobalActionImpl::IsSetParameterAction() const
+	   {
+			return isSetParameterAction;
+	   }
+       void GlobalActionImpl::ResetInfrastructureAction()
+	   {
+	   		isSetInfrastructureAction = false; 
+			_infrastructureAction = {};
+			
+	   }
+       bool GlobalActionImpl::IsSetInfrastructureAction() const
+	   {
+			return isSetInfrastructureAction;
+	   }
+       void GlobalActionImpl::ResetTrafficAction()
+	   {
+	   		isSetTrafficAction = false; 
+			_trafficAction = {};
+			
+	   }
+       bool GlobalActionImpl::IsSetTrafficAction() const
+	   {
+			return isSetTrafficAction;
+	   }
 
         IOpenScenarioFlexElement* HistogramImpl::GetOpenScenarioFlexElement()
         {
@@ -21064,6 +22198,8 @@ namespace NET_ASAM_OPENSCENARIO
             _fromCurrentEntity = fromCurrentEntity;
             _fromRoadCoordinates = {};
             _fromLaneCoordinates = {};
+			// set the indicator to true
+            isSetFromCurrentEntity = true;          
         }
 
         void InRoutePositionImpl::SetFromRoadCoordinates(std::shared_ptr<IPositionInRoadCoordinatesWriter> fromRoadCoordinates)
@@ -21071,6 +22207,8 @@ namespace NET_ASAM_OPENSCENARIO
             _fromRoadCoordinates = fromRoadCoordinates;
             _fromCurrentEntity = {};
             _fromLaneCoordinates = {};
+			// set the indicator to true
+            isSetFromRoadCoordinates = true;          
         }
 
         void InRoutePositionImpl::SetFromLaneCoordinates(std::shared_ptr<IPositionInLaneCoordinatesWriter> fromLaneCoordinates)
@@ -21078,6 +22216,8 @@ namespace NET_ASAM_OPENSCENARIO
             _fromLaneCoordinates = fromLaneCoordinates;
             _fromCurrentEntity = {};
             _fromRoadCoordinates = {};
+			// set the indicator to true
+            isSetFromLaneCoordinates = true;          
         }
 
         std::shared_ptr<void> InRoutePositionImpl::GetAdapter(const std::string classifier)
@@ -21297,6 +22437,36 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void InRoutePositionImpl::ResetFromCurrentEntity()
+	   {
+	   		isSetFromCurrentEntity = false; 
+			_fromCurrentEntity = {};
+			
+	   }
+       bool InRoutePositionImpl::IsSetFromCurrentEntity() const
+	   {
+			return isSetFromCurrentEntity;
+	   }
+       void InRoutePositionImpl::ResetFromRoadCoordinates()
+	   {
+	   		isSetFromRoadCoordinates = false; 
+			_fromRoadCoordinates = {};
+			
+	   }
+       bool InRoutePositionImpl::IsSetFromRoadCoordinates() const
+	   {
+			return isSetFromRoadCoordinates;
+	   }
+       void InRoutePositionImpl::ResetFromLaneCoordinates()
+	   {
+	   		isSetFromLaneCoordinates = false; 
+			_fromLaneCoordinates = {};
+			
+	   }
+       bool InRoutePositionImpl::IsSetFromLaneCoordinates() const
+	   {
+			return isSetFromLaneCoordinates;
+	   }
 
         IOpenScenarioFlexElement* InfrastructureActionImpl::GetOpenScenarioFlexElement()
         {
@@ -21760,16 +22930,22 @@ namespace NET_ASAM_OPENSCENARIO
         void InitActionsImpl::SetGlobalActions(std::vector<std::shared_ptr<IGlobalActionWriter>>& globalActions)
         {
             _globalActions = globalActions;
+			// set the indicator to true
+            isSetGlobalActions = true;          
         }
 
         void InitActionsImpl::SetUserDefinedActions(std::vector<std::shared_ptr<IUserDefinedActionWriter>>& userDefinedActions)
         {
             _userDefinedActions = userDefinedActions;
+			// set the indicator to true
+            isSetUserDefinedActions = true;          
         }
 
         void InitActionsImpl::SetPrivates(std::vector<std::shared_ptr<IPrivateWriter>>& privates)
         {
             _privates = privates;
+			// set the indicator to true
+            isSetPrivates = true;          
         }
 
         std::shared_ptr<void> InitActionsImpl::GetAdapter(const std::string classifier)
@@ -22008,6 +23184,36 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void InitActionsImpl::ResetGlobalActions()
+	   {
+	   		isSetGlobalActions = false; 
+			_globalActions = {};
+			
+	   }
+       bool InitActionsImpl::IsSetGlobalActions() const
+	   {
+			return isSetGlobalActions;
+	   }
+       void InitActionsImpl::ResetUserDefinedActions()
+	   {
+	   		isSetUserDefinedActions = false; 
+			_userDefinedActions = {};
+			
+	   }
+       bool InitActionsImpl::IsSetUserDefinedActions() const
+	   {
+			return isSetUserDefinedActions;
+	   }
+       void InitActionsImpl::ResetPrivates()
+	   {
+	   		isSetPrivates = false; 
+			_privates = {};
+			
+	   }
+       bool InitActionsImpl::IsSetPrivates() const
+	   {
+			return isSetPrivates;
+	   }
 
         IOpenScenarioFlexElement* KnotImpl::GetOpenScenarioFlexElement()
         {
@@ -22245,6 +23451,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _targetLaneOffset = targetLaneOffset;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__TARGET_LANE_OFFSET);
+			// set the indicator to true
+            isSetTargetLaneOffset = true;          
         }
 
         void LaneChangeActionImpl::SetLaneChangeActionDynamics(std::shared_ptr<ITransitionDynamicsWriter> laneChangeActionDynamics)
@@ -22431,6 +23639,7 @@ namespace NET_ASAM_OPENSCENARIO
             // Simple type
             clonedObject->_targetLaneOffset = GetTargetLaneOffset();
             // clone indicators
+            	clonedObject->isSetTargetLaneOffset = isSetTargetLaneOffset;
             // clone children
             const auto kLaneChangeActionDynamics =  GetWriterLaneChangeActionDynamics();
             if (kLaneChangeActionDynamics)
@@ -22502,6 +23711,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void LaneChangeActionImpl::ResetTargetLaneOffset()
+	   {
+	   		isSetTargetLaneOffset = false; 
+			_targetLaneOffset = {0};
+			
+	   }
+       bool LaneChangeActionImpl::IsSetTargetLaneOffset() const
+	   {
+			return isSetTargetLaneOffset;
+	   }
 
         IOpenScenarioFlexElement* LaneChangeTargetImpl::GetOpenScenarioFlexElement()
         {
@@ -22521,12 +23740,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _relativeTargetLane = relativeTargetLane;
             _absoluteTargetLane = {};
+			// set the indicator to true
+            isSetRelativeTargetLane = true;          
         }
 
         void LaneChangeTargetImpl::SetAbsoluteTargetLane(std::shared_ptr<IAbsoluteTargetLaneWriter> absoluteTargetLane)
         {
             _absoluteTargetLane = absoluteTargetLane;
             _relativeTargetLane = {};
+			// set the indicator to true
+            isSetAbsoluteTargetLane = true;          
         }
 
         std::shared_ptr<void> LaneChangeTargetImpl::GetAdapter(const std::string classifier)
@@ -22724,6 +23947,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void LaneChangeTargetImpl::ResetRelativeTargetLane()
+	   {
+	   		isSetRelativeTargetLane = false; 
+			_relativeTargetLane = {};
+			
+	   }
+       bool LaneChangeTargetImpl::IsSetRelativeTargetLane() const
+	   {
+			return isSetRelativeTargetLane;
+	   }
+       void LaneChangeTargetImpl::ResetAbsoluteTargetLane()
+	   {
+	   		isSetAbsoluteTargetLane = false; 
+			_absoluteTargetLane = {};
+			
+	   }
+       bool LaneChangeTargetImpl::IsSetAbsoluteTargetLane() const
+	   {
+			return isSetAbsoluteTargetLane;
+	   }
 
         IOpenScenarioFlexElement* LaneOffsetActionImpl::GetOpenScenarioFlexElement()
         {
@@ -23314,12 +24557,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _relativeTargetLaneOffset = relativeTargetLaneOffset;
             _absoluteTargetLaneOffset = {};
+			// set the indicator to true
+            isSetRelativeTargetLaneOffset = true;          
         }
 
         void LaneOffsetTargetImpl::SetAbsoluteTargetLaneOffset(std::shared_ptr<IAbsoluteTargetLaneOffsetWriter> absoluteTargetLaneOffset)
         {
             _absoluteTargetLaneOffset = absoluteTargetLaneOffset;
             _relativeTargetLaneOffset = {};
+			// set the indicator to true
+            isSetAbsoluteTargetLaneOffset = true;          
         }
 
         std::shared_ptr<void> LaneOffsetTargetImpl::GetAdapter(const std::string classifier)
@@ -23517,6 +24764,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void LaneOffsetTargetImpl::ResetRelativeTargetLaneOffset()
+	   {
+	   		isSetRelativeTargetLaneOffset = false; 
+			_relativeTargetLaneOffset = {};
+			
+	   }
+       bool LaneOffsetTargetImpl::IsSetRelativeTargetLaneOffset() const
+	   {
+			return isSetRelativeTargetLaneOffset;
+	   }
+       void LaneOffsetTargetImpl::ResetAbsoluteTargetLaneOffset()
+	   {
+	   		isSetAbsoluteTargetLaneOffset = false; 
+			_absoluteTargetLaneOffset = {};
+			
+	   }
+       bool LaneOffsetTargetImpl::IsSetAbsoluteTargetLaneOffset() const
+	   {
+			return isSetAbsoluteTargetLaneOffset;
+	   }
 
         IOpenScenarioFlexElement* LanePositionImpl::GetOpenScenarioFlexElement()
         {
@@ -23554,6 +24821,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _offset = offset;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__OFFSET);
+			// set the indicator to true
+            isSetOffset = true;          
         }
 
         void LanePositionImpl::SetRoadId(const std::string roadId)
@@ -23571,6 +24840,8 @@ namespace NET_ASAM_OPENSCENARIO
         void LanePositionImpl::SetOrientation(std::shared_ptr<IOrientationWriter> orientation)
         {
             _orientation = orientation;
+			// set the indicator to true
+            isSetOrientation = true;          
         }
 
         std::shared_ptr<void> LanePositionImpl::GetAdapter(const std::string classifier)
@@ -23835,6 +25106,7 @@ namespace NET_ASAM_OPENSCENARIO
             // Simple type
             clonedObject->_s = GetS();
             // clone indicators
+            	clonedObject->isSetOffset = isSetOffset;
             // clone children
             const auto kOrientation =  GetWriterOrientation();
             if (kOrientation)
@@ -23929,6 +25201,26 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void LanePositionImpl::ResetOffset()
+	   {
+	   		isSetOffset = false; 
+			_offset = {0};
+			
+	   }
+       bool LanePositionImpl::IsSetOffset() const
+	   {
+			return isSetOffset;
+	   }
+       void LanePositionImpl::ResetOrientation()
+	   {
+	   		isSetOrientation = false; 
+			_orientation = {};
+			
+	   }
+       bool LanePositionImpl::IsSetOrientation() const
+	   {
+			return isSetOrientation;
+	   }
 
         IOpenScenarioFlexElement* LateralActionImpl::GetOpenScenarioFlexElement()
         {
@@ -23953,6 +25245,8 @@ namespace NET_ASAM_OPENSCENARIO
             _laneChangeAction = laneChangeAction;
             _laneOffsetAction = {};
             _lateralDistanceAction = {};
+			// set the indicator to true
+            isSetLaneChangeAction = true;          
         }
 
         void LateralActionImpl::SetLaneOffsetAction(std::shared_ptr<ILaneOffsetActionWriter> laneOffsetAction)
@@ -23960,6 +25254,8 @@ namespace NET_ASAM_OPENSCENARIO
             _laneOffsetAction = laneOffsetAction;
             _laneChangeAction = {};
             _lateralDistanceAction = {};
+			// set the indicator to true
+            isSetLaneOffsetAction = true;          
         }
 
         void LateralActionImpl::SetLateralDistanceAction(std::shared_ptr<ILateralDistanceActionWriter> lateralDistanceAction)
@@ -23967,6 +25263,8 @@ namespace NET_ASAM_OPENSCENARIO
             _lateralDistanceAction = lateralDistanceAction;
             _laneChangeAction = {};
             _laneOffsetAction = {};
+			// set the indicator to true
+            isSetLateralDistanceAction = true;          
         }
 
         std::shared_ptr<void> LateralActionImpl::GetAdapter(const std::string classifier)
@@ -24186,6 +25484,36 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void LateralActionImpl::ResetLaneChangeAction()
+	   {
+	   		isSetLaneChangeAction = false; 
+			_laneChangeAction = {};
+			
+	   }
+       bool LateralActionImpl::IsSetLaneChangeAction() const
+	   {
+			return isSetLaneChangeAction;
+	   }
+       void LateralActionImpl::ResetLaneOffsetAction()
+	   {
+	   		isSetLaneOffsetAction = false; 
+			_laneOffsetAction = {};
+			
+	   }
+       bool LateralActionImpl::IsSetLaneOffsetAction() const
+	   {
+			return isSetLaneOffsetAction;
+	   }
+       void LateralActionImpl::ResetLateralDistanceAction()
+	   {
+	   		isSetLateralDistanceAction = false; 
+			_lateralDistanceAction = {};
+			
+	   }
+       bool LateralActionImpl::IsSetLateralDistanceAction() const
+	   {
+			return isSetLateralDistanceAction;
+	   }
 
         IOpenScenarioFlexElement* LateralDistanceActionImpl::GetOpenScenarioFlexElement()
         {
@@ -24231,18 +25559,24 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _coordinateSystem = coordinateSystem;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM);
+			// set the indicator to true
+            isSetCoordinateSystem = true;          
         }
 
         void LateralDistanceActionImpl::SetDisplacement(const LateralDisplacement displacement)
         {
             _displacement = displacement;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__DISPLACEMENT);
+			// set the indicator to true
+            isSetDisplacement = true;          
         }
 
         void LateralDistanceActionImpl::SetDistance(const double distance)
         {
             _distance = distance;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__DISTANCE);
+			// set the indicator to true
+            isSetDistance = true;          
         }
 
         void LateralDistanceActionImpl::SetEntityRef(std::shared_ptr<INamedReference<IEntity>> entityRef)
@@ -24260,6 +25594,8 @@ namespace NET_ASAM_OPENSCENARIO
         void LateralDistanceActionImpl::SetDynamicConstraints(std::shared_ptr<IDynamicConstraintsWriter> dynamicConstraints)
         {
             _dynamicConstraints = dynamicConstraints;
+			// set the indicator to true
+            isSetDynamicConstraints = true;          
         }
 
         std::shared_ptr<void> LateralDistanceActionImpl::GetAdapter(const std::string classifier)
@@ -24625,6 +25961,9 @@ namespace NET_ASAM_OPENSCENARIO
             // Simple type
             clonedObject->_freespace = GetFreespace();
             // clone indicators
+            	clonedObject->isSetCoordinateSystem = isSetCoordinateSystem;
+            	clonedObject->isSetDisplacement = isSetDisplacement;
+            	clonedObject->isSetDistance = isSetDistance;
             // clone children
             const auto kDynamicConstraints =  GetWriterDynamicConstraints();
             if (kDynamicConstraints)
@@ -24736,6 +26075,46 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void LateralDistanceActionImpl::ResetCoordinateSystem()
+	   {
+	   		isSetCoordinateSystem = false; 
+			_coordinateSystem = {CoordinateSystem::CoordinateSystemEnum::ENTITY};
+			
+	   }
+       bool LateralDistanceActionImpl::IsSetCoordinateSystem() const
+	   {
+			return isSetCoordinateSystem;
+	   }
+       void LateralDistanceActionImpl::ResetDisplacement()
+	   {
+	   		isSetDisplacement = false; 
+			_displacement = {LateralDisplacement::LateralDisplacementEnum::ANY};
+			
+	   }
+       bool LateralDistanceActionImpl::IsSetDisplacement() const
+	   {
+			return isSetDisplacement;
+	   }
+       void LateralDistanceActionImpl::ResetDistance()
+	   {
+	   		isSetDistance = false; 
+			_distance = {0};
+			
+	   }
+       bool LateralDistanceActionImpl::IsSetDistance() const
+	   {
+			return isSetDistance;
+	   }
+       void LateralDistanceActionImpl::ResetDynamicConstraints()
+	   {
+	   		isSetDynamicConstraints = false; 
+			_dynamicConstraints = {};
+			
+	   }
+       bool LateralDistanceActionImpl::IsSetDynamicConstraints() const
+	   {
+			return isSetDynamicConstraints;
+	   }
 
         IOpenScenarioFlexElement* LicenseImpl::GetOpenScenarioFlexElement()
         {
@@ -24763,6 +26142,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _text = text;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__TEXT);
+			// set the indicator to true
+            isSetText = true;          
         }
 
         void LicenseImpl::SetName(const std::string name)
@@ -25110,6 +26491,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void LicenseImpl::ResetText()
+	   {
+	   		isSetText = false; 
+			_text = {};
+			
+	   }
+       bool LicenseImpl::IsSetText() const
+	   {
+			return isSetText;
+	   }
        void LicenseImpl::ResetResource()
 	   {
 	   		isSetResource = false; 
@@ -25149,12 +26540,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _speedAction = speedAction;
             _longitudinalDistanceAction = {};
+			// set the indicator to true
+            isSetSpeedAction = true;          
         }
 
         void LongitudinalActionImpl::SetLongitudinalDistanceAction(std::shared_ptr<ILongitudinalDistanceActionWriter> longitudinalDistanceAction)
         {
             _longitudinalDistanceAction = longitudinalDistanceAction;
             _speedAction = {};
+			// set the indicator to true
+            isSetLongitudinalDistanceAction = true;          
         }
 
         std::shared_ptr<void> LongitudinalActionImpl::GetAdapter(const std::string classifier)
@@ -25352,6 +26747,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void LongitudinalActionImpl::ResetSpeedAction()
+	   {
+	   		isSetSpeedAction = false; 
+			_speedAction = {};
+			
+	   }
+       bool LongitudinalActionImpl::IsSetSpeedAction() const
+	   {
+			return isSetSpeedAction;
+	   }
+       void LongitudinalActionImpl::ResetLongitudinalDistanceAction()
+	   {
+	   		isSetLongitudinalDistanceAction = false; 
+			_longitudinalDistanceAction = {};
+			
+	   }
+       bool LongitudinalActionImpl::IsSetLongitudinalDistanceAction() const
+	   {
+			return isSetLongitudinalDistanceAction;
+	   }
 
         IOpenScenarioFlexElement* LongitudinalDistanceActionImpl::GetOpenScenarioFlexElement()
         {
@@ -25401,12 +26816,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _coordinateSystem = coordinateSystem;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM);
+			// set the indicator to true
+            isSetCoordinateSystem = true;          
         }
 
         void LongitudinalDistanceActionImpl::SetDisplacement(const LongitudinalDisplacement displacement)
         {
             _displacement = displacement;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__DISPLACEMENT);
+			// set the indicator to true
+            isSetDisplacement = true;          
         }
 
         void LongitudinalDistanceActionImpl::SetDistance(const double distance)
@@ -25440,6 +26859,8 @@ namespace NET_ASAM_OPENSCENARIO
         void LongitudinalDistanceActionImpl::SetDynamicConstraints(std::shared_ptr<IDynamicConstraintsWriter> dynamicConstraints)
         {
             _dynamicConstraints = dynamicConstraints;
+			// set the indicator to true
+            isSetDynamicConstraints = true;          
         }
 
         std::shared_ptr<void> LongitudinalDistanceActionImpl::GetAdapter(const std::string classifier)
@@ -25840,6 +27261,8 @@ namespace NET_ASAM_OPENSCENARIO
             // Simple type
             clonedObject->_timeGap = GetTimeGap();
             // clone indicators
+            	clonedObject->isSetCoordinateSystem = isSetCoordinateSystem;
+            	clonedObject->isSetDisplacement = isSetDisplacement;
             	clonedObject->isSetDistance = isSetDistance;
             	clonedObject->isSetTimeGap = isSetTimeGap;
             // clone children
@@ -25959,6 +27382,26 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void LongitudinalDistanceActionImpl::ResetCoordinateSystem()
+	   {
+	   		isSetCoordinateSystem = false; 
+			_coordinateSystem = {CoordinateSystem::CoordinateSystemEnum::ENTITY};
+			
+	   }
+       bool LongitudinalDistanceActionImpl::IsSetCoordinateSystem() const
+	   {
+			return isSetCoordinateSystem;
+	   }
+       void LongitudinalDistanceActionImpl::ResetDisplacement()
+	   {
+	   		isSetDisplacement = false; 
+			_displacement = {LongitudinalDisplacement::LongitudinalDisplacementEnum::TRAILING_REFERENCED_ENTITY};
+			
+	   }
+       bool LongitudinalDistanceActionImpl::IsSetDisplacement() const
+	   {
+			return isSetDisplacement;
+	   }
        void LongitudinalDistanceActionImpl::ResetDistance()
 	   {
 	   		isSetDistance = false; 
@@ -25978,6 +27421,16 @@ namespace NET_ASAM_OPENSCENARIO
        bool LongitudinalDistanceActionImpl::IsSetTimeGap() const
 	   {
 			return isSetTimeGap;
+	   }
+       void LongitudinalDistanceActionImpl::ResetDynamicConstraints()
+	   {
+	   		isSetDynamicConstraints = false; 
+			_dynamicConstraints = {};
+			
+	   }
+       bool LongitudinalDistanceActionImpl::IsSetDynamicConstraints() const
+	   {
+			return isSetDynamicConstraints;
 	   }
 
         IOpenScenarioFlexElement* ManeuverImpl::GetOpenScenarioFlexElement()
@@ -26049,6 +27502,8 @@ namespace NET_ASAM_OPENSCENARIO
         void ManeuverImpl::SetParameterDeclarations(std::vector<std::shared_ptr<IParameterDeclarationWriter>>& parameterDeclarations)
         {
             _parameterDeclarations = parameterDeclarations;
+			// set the indicator to true
+            isSetParameterDeclarations = true;          
         }
 
         void ManeuverImpl::SetEvents(std::vector<std::shared_ptr<IEventWriter>>& events)
@@ -26333,6 +27788,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void ManeuverImpl::ResetParameterDeclarations()
+	   {
+	   		isSetParameterDeclarations = false; 
+			_parameterDeclarations = {};
+			
+	   }
+       bool ManeuverImpl::IsSetParameterDeclarations() const
+	   {
+			return isSetParameterDeclarations;
+	   }
 
         IOpenScenarioFlexElement* ManeuverCatalogLocationImpl::GetOpenScenarioFlexElement()
         {
@@ -26611,11 +28076,15 @@ namespace NET_ASAM_OPENSCENARIO
         void ManeuverGroupImpl::SetCatalogReferences(std::vector<std::shared_ptr<ICatalogReferenceWriter>>& catalogReferences)
         {
             _catalogReferences = catalogReferences;
+			// set the indicator to true
+            isSetCatalogReferences = true;          
         }
 
         void ManeuverGroupImpl::SetManeuvers(std::vector<std::shared_ptr<IManeuverWriter>>& maneuvers)
         {
             _maneuvers = maneuvers;
+			// set the indicator to true
+            isSetManeuvers = true;          
         }
 
         std::shared_ptr<void> ManeuverGroupImpl::GetAdapter(const std::string classifier)
@@ -26952,6 +28421,26 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void ManeuverGroupImpl::ResetCatalogReferences()
+	   {
+	   		isSetCatalogReferences = false; 
+			_catalogReferences = {};
+			
+	   }
+       bool ManeuverGroupImpl::IsSetCatalogReferences() const
+	   {
+			return isSetCatalogReferences;
+	   }
+       void ManeuverGroupImpl::ResetManeuvers()
+	   {
+	   		isSetManeuvers = false; 
+			_maneuvers = {};
+			
+	   }
+       bool ManeuverGroupImpl::IsSetManeuvers() const
+	   {
+			return isSetManeuvers;
+	   }
 
         IOpenScenarioFlexElement* MiscObjectImpl::GetOpenScenarioFlexElement()
         {
@@ -27037,6 +28526,8 @@ namespace NET_ASAM_OPENSCENARIO
         void MiscObjectImpl::SetParameterDeclarations(std::vector<std::shared_ptr<IParameterDeclarationWriter>>& parameterDeclarations)
         {
             _parameterDeclarations = parameterDeclarations;
+			// set the indicator to true
+            isSetParameterDeclarations = true;          
         }
 
         void MiscObjectImpl::SetBoundingBox(std::shared_ptr<IBoundingBoxWriter> boundingBox)
@@ -27503,6 +28994,16 @@ namespace NET_ASAM_OPENSCENARIO
 	   {
 			return isSetModel3d;
 	   }
+       void MiscObjectImpl::ResetParameterDeclarations()
+	   {
+	   		isSetParameterDeclarations = false; 
+			_parameterDeclarations = {};
+			
+	   }
+       bool MiscObjectImpl::IsSetParameterDeclarations() const
+	   {
+			return isSetParameterDeclarations;
+	   }
 
         IOpenScenarioFlexElement* MiscObjectCatalogLocationImpl::GetOpenScenarioFlexElement()
         {
@@ -27711,12 +29212,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _addValue = addValue;
             _multiplyByValue = {};
+			// set the indicator to true
+            isSetAddValue = true;          
         }
 
         void ModifyRuleImpl::SetMultiplyByValue(std::shared_ptr<IParameterMultiplyByValueRuleWriter> multiplyByValue)
         {
             _multiplyByValue = multiplyByValue;
             _addValue = {};
+			// set the indicator to true
+            isSetMultiplyByValue = true;          
         }
 
         std::shared_ptr<void> ModifyRuleImpl::GetAdapter(const std::string classifier)
@@ -27914,6 +29419,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void ModifyRuleImpl::ResetAddValue()
+	   {
+	   		isSetAddValue = false; 
+			_addValue = {};
+			
+	   }
+       bool ModifyRuleImpl::IsSetAddValue() const
+	   {
+			return isSetAddValue;
+	   }
+       void ModifyRuleImpl::ResetMultiplyByValue()
+	   {
+	   		isSetMultiplyByValue = false; 
+			_multiplyByValue = {};
+			
+	   }
+       bool ModifyRuleImpl::IsSetMultiplyByValue() const
+	   {
+			return isSetMultiplyByValue;
+	   }
 
         IOpenScenarioFlexElement* NoneImpl::GetOpenScenarioFlexElement()
         {
@@ -28102,6 +29627,8 @@ namespace NET_ASAM_OPENSCENARIO
         void NormalDistributionImpl::SetRange(std::shared_ptr<IRangeWriter> range)
         {
             _range = range;
+			// set the indicator to true
+            isSetRange = true;          
         }
 
         std::shared_ptr<void> NormalDistributionImpl::GetAdapter(const std::string classifier)
@@ -28368,6 +29895,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void NormalDistributionImpl::ResetRange()
+	   {
+	   		isSetRange = false; 
+			_range = {};
+			
+	   }
+       bool NormalDistributionImpl::IsSetRange() const
+	   {
+			return isSetRange;
+	   }
 
         IOpenScenarioFlexElement* NurbsImpl::GetOpenScenarioFlexElement()
         {
@@ -28722,12 +30259,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _catalogReference = catalogReference;
             _controller = {};
+			// set the indicator to true
+            isSetCatalogReference = true;          
         }
 
         void ObjectControllerImpl::SetController(std::shared_ptr<IControllerWriter> controller)
         {
             _controller = controller;
             _catalogReference = {};
+			// set the indicator to true
+            isSetController = true;          
         }
 
         std::shared_ptr<void> ObjectControllerImpl::GetAdapter(const std::string classifier)
@@ -28925,6 +30466,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void ObjectControllerImpl::ResetCatalogReference()
+	   {
+	   		isSetCatalogReference = false; 
+			_catalogReference = {};
+			
+	   }
+       bool ObjectControllerImpl::IsSetCatalogReference() const
+	   {
+			return isSetCatalogReference;
+	   }
+       void ObjectControllerImpl::ResetController()
+	   {
+	   		isSetController = false; 
+			_controller = {};
+			
+	   }
+       bool ObjectControllerImpl::IsSetController() const
+	   {
+			return isSetController;
+	   }
 
         IOpenScenarioFlexElement* OffroadConditionImpl::GetOpenScenarioFlexElement()
         {
@@ -29643,24 +31204,32 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _h = h;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__H);
+			// set the indicator to true
+            isSetH = true;          
         }
 
         void OrientationImpl::SetP(const double p)
         {
             _p = p;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__P);
+			// set the indicator to true
+            isSetP = true;          
         }
 
         void OrientationImpl::SetR(const double r)
         {
             _r = r;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__R);
+			// set the indicator to true
+            isSetR = true;          
         }
 
         void OrientationImpl::SetType(const ReferenceContext type)
         {
             _type = type;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__TYPE);
+			// set the indicator to true
+            isSetType = true;          
         }
 
         std::shared_ptr<void> OrientationImpl::GetAdapter(const std::string classifier)
@@ -29933,6 +31502,10 @@ namespace NET_ASAM_OPENSCENARIO
                 clonedObject->_type = ReferenceContext::GetFromLiteral(kType.GetLiteral());
             }
             // clone indicators
+            	clonedObject->isSetH = isSetH;
+            	clonedObject->isSetP = isSetP;
+            	clonedObject->isSetR = isSetR;
+            	clonedObject->isSetType = isSetType;
             // clone children
             return clonedObject;
         }
@@ -29996,6 +31569,46 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void OrientationImpl::ResetH()
+	   {
+	   		isSetH = false; 
+			_h = {0};
+			
+	   }
+       bool OrientationImpl::IsSetH() const
+	   {
+			return isSetH;
+	   }
+       void OrientationImpl::ResetP()
+	   {
+	   		isSetP = false; 
+			_p = {0};
+			
+	   }
+       bool OrientationImpl::IsSetP() const
+	   {
+			return isSetP;
+	   }
+       void OrientationImpl::ResetR()
+	   {
+	   		isSetR = false; 
+			_r = {0};
+			
+	   }
+       bool OrientationImpl::IsSetR() const
+	   {
+			return isSetR;
+	   }
+       void OrientationImpl::ResetType()
+	   {
+	   		isSetType = false; 
+			_type = {ReferenceContext::ReferenceContextEnum::ABSOLUTE};
+			
+	   }
+       bool OrientationImpl::IsSetType() const
+	   {
+			return isSetType;
+	   }
 
         IOpenScenarioFlexElement* OverrideBrakeActionImpl::GetOpenScenarioFlexElement()
         {
@@ -30578,31 +32191,43 @@ namespace NET_ASAM_OPENSCENARIO
         void OverrideControllerValueActionImpl::SetThrottle(std::shared_ptr<IOverrideThrottleActionWriter> throttle)
         {
             _throttle = throttle;
+			// set the indicator to true
+            isSetThrottle = true;          
         }
 
         void OverrideControllerValueActionImpl::SetBrake(std::shared_ptr<IOverrideBrakeActionWriter> brake)
         {
             _brake = brake;
+			// set the indicator to true
+            isSetBrake = true;          
         }
 
         void OverrideControllerValueActionImpl::SetClutch(std::shared_ptr<IOverrideClutchActionWriter> clutch)
         {
             _clutch = clutch;
+			// set the indicator to true
+            isSetClutch = true;          
         }
 
         void OverrideControllerValueActionImpl::SetParkingBrake(std::shared_ptr<IOverrideParkingBrakeActionWriter> parkingBrake)
         {
             _parkingBrake = parkingBrake;
+			// set the indicator to true
+            isSetParkingBrake = true;          
         }
 
         void OverrideControllerValueActionImpl::SetSteeringWheel(std::shared_ptr<IOverrideSteeringWheelActionWriter> steeringWheel)
         {
             _steeringWheel = steeringWheel;
+			// set the indicator to true
+            isSetSteeringWheel = true;          
         }
 
         void OverrideControllerValueActionImpl::SetGear(std::shared_ptr<IOverrideGearActionWriter> gear)
         {
             _gear = gear;
+			// set the indicator to true
+            isSetGear = true;          
         }
 
         std::shared_ptr<void> OverrideControllerValueActionImpl::GetAdapter(const std::string classifier)
@@ -30888,6 +32513,66 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void OverrideControllerValueActionImpl::ResetThrottle()
+	   {
+	   		isSetThrottle = false; 
+			_throttle = {};
+			
+	   }
+       bool OverrideControllerValueActionImpl::IsSetThrottle() const
+	   {
+			return isSetThrottle;
+	   }
+       void OverrideControllerValueActionImpl::ResetBrake()
+	   {
+	   		isSetBrake = false; 
+			_brake = {};
+			
+	   }
+       bool OverrideControllerValueActionImpl::IsSetBrake() const
+	   {
+			return isSetBrake;
+	   }
+       void OverrideControllerValueActionImpl::ResetClutch()
+	   {
+	   		isSetClutch = false; 
+			_clutch = {};
+			
+	   }
+       bool OverrideControllerValueActionImpl::IsSetClutch() const
+	   {
+			return isSetClutch;
+	   }
+       void OverrideControllerValueActionImpl::ResetParkingBrake()
+	   {
+	   		isSetParkingBrake = false; 
+			_parkingBrake = {};
+			
+	   }
+       bool OverrideControllerValueActionImpl::IsSetParkingBrake() const
+	   {
+			return isSetParkingBrake;
+	   }
+       void OverrideControllerValueActionImpl::ResetSteeringWheel()
+	   {
+	   		isSetSteeringWheel = false; 
+			_steeringWheel = {};
+			
+	   }
+       bool OverrideControllerValueActionImpl::IsSetSteeringWheel() const
+	   {
+			return isSetSteeringWheel;
+	   }
+       void OverrideControllerValueActionImpl::ResetGear()
+	   {
+	   		isSetGear = false; 
+			_gear = {};
+			
+	   }
+       bool OverrideControllerValueActionImpl::IsSetGear() const
+	   {
+			return isSetGear;
+	   }
 
         IOpenScenarioFlexElement* OverrideGearActionImpl::GetOpenScenarioFlexElement()
         {
@@ -32013,12 +33698,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _setAction = setAction;
             _modifyAction = {};
+			// set the indicator to true
+            isSetSetAction = true;          
         }
 
         void ParameterActionImpl::SetModifyAction(std::shared_ptr<IParameterModifyActionWriter> modifyAction)
         {
             _modifyAction = modifyAction;
             _setAction = {};
+			// set the indicator to true
+            isSetModifyAction = true;          
         }
 
         std::shared_ptr<void> ParameterActionImpl::GetAdapter(const std::string classifier)
@@ -32273,6 +33962,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void ParameterActionImpl::ResetSetAction()
+	   {
+	   		isSetSetAction = false; 
+			_setAction = {};
+			
+	   }
+       bool ParameterActionImpl::IsSetSetAction() const
+	   {
+			return isSetSetAction;
+	   }
+       void ParameterActionImpl::ResetModifyAction()
+	   {
+	   		isSetModifyAction = false; 
+			_modifyAction = {};
+			
+	   }
+       bool ParameterActionImpl::IsSetModifyAction() const
+	   {
+			return isSetModifyAction;
+	   }
 
         IOpenScenarioFlexElement* ParameterAddValueRuleImpl::GetOpenScenarioFlexElement()
         {
@@ -33143,6 +34852,8 @@ namespace NET_ASAM_OPENSCENARIO
         void ParameterDeclarationImpl::SetConstraintGroups(std::vector<std::shared_ptr<IValueConstraintGroupWriter>>& constraintGroups)
         {
             _constraintGroups = constraintGroups;
+			// set the indicator to true
+            isSetConstraintGroups = true;          
         }
 
         std::shared_ptr<void> ParameterDeclarationImpl::GetAdapter(const std::string classifier)
@@ -33441,6 +35152,16 @@ namespace NET_ASAM_OPENSCENARIO
 			return (attributeKey == OSC_CONSTANTS::ATTRIBUTE__VALUE);
 		}
 
+       void ParameterDeclarationImpl::ResetConstraintGroups()
+	   {
+	   		isSetConstraintGroups = false; 
+			_constraintGroups = {};
+			
+	   }
+       bool ParameterDeclarationImpl::IsSetConstraintGroups() const
+	   {
+			return isSetConstraintGroups;
+	   }
 
         IOpenScenarioFlexElement* ParameterModifyActionImpl::GetOpenScenarioFlexElement()
         {
@@ -34781,6 +36502,8 @@ namespace NET_ASAM_OPENSCENARIO
         void PedestrianImpl::SetParameterDeclarations(std::vector<std::shared_ptr<IParameterDeclarationWriter>>& parameterDeclarations)
         {
             _parameterDeclarations = parameterDeclarations;
+			// set the indicator to true
+            isSetParameterDeclarations = true;          
         }
 
         void PedestrianImpl::SetBoundingBox(std::shared_ptr<IBoundingBoxWriter> boundingBox)
@@ -35299,6 +37022,16 @@ namespace NET_ASAM_OPENSCENARIO
        bool PedestrianImpl::IsSetModel3d() const
 	   {
 			return isSetModel3d;
+	   }
+       void PedestrianImpl::ResetParameterDeclarations()
+	   {
+	   		isSetParameterDeclarations = false; 
+			_parameterDeclarations = {};
+			
+	   }
+       bool PedestrianImpl::IsSetParameterDeclarations() const
+	   {
+			return isSetParameterDeclarations;
 	   }
 
         IOpenScenarioFlexElement* PedestrianCatalogLocationImpl::GetOpenScenarioFlexElement()
@@ -35860,6 +37593,8 @@ namespace NET_ASAM_OPENSCENARIO
         void PhaseImpl::SetTrafficSignalStates(std::vector<std::shared_ptr<ITrafficSignalStateWriter>>& trafficSignalStates)
         {
             _trafficSignalStates = trafficSignalStates;
+			// set the indicator to true
+            isSetTrafficSignalStates = true;          
         }
 
         std::shared_ptr<void> PhaseImpl::GetAdapter(const std::string classifier)
@@ -36142,6 +37877,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void PhaseImpl::ResetTrafficSignalStates()
+	   {
+	   		isSetTrafficSignalStates = false; 
+			_trafficSignalStates = {};
+			
+	   }
+       bool PhaseImpl::IsSetTrafficSignalStates() const
+	   {
+			return isSetTrafficSignalStates;
+	   }
 
         IOpenScenarioFlexElement* PoissonDistributionImpl::GetOpenScenarioFlexElement()
         {
@@ -36166,6 +37911,8 @@ namespace NET_ASAM_OPENSCENARIO
         void PoissonDistributionImpl::SetRange(std::shared_ptr<IRangeWriter> range)
         {
             _range = range;
+			// set the indicator to true
+            isSetRange = true;          
         }
 
         std::shared_ptr<void> PoissonDistributionImpl::GetAdapter(const std::string classifier)
@@ -36391,6 +38138,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void PoissonDistributionImpl::ResetRange()
+	   {
+	   		isSetRange = false; 
+			_range = {};
+			
+	   }
+       bool PoissonDistributionImpl::IsSetRange() const
+	   {
+			return isSetRange;
+	   }
 
         IOpenScenarioFlexElement* PolylineImpl::GetOpenScenarioFlexElement()
         {
@@ -36667,6 +38424,8 @@ namespace NET_ASAM_OPENSCENARIO
             _routePosition = {};
             _geoPosition = {};
             _trajectoryPosition = {};
+			// set the indicator to true
+            isSetWorldPosition = true;          
         }
 
         void PositionImpl::SetRelativeWorldPosition(std::shared_ptr<IRelativeWorldPositionWriter> relativeWorldPosition)
@@ -36681,6 +38440,8 @@ namespace NET_ASAM_OPENSCENARIO
             _routePosition = {};
             _geoPosition = {};
             _trajectoryPosition = {};
+			// set the indicator to true
+            isSetRelativeWorldPosition = true;          
         }
 
         void PositionImpl::SetRelativeObjectPosition(std::shared_ptr<IRelativeObjectPositionWriter> relativeObjectPosition)
@@ -36695,6 +38456,8 @@ namespace NET_ASAM_OPENSCENARIO
             _routePosition = {};
             _geoPosition = {};
             _trajectoryPosition = {};
+			// set the indicator to true
+            isSetRelativeObjectPosition = true;          
         }
 
         void PositionImpl::SetRoadPosition(std::shared_ptr<IRoadPositionWriter> roadPosition)
@@ -36709,6 +38472,8 @@ namespace NET_ASAM_OPENSCENARIO
             _routePosition = {};
             _geoPosition = {};
             _trajectoryPosition = {};
+			// set the indicator to true
+            isSetRoadPosition = true;          
         }
 
         void PositionImpl::SetRelativeRoadPosition(std::shared_ptr<IRelativeRoadPositionWriter> relativeRoadPosition)
@@ -36723,6 +38488,8 @@ namespace NET_ASAM_OPENSCENARIO
             _routePosition = {};
             _geoPosition = {};
             _trajectoryPosition = {};
+			// set the indicator to true
+            isSetRelativeRoadPosition = true;          
         }
 
         void PositionImpl::SetLanePosition(std::shared_ptr<ILanePositionWriter> lanePosition)
@@ -36737,6 +38504,8 @@ namespace NET_ASAM_OPENSCENARIO
             _routePosition = {};
             _geoPosition = {};
             _trajectoryPosition = {};
+			// set the indicator to true
+            isSetLanePosition = true;          
         }
 
         void PositionImpl::SetRelativeLanePosition(std::shared_ptr<IRelativeLanePositionWriter> relativeLanePosition)
@@ -36751,6 +38520,8 @@ namespace NET_ASAM_OPENSCENARIO
             _routePosition = {};
             _geoPosition = {};
             _trajectoryPosition = {};
+			// set the indicator to true
+            isSetRelativeLanePosition = true;          
         }
 
         void PositionImpl::SetRoutePosition(std::shared_ptr<IRoutePositionWriter> routePosition)
@@ -36765,6 +38536,8 @@ namespace NET_ASAM_OPENSCENARIO
             _relativeLanePosition = {};
             _geoPosition = {};
             _trajectoryPosition = {};
+			// set the indicator to true
+            isSetRoutePosition = true;          
         }
 
         void PositionImpl::SetGeoPosition(std::shared_ptr<IGeoPositionWriter> geoPosition)
@@ -36779,6 +38552,8 @@ namespace NET_ASAM_OPENSCENARIO
             _relativeLanePosition = {};
             _routePosition = {};
             _trajectoryPosition = {};
+			// set the indicator to true
+            isSetGeoPosition = true;          
         }
 
         void PositionImpl::SetTrajectoryPosition(std::shared_ptr<ITrajectoryPositionWriter> trajectoryPosition)
@@ -36793,6 +38568,8 @@ namespace NET_ASAM_OPENSCENARIO
             _relativeLanePosition = {};
             _routePosition = {};
             _geoPosition = {};
+			// set the indicator to true
+            isSetTrajectoryPosition = true;          
         }
 
         std::shared_ptr<void> PositionImpl::GetAdapter(const std::string classifier)
@@ -37166,6 +38943,106 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void PositionImpl::ResetWorldPosition()
+	   {
+	   		isSetWorldPosition = false; 
+			_worldPosition = {};
+			
+	   }
+       bool PositionImpl::IsSetWorldPosition() const
+	   {
+			return isSetWorldPosition;
+	   }
+       void PositionImpl::ResetRelativeWorldPosition()
+	   {
+	   		isSetRelativeWorldPosition = false; 
+			_relativeWorldPosition = {};
+			
+	   }
+       bool PositionImpl::IsSetRelativeWorldPosition() const
+	   {
+			return isSetRelativeWorldPosition;
+	   }
+       void PositionImpl::ResetRelativeObjectPosition()
+	   {
+	   		isSetRelativeObjectPosition = false; 
+			_relativeObjectPosition = {};
+			
+	   }
+       bool PositionImpl::IsSetRelativeObjectPosition() const
+	   {
+			return isSetRelativeObjectPosition;
+	   }
+       void PositionImpl::ResetRoadPosition()
+	   {
+	   		isSetRoadPosition = false; 
+			_roadPosition = {};
+			
+	   }
+       bool PositionImpl::IsSetRoadPosition() const
+	   {
+			return isSetRoadPosition;
+	   }
+       void PositionImpl::ResetRelativeRoadPosition()
+	   {
+	   		isSetRelativeRoadPosition = false; 
+			_relativeRoadPosition = {};
+			
+	   }
+       bool PositionImpl::IsSetRelativeRoadPosition() const
+	   {
+			return isSetRelativeRoadPosition;
+	   }
+       void PositionImpl::ResetLanePosition()
+	   {
+	   		isSetLanePosition = false; 
+			_lanePosition = {};
+			
+	   }
+       bool PositionImpl::IsSetLanePosition() const
+	   {
+			return isSetLanePosition;
+	   }
+       void PositionImpl::ResetRelativeLanePosition()
+	   {
+	   		isSetRelativeLanePosition = false; 
+			_relativeLanePosition = {};
+			
+	   }
+       bool PositionImpl::IsSetRelativeLanePosition() const
+	   {
+			return isSetRelativeLanePosition;
+	   }
+       void PositionImpl::ResetRoutePosition()
+	   {
+	   		isSetRoutePosition = false; 
+			_routePosition = {};
+			
+	   }
+       bool PositionImpl::IsSetRoutePosition() const
+	   {
+			return isSetRoutePosition;
+	   }
+       void PositionImpl::ResetGeoPosition()
+	   {
+	   		isSetGeoPosition = false; 
+			_geoPosition = {};
+			
+	   }
+       bool PositionImpl::IsSetGeoPosition() const
+	   {
+			return isSetGeoPosition;
+	   }
+       void PositionImpl::ResetTrajectoryPosition()
+	   {
+	   		isSetTrajectoryPosition = false; 
+			_trajectoryPosition = {};
+			
+	   }
+       bool PositionImpl::IsSetTrajectoryPosition() const
+	   {
+			return isSetTrajectoryPosition;
+	   }
 
         IOpenScenarioFlexElement* PositionInLaneCoordinatesImpl::GetOpenScenarioFlexElement()
         {
@@ -37195,6 +39072,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _laneOffset = laneOffset;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__LANE_OFFSET);
+			// set the indicator to true
+            isSetLaneOffset = true;          
         }
 
         void PositionInLaneCoordinatesImpl::SetPathS(const double pathS)
@@ -37425,6 +39304,7 @@ namespace NET_ASAM_OPENSCENARIO
             // Simple type
             clonedObject->_pathS = GetPathS();
             // clone indicators
+            	clonedObject->isSetLaneOffset = isSetLaneOffset;
             // clone children
             return clonedObject;
         }
@@ -37491,6 +39371,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void PositionInLaneCoordinatesImpl::ResetLaneOffset()
+	   {
+	   		isSetLaneOffset = false; 
+			_laneOffset = {0};
+			
+	   }
+       bool PositionInLaneCoordinatesImpl::IsSetLaneOffset() const
+	   {
+			return isSetLaneOffset;
+	   }
 
         IOpenScenarioFlexElement* PositionInRoadCoordinatesImpl::GetOpenScenarioFlexElement()
         {
@@ -38665,6 +40555,8 @@ namespace NET_ASAM_OPENSCENARIO
             _controllerAction = {};
             _teleportAction = {};
             _routingAction = {};
+			// set the indicator to true
+            isSetLongitudinalAction = true;          
         }
 
         void PrivateActionImpl::SetLateralAction(std::shared_ptr<ILateralActionWriter> lateralAction)
@@ -38677,6 +40569,8 @@ namespace NET_ASAM_OPENSCENARIO
             _controllerAction = {};
             _teleportAction = {};
             _routingAction = {};
+			// set the indicator to true
+            isSetLateralAction = true;          
         }
 
         void PrivateActionImpl::SetVisibilityAction(std::shared_ptr<IVisibilityActionWriter> visibilityAction)
@@ -38689,6 +40583,8 @@ namespace NET_ASAM_OPENSCENARIO
             _controllerAction = {};
             _teleportAction = {};
             _routingAction = {};
+			// set the indicator to true
+            isSetVisibilityAction = true;          
         }
 
         void PrivateActionImpl::SetSynchronizeAction(std::shared_ptr<ISynchronizeActionWriter> synchronizeAction)
@@ -38701,6 +40597,8 @@ namespace NET_ASAM_OPENSCENARIO
             _controllerAction = {};
             _teleportAction = {};
             _routingAction = {};
+			// set the indicator to true
+            isSetSynchronizeAction = true;          
         }
 
         void PrivateActionImpl::SetActivateControllerAction(std::shared_ptr<IActivateControllerActionWriter> activateControllerAction)
@@ -38713,6 +40611,8 @@ namespace NET_ASAM_OPENSCENARIO
             _controllerAction = {};
             _teleportAction = {};
             _routingAction = {};
+			// set the indicator to true
+            isSetActivateControllerAction = true;          
         }
 
         void PrivateActionImpl::SetControllerAction(std::shared_ptr<IControllerActionWriter> controllerAction)
@@ -38725,6 +40625,8 @@ namespace NET_ASAM_OPENSCENARIO
             _activateControllerAction = {};
             _teleportAction = {};
             _routingAction = {};
+			// set the indicator to true
+            isSetControllerAction = true;          
         }
 
         void PrivateActionImpl::SetTeleportAction(std::shared_ptr<ITeleportActionWriter> teleportAction)
@@ -38737,6 +40639,8 @@ namespace NET_ASAM_OPENSCENARIO
             _activateControllerAction = {};
             _controllerAction = {};
             _routingAction = {};
+			// set the indicator to true
+            isSetTeleportAction = true;          
         }
 
         void PrivateActionImpl::SetRoutingAction(std::shared_ptr<IRoutingActionWriter> routingAction)
@@ -38749,6 +40653,8 @@ namespace NET_ASAM_OPENSCENARIO
             _activateControllerAction = {};
             _controllerAction = {};
             _teleportAction = {};
+			// set the indicator to true
+            isSetRoutingAction = true;          
         }
 
         std::shared_ptr<void> PrivateActionImpl::GetAdapter(const std::string classifier)
@@ -39078,6 +40984,86 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void PrivateActionImpl::ResetLongitudinalAction()
+	   {
+	   		isSetLongitudinalAction = false; 
+			_longitudinalAction = {};
+			
+	   }
+       bool PrivateActionImpl::IsSetLongitudinalAction() const
+	   {
+			return isSetLongitudinalAction;
+	   }
+       void PrivateActionImpl::ResetLateralAction()
+	   {
+	   		isSetLateralAction = false; 
+			_lateralAction = {};
+			
+	   }
+       bool PrivateActionImpl::IsSetLateralAction() const
+	   {
+			return isSetLateralAction;
+	   }
+       void PrivateActionImpl::ResetVisibilityAction()
+	   {
+	   		isSetVisibilityAction = false; 
+			_visibilityAction = {};
+			
+	   }
+       bool PrivateActionImpl::IsSetVisibilityAction() const
+	   {
+			return isSetVisibilityAction;
+	   }
+       void PrivateActionImpl::ResetSynchronizeAction()
+	   {
+	   		isSetSynchronizeAction = false; 
+			_synchronizeAction = {};
+			
+	   }
+       bool PrivateActionImpl::IsSetSynchronizeAction() const
+	   {
+			return isSetSynchronizeAction;
+	   }
+       void PrivateActionImpl::ResetActivateControllerAction()
+	   {
+	   		isSetActivateControllerAction = false; 
+			_activateControllerAction = {};
+			
+	   }
+       bool PrivateActionImpl::IsSetActivateControllerAction() const
+	   {
+			return isSetActivateControllerAction;
+	   }
+       void PrivateActionImpl::ResetControllerAction()
+	   {
+	   		isSetControllerAction = false; 
+			_controllerAction = {};
+			
+	   }
+       bool PrivateActionImpl::IsSetControllerAction() const
+	   {
+			return isSetControllerAction;
+	   }
+       void PrivateActionImpl::ResetTeleportAction()
+	   {
+	   		isSetTeleportAction = false; 
+			_teleportAction = {};
+			
+	   }
+       bool PrivateActionImpl::IsSetTeleportAction() const
+	   {
+			return isSetTeleportAction;
+	   }
+       void PrivateActionImpl::ResetRoutingAction()
+	   {
+	   		isSetRoutingAction = false; 
+			_routingAction = {};
+			
+	   }
+       bool PrivateActionImpl::IsSetRoutingAction() const
+	   {
+			return isSetRoutingAction;
+	   }
 
         IOpenScenarioFlexElement* ProbabilityDistributionSetImpl::GetOpenScenarioFlexElement()
         {
@@ -39629,11 +41615,15 @@ namespace NET_ASAM_OPENSCENARIO
         void PropertiesImpl::SetProperties(std::vector<std::shared_ptr<IPropertyWriter>>& properties)
         {
             _properties = properties;
+			// set the indicator to true
+            isSetProperties = true;          
         }
 
         void PropertiesImpl::SetFiles(std::vector<std::shared_ptr<IFileWriter>>& files)
         {
             _files = files;
+			// set the indicator to true
+            isSetFiles = true;          
         }
 
         std::shared_ptr<void> PropertiesImpl::GetAdapter(const std::string classifier)
@@ -39844,6 +41834,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void PropertiesImpl::ResetProperties()
+	   {
+	   		isSetProperties = false; 
+			_properties = {};
+			
+	   }
+       bool PropertiesImpl::IsSetProperties() const
+	   {
+			return isSetProperties;
+	   }
+       void PropertiesImpl::ResetFiles()
+	   {
+	   		isSetFiles = false; 
+			_files = {};
+			
+	   }
+       bool PropertiesImpl::IsSetFiles() const
+	   {
+			return isSetFiles;
+	   }
 
         IOpenScenarioFlexElement* PropertyImpl::GetOpenScenarioFlexElement()
         {
@@ -40659,6 +42669,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _coordinateSystem = coordinateSystem;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM);
+			// set the indicator to true
+            isSetCoordinateSystem = true;          
         }
 
         void RelativeDistanceConditionImpl::SetEntityRef(std::shared_ptr<INamedReference<IEntity>> entityRef)
@@ -41054,6 +43066,7 @@ namespace NET_ASAM_OPENSCENARIO
             // Simple type
             clonedObject->_value = GetValue();
             // clone indicators
+            	clonedObject->isSetCoordinateSystem = isSetCoordinateSystem;
             // clone children
             return clonedObject;
         }
@@ -41147,6 +43160,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void RelativeDistanceConditionImpl::ResetCoordinateSystem()
+	   {
+	   		isSetCoordinateSystem = false; 
+			_coordinateSystem = {CoordinateSystem::CoordinateSystemEnum::ENTITY};
+			
+	   }
+       bool RelativeDistanceConditionImpl::IsSetCoordinateSystem() const
+	   {
+			return isSetCoordinateSystem;
+	   }
 
         IOpenScenarioFlexElement* RelativeLanePositionImpl::GetOpenScenarioFlexElement()
         {
@@ -41210,11 +43233,15 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _offset = offset;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__OFFSET);
+			// set the indicator to true
+            isSetOffset = true;          
         }
 
         void RelativeLanePositionImpl::SetOrientation(std::shared_ptr<IOrientationWriter> orientation)
         {
             _orientation = orientation;
+			// set the indicator to true
+            isSetOrientation = true;          
         }
 
         std::shared_ptr<void> RelativeLanePositionImpl::GetAdapter(const std::string classifier)
@@ -41529,6 +43556,7 @@ namespace NET_ASAM_OPENSCENARIO
             // clone indicators
             	clonedObject->isSetDs = isSetDs;
             	clonedObject->isSetDsLane = isSetDsLane;
+            	clonedObject->isSetOffset = isSetOffset;
             // clone children
             const auto kOrientation =  GetWriterOrientation();
             if (kOrientation)
@@ -41651,6 +43679,26 @@ namespace NET_ASAM_OPENSCENARIO
 	   {
 			return isSetDsLane;
 	   }
+       void RelativeLanePositionImpl::ResetOffset()
+	   {
+	   		isSetOffset = false; 
+			_offset = {0};
+			
+	   }
+       bool RelativeLanePositionImpl::IsSetOffset() const
+	   {
+			return isSetOffset;
+	   }
+       void RelativeLanePositionImpl::ResetOrientation()
+	   {
+	   		isSetOrientation = false; 
+			_orientation = {};
+			
+	   }
+       bool RelativeLanePositionImpl::IsSetOrientation() const
+	   {
+			return isSetOrientation;
+	   }
 
         IOpenScenarioFlexElement* RelativeObjectPositionImpl::GetOpenScenarioFlexElement()
         {
@@ -41694,6 +43742,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _dz = dz;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__DZ);
+			// set the indicator to true
+            isSetDz = true;          
         }
 
         void RelativeObjectPositionImpl::SetEntityRef(std::shared_ptr<INamedReference<IEntity>> entityRef)
@@ -41705,6 +43755,8 @@ namespace NET_ASAM_OPENSCENARIO
         void RelativeObjectPositionImpl::SetOrientation(std::shared_ptr<IOrientationWriter> orientation)
         {
             _orientation = orientation;
+			// set the indicator to true
+            isSetOrientation = true;          
         }
 
         std::shared_ptr<void> RelativeObjectPositionImpl::GetAdapter(const std::string classifier)
@@ -41977,6 +44029,7 @@ namespace NET_ASAM_OPENSCENARIO
             clonedObject->_entityRef = proxy;
             
             // clone indicators
+            	clonedObject->isSetDz = isSetDz;
             // clone children
             const auto kOrientation =  GetWriterOrientation();
             if (kOrientation)
@@ -42069,6 +44122,26 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void RelativeObjectPositionImpl::ResetDz()
+	   {
+	   		isSetDz = false; 
+			_dz = {0};
+			
+	   }
+       bool RelativeObjectPositionImpl::IsSetDz() const
+	   {
+			return isSetDz;
+	   }
+       void RelativeObjectPositionImpl::ResetOrientation()
+	   {
+	   		isSetOrientation = false; 
+			_orientation = {};
+			
+	   }
+       bool RelativeObjectPositionImpl::IsSetOrientation() const
+	   {
+			return isSetOrientation;
+	   }
 
         IOpenScenarioFlexElement* RelativeRoadPositionImpl::GetOpenScenarioFlexElement()
         {
@@ -42113,6 +44186,8 @@ namespace NET_ASAM_OPENSCENARIO
         void RelativeRoadPositionImpl::SetOrientation(std::shared_ptr<IOrientationWriter> orientation)
         {
             _orientation = orientation;
+			// set the indicator to true
+            isSetOrientation = true;          
         }
 
         std::shared_ptr<void> RelativeRoadPositionImpl::GetAdapter(const std::string classifier)
@@ -42436,6 +44511,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void RelativeRoadPositionImpl::ResetOrientation()
+	   {
+	   		isSetOrientation = false; 
+			_orientation = {};
+			
+	   }
+       bool RelativeRoadPositionImpl::IsSetOrientation() const
+	   {
+			return isSetOrientation;
+	   }
 
         IOpenScenarioFlexElement* RelativeSpeedConditionImpl::GetOpenScenarioFlexElement()
         {
@@ -42815,6 +44900,8 @@ namespace NET_ASAM_OPENSCENARIO
         void RelativeSpeedToMasterImpl::SetSteadyState(std::shared_ptr<ISteadyStateWriter> steadyState)
         {
             _steadyState = steadyState;
+			// set the indicator to true
+            isSetSteadyState = true;          
         }
 
         std::shared_ptr<void> RelativeSpeedToMasterImpl::GetAdapter(const std::string classifier)
@@ -43094,6 +45181,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void RelativeSpeedToMasterImpl::ResetSteadyState()
+	   {
+	   		isSetSteadyState = false; 
+			_steadyState = {};
+			
+	   }
+       bool RelativeSpeedToMasterImpl::IsSetSteadyState() const
+	   {
+			return isSetSteadyState;
+	   }
 
         IOpenScenarioFlexElement* RelativeTargetLaneImpl::GetOpenScenarioFlexElement()
         {
@@ -44104,6 +46201,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _dz = dz;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__DZ);
+			// set the indicator to true
+            isSetDz = true;          
         }
 
         void RelativeWorldPositionImpl::SetEntityRef(std::shared_ptr<INamedReference<IEntity>> entityRef)
@@ -44115,6 +46214,8 @@ namespace NET_ASAM_OPENSCENARIO
         void RelativeWorldPositionImpl::SetOrientation(std::shared_ptr<IOrientationWriter> orientation)
         {
             _orientation = orientation;
+			// set the indicator to true
+            isSetOrientation = true;          
         }
 
         std::shared_ptr<void> RelativeWorldPositionImpl::GetAdapter(const std::string classifier)
@@ -44387,6 +46488,7 @@ namespace NET_ASAM_OPENSCENARIO
             clonedObject->_entityRef = proxy;
             
             // clone indicators
+            	clonedObject->isSetDz = isSetDz;
             // clone children
             const auto kOrientation =  GetWriterOrientation();
             if (kOrientation)
@@ -44479,6 +46581,26 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void RelativeWorldPositionImpl::ResetDz()
+	   {
+	   		isSetDz = false; 
+			_dz = {0};
+			
+	   }
+       bool RelativeWorldPositionImpl::IsSetDz() const
+	   {
+			return isSetDz;
+	   }
+       void RelativeWorldPositionImpl::ResetOrientation()
+	   {
+	   		isSetOrientation = false; 
+			_orientation = {};
+			
+	   }
+       bool RelativeWorldPositionImpl::IsSetOrientation() const
+	   {
+			return isSetOrientation;
+	   }
 
         IOpenScenarioFlexElement* RoadConditionImpl::GetOpenScenarioFlexElement()
         {
@@ -44503,6 +46625,8 @@ namespace NET_ASAM_OPENSCENARIO
         void RoadConditionImpl::SetProperties(std::shared_ptr<IPropertiesWriter> properties)
         {
             _properties = properties;
+			// set the indicator to true
+            isSetProperties = true;          
         }
 
         std::shared_ptr<void> RoadConditionImpl::GetAdapter(const std::string classifier)
@@ -44728,6 +46852,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void RoadConditionImpl::ResetProperties()
+	   {
+	   		isSetProperties = false; 
+			_properties = {};
+			
+	   }
+       bool RoadConditionImpl::IsSetProperties() const
+	   {
+			return isSetProperties;
+	   }
 
         IOpenScenarioFlexElement* RoadNetworkImpl::GetOpenScenarioFlexElement()
         {
@@ -44775,21 +46909,29 @@ namespace NET_ASAM_OPENSCENARIO
         void RoadNetworkImpl::SetLogicFile(std::shared_ptr<IFileWriter> logicFile)
         {
             _logicFile = logicFile;
+			// set the indicator to true
+            isSetLogicFile = true;          
         }
 
         void RoadNetworkImpl::SetSceneGraphFile(std::shared_ptr<IFileWriter> sceneGraphFile)
         {
             _sceneGraphFile = sceneGraphFile;
+			// set the indicator to true
+            isSetSceneGraphFile = true;          
         }
 
         void RoadNetworkImpl::SetTrafficSignals(std::vector<std::shared_ptr<ITrafficSignalControllerWriter>>& trafficSignals)
         {
             _trafficSignals = trafficSignals;
+			// set the indicator to true
+            isSetTrafficSignals = true;          
         }
 
         void RoadNetworkImpl::SetUsedArea(std::shared_ptr<IUsedAreaWriter> usedArea)
         {
             _usedArea = usedArea;
+			// set the indicator to true
+            isSetUsedArea = true;          
         }
 
         std::shared_ptr<void> RoadNetworkImpl::GetAdapter(const std::string classifier)
@@ -45041,6 +47183,46 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void RoadNetworkImpl::ResetLogicFile()
+	   {
+	   		isSetLogicFile = false; 
+			_logicFile = {};
+			
+	   }
+       bool RoadNetworkImpl::IsSetLogicFile() const
+	   {
+			return isSetLogicFile;
+	   }
+       void RoadNetworkImpl::ResetSceneGraphFile()
+	   {
+	   		isSetSceneGraphFile = false; 
+			_sceneGraphFile = {};
+			
+	   }
+       bool RoadNetworkImpl::IsSetSceneGraphFile() const
+	   {
+			return isSetSceneGraphFile;
+	   }
+       void RoadNetworkImpl::ResetTrafficSignals()
+	   {
+	   		isSetTrafficSignals = false; 
+			_trafficSignals = {};
+			
+	   }
+       bool RoadNetworkImpl::IsSetTrafficSignals() const
+	   {
+			return isSetTrafficSignals;
+	   }
+       void RoadNetworkImpl::ResetUsedArea()
+	   {
+	   		isSetUsedArea = false; 
+			_usedArea = {};
+			
+	   }
+       bool RoadNetworkImpl::IsSetUsedArea() const
+	   {
+			return isSetUsedArea;
+	   }
 
         IOpenScenarioFlexElement* RoadPositionImpl::GetOpenScenarioFlexElement()
         {
@@ -45085,6 +47267,8 @@ namespace NET_ASAM_OPENSCENARIO
         void RoadPositionImpl::SetOrientation(std::shared_ptr<IOrientationWriter> orientation)
         {
             _orientation = orientation;
+			// set the indicator to true
+            isSetOrientation = true;          
         }
 
         std::shared_ptr<void> RoadPositionImpl::GetAdapter(const std::string classifier)
@@ -45401,6 +47585,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void RoadPositionImpl::ResetOrientation()
+	   {
+	   		isSetOrientation = false; 
+			_orientation = {};
+			
+	   }
+       bool RoadPositionImpl::IsSetOrientation() const
+	   {
+			return isSetOrientation;
+	   }
 
         IOpenScenarioFlexElement* RouteImpl::GetOpenScenarioFlexElement()
         {
@@ -45481,6 +47675,8 @@ namespace NET_ASAM_OPENSCENARIO
         void RouteImpl::SetParameterDeclarations(std::vector<std::shared_ptr<IParameterDeclarationWriter>>& parameterDeclarations)
         {
             _parameterDeclarations = parameterDeclarations;
+			// set the indicator to true
+            isSetParameterDeclarations = true;          
         }
 
         void RouteImpl::SetWaypoints(std::vector<std::shared_ptr<IWaypointWriter>>& waypoints)
@@ -45815,6 +48011,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void RouteImpl::ResetParameterDeclarations()
+	   {
+	   		isSetParameterDeclarations = false; 
+			_parameterDeclarations = {};
+			
+	   }
+       bool RouteImpl::IsSetParameterDeclarations() const
+	   {
+			return isSetParameterDeclarations;
+	   }
 
         IOpenScenarioFlexElement* RouteCatalogLocationImpl::GetOpenScenarioFlexElement()
         {
@@ -46031,6 +48237,8 @@ namespace NET_ASAM_OPENSCENARIO
         void RoutePositionImpl::SetOrientation(std::shared_ptr<IOrientationWriter> orientation)
         {
             _orientation = orientation;
+			// set the indicator to true
+            isSetOrientation = true;          
         }
 
         void RoutePositionImpl::SetInRoutePosition(std::shared_ptr<IInRoutePositionWriter> inRoutePosition)
@@ -46255,6 +48463,16 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void RoutePositionImpl::ResetOrientation()
+	   {
+	   		isSetOrientation = false; 
+			_orientation = {};
+			
+	   }
+       bool RoutePositionImpl::IsSetOrientation() const
+	   {
+			return isSetOrientation;
+	   }
 
         IOpenScenarioFlexElement* RouteRefImpl::GetOpenScenarioFlexElement()
         {
@@ -46274,12 +48492,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _route = route;
             _catalogReference = {};
+			// set the indicator to true
+            isSetRoute = true;          
         }
 
         void RouteRefImpl::SetCatalogReference(std::shared_ptr<ICatalogReferenceWriter> catalogReference)
         {
             _catalogReference = catalogReference;
             _route = {};
+			// set the indicator to true
+            isSetCatalogReference = true;          
         }
 
         std::shared_ptr<void> RouteRefImpl::GetAdapter(const std::string classifier)
@@ -46477,6 +48699,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void RouteRefImpl::ResetRoute()
+	   {
+	   		isSetRoute = false; 
+			_route = {};
+			
+	   }
+       bool RouteRefImpl::IsSetRoute() const
+	   {
+			return isSetRoute;
+	   }
+       void RouteRefImpl::ResetCatalogReference()
+	   {
+	   		isSetCatalogReference = false; 
+			_catalogReference = {};
+			
+	   }
+       bool RouteRefImpl::IsSetCatalogReference() const
+	   {
+			return isSetCatalogReference;
+	   }
 
         IOpenScenarioFlexElement* RoutingActionImpl::GetOpenScenarioFlexElement()
         {
@@ -46501,6 +48743,8 @@ namespace NET_ASAM_OPENSCENARIO
             _assignRouteAction = assignRouteAction;
             _followTrajectoryAction = {};
             _acquirePositionAction = {};
+			// set the indicator to true
+            isSetAssignRouteAction = true;          
         }
 
         void RoutingActionImpl::SetFollowTrajectoryAction(std::shared_ptr<IFollowTrajectoryActionWriter> followTrajectoryAction)
@@ -46508,6 +48752,8 @@ namespace NET_ASAM_OPENSCENARIO
             _followTrajectoryAction = followTrajectoryAction;
             _assignRouteAction = {};
             _acquirePositionAction = {};
+			// set the indicator to true
+            isSetFollowTrajectoryAction = true;          
         }
 
         void RoutingActionImpl::SetAcquirePositionAction(std::shared_ptr<IAcquirePositionActionWriter> acquirePositionAction)
@@ -46515,6 +48761,8 @@ namespace NET_ASAM_OPENSCENARIO
             _acquirePositionAction = acquirePositionAction;
             _assignRouteAction = {};
             _followTrajectoryAction = {};
+			// set the indicator to true
+            isSetAcquirePositionAction = true;          
         }
 
         std::shared_ptr<void> RoutingActionImpl::GetAdapter(const std::string classifier)
@@ -46734,6 +48982,36 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void RoutingActionImpl::ResetAssignRouteAction()
+	   {
+	   		isSetAssignRouteAction = false; 
+			_assignRouteAction = {};
+			
+	   }
+       bool RoutingActionImpl::IsSetAssignRouteAction() const
+	   {
+			return isSetAssignRouteAction;
+	   }
+       void RoutingActionImpl::ResetFollowTrajectoryAction()
+	   {
+	   		isSetFollowTrajectoryAction = false; 
+			_followTrajectoryAction = {};
+			
+	   }
+       bool RoutingActionImpl::IsSetFollowTrajectoryAction() const
+	   {
+			return isSetFollowTrajectoryAction;
+	   }
+       void RoutingActionImpl::ResetAcquirePositionAction()
+	   {
+	   		isSetAcquirePositionAction = false; 
+			_acquirePositionAction = {};
+			
+	   }
+       bool RoutingActionImpl::IsSetAcquirePositionAction() const
+	   {
+			return isSetAcquirePositionAction;
+	   }
 
         IOpenScenarioFlexElement* ScenarioDefinitionImpl::GetOpenScenarioFlexElement()
         {
@@ -46785,6 +49063,8 @@ namespace NET_ASAM_OPENSCENARIO
         void ScenarioDefinitionImpl::SetParameterDeclarations(std::vector<std::shared_ptr<IParameterDeclarationWriter>>& parameterDeclarations)
         {
             _parameterDeclarations = parameterDeclarations;
+			// set the indicator to true
+            isSetParameterDeclarations = true;          
         }
 
         void ScenarioDefinitionImpl::SetCatalogLocations(std::shared_ptr<ICatalogLocationsWriter> catalogLocations)
@@ -47098,6 +49378,16 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void ScenarioDefinitionImpl::ResetParameterDeclarations()
+	   {
+	   		isSetParameterDeclarations = false; 
+			_parameterDeclarations = {};
+			
+	   }
+       bool ScenarioDefinitionImpl::IsSetParameterDeclarations() const
+	   {
+			return isSetParameterDeclarations;
+	   }
 
         IOpenScenarioFlexElement* ScenarioObjectImpl::GetOpenScenarioFlexElement()
         {
@@ -47131,6 +49421,8 @@ namespace NET_ASAM_OPENSCENARIO
         void ScenarioObjectImpl::SetObjectController(std::shared_ptr<IObjectControllerWriter> objectController)
         {
             _objectController = objectController;
+			// set the indicator to true
+            isSetObjectController = true;          
         }
 
         std::shared_ptr<void> ScenarioObjectImpl::GetAdapter(const std::string classifier)
@@ -47378,6 +49670,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void ScenarioObjectImpl::ResetObjectController()
+	   {
+	   		isSetObjectController = false; 
+			_objectController = {};
+			
+	   }
+       bool ScenarioObjectImpl::IsSetObjectController() const
+	   {
+			return isSetObjectController;
+	   }
 
         IOpenScenarioFlexElement* SelectedEntitiesImpl::GetOpenScenarioFlexElement()
         {
@@ -47439,12 +49741,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _entityRef = entityRef;
             _byType = {};
+			// set the indicator to true
+            isSetEntityRef = true;          
         }
 
         void SelectedEntitiesImpl::SetByType(std::vector<std::shared_ptr<IByTypeWriter>>& byType)
         {
             _byType = byType;
             _entityRef = {};
+			// set the indicator to true
+            isSetByType = true;          
         }
 
         std::shared_ptr<void> SelectedEntitiesImpl::GetAdapter(const std::string classifier)
@@ -47655,6 +49961,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void SelectedEntitiesImpl::ResetEntityRef()
+	   {
+	   		isSetEntityRef = false; 
+			_entityRef = {};
+			
+	   }
+       bool SelectedEntitiesImpl::IsSetEntityRef() const
+	   {
+			return isSetEntityRef;
+	   }
+       void SelectedEntitiesImpl::ResetByType()
+	   {
+	   		isSetByType = false; 
+			_byType = {};
+			
+	   }
+       bool SelectedEntitiesImpl::IsSetByType() const
+	   {
+			return isSetByType;
+	   }
 
         IOpenScenarioFlexElement* ShapeImpl::GetOpenScenarioFlexElement()
         {
@@ -47679,6 +50005,8 @@ namespace NET_ASAM_OPENSCENARIO
             _polyline = polyline;
             _clothoid = {};
             _nurbs = {};
+			// set the indicator to true
+            isSetPolyline = true;          
         }
 
         void ShapeImpl::SetClothoid(std::shared_ptr<IClothoidWriter> clothoid)
@@ -47686,6 +50014,8 @@ namespace NET_ASAM_OPENSCENARIO
             _clothoid = clothoid;
             _polyline = {};
             _nurbs = {};
+			// set the indicator to true
+            isSetClothoid = true;          
         }
 
         void ShapeImpl::SetNurbs(std::shared_ptr<INurbsWriter> nurbs)
@@ -47693,6 +50023,8 @@ namespace NET_ASAM_OPENSCENARIO
             _nurbs = nurbs;
             _polyline = {};
             _clothoid = {};
+			// set the indicator to true
+            isSetNurbs = true;          
         }
 
         std::shared_ptr<void> ShapeImpl::GetAdapter(const std::string classifier)
@@ -47912,6 +50244,36 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void ShapeImpl::ResetPolyline()
+	   {
+	   		isSetPolyline = false; 
+			_polyline = {};
+			
+	   }
+       bool ShapeImpl::IsSetPolyline() const
+	   {
+			return isSetPolyline;
+	   }
+       void ShapeImpl::ResetClothoid()
+	   {
+	   		isSetClothoid = false; 
+			_clothoid = {};
+			
+	   }
+       bool ShapeImpl::IsSetClothoid() const
+	   {
+			return isSetClothoid;
+	   }
+       void ShapeImpl::ResetNurbs()
+	   {
+	   		isSetNurbs = false; 
+			_nurbs = {};
+			
+	   }
+       bool ShapeImpl::IsSetNurbs() const
+	   {
+			return isSetNurbs;
+	   }
 
         IOpenScenarioFlexElement* SimulationTimeConditionImpl::GetOpenScenarioFlexElement()
         {
@@ -48429,12 +50791,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _relativeTargetSpeed = relativeTargetSpeed;
             _absoluteTargetSpeed = {};
+			// set the indicator to true
+            isSetRelativeTargetSpeed = true;          
         }
 
         void SpeedActionTargetImpl::SetAbsoluteTargetSpeed(std::shared_ptr<IAbsoluteTargetSpeedWriter> absoluteTargetSpeed)
         {
             _absoluteTargetSpeed = absoluteTargetSpeed;
             _relativeTargetSpeed = {};
+			// set the indicator to true
+            isSetAbsoluteTargetSpeed = true;          
         }
 
         std::shared_ptr<void> SpeedActionTargetImpl::GetAdapter(const std::string classifier)
@@ -48632,6 +50998,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void SpeedActionTargetImpl::ResetRelativeTargetSpeed()
+	   {
+	   		isSetRelativeTargetSpeed = false; 
+			_relativeTargetSpeed = {};
+			
+	   }
+       bool SpeedActionTargetImpl::IsSetRelativeTargetSpeed() const
+	   {
+			return isSetRelativeTargetSpeed;
+	   }
+       void SpeedActionTargetImpl::ResetAbsoluteTargetSpeed()
+	   {
+	   		isSetAbsoluteTargetSpeed = false; 
+			_absoluteTargetSpeed = {};
+			
+	   }
+       bool SpeedActionTargetImpl::IsSetAbsoluteTargetSpeed() const
+	   {
+			return isSetAbsoluteTargetSpeed;
+	   }
 
         IOpenScenarioFlexElement* SpeedConditionImpl::GetOpenScenarioFlexElement()
         {
@@ -50389,6 +52775,8 @@ namespace NET_ASAM_OPENSCENARIO
         void StoryImpl::SetParameterDeclarations(std::vector<std::shared_ptr<IParameterDeclarationWriter>>& parameterDeclarations)
         {
             _parameterDeclarations = parameterDeclarations;
+			// set the indicator to true
+            isSetParameterDeclarations = true;          
         }
 
         void StoryImpl::SetActs(std::vector<std::shared_ptr<IActWriter>>& acts)
@@ -50673,6 +53061,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void StoryImpl::ResetParameterDeclarations()
+	   {
+	   		isSetParameterDeclarations = false; 
+			_parameterDeclarations = {};
+			
+	   }
+       bool StoryImpl::IsSetParameterDeclarations() const
+	   {
+			return isSetParameterDeclarations;
+	   }
 
         IOpenScenarioFlexElement* StoryboardImpl::GetOpenScenarioFlexElement()
         {
@@ -51682,6 +54080,8 @@ namespace NET_ASAM_OPENSCENARIO
         void SynchronizeActionImpl::SetFinalSpeed(std::shared_ptr<IFinalSpeedWriter> finalSpeed)
         {
             _finalSpeed = finalSpeed;
+			// set the indicator to true
+            isSetFinalSpeed = true;          
         }
 
         std::shared_ptr<void> SynchronizeActionImpl::GetAdapter(const std::string classifier)
@@ -52070,6 +54470,16 @@ namespace NET_ASAM_OPENSCENARIO
        bool SynchronizeActionImpl::IsSetTargetToleranceMaster() const
 	   {
 			return isSetTargetToleranceMaster;
+	   }
+       void SynchronizeActionImpl::ResetFinalSpeed()
+	   {
+	   		isSetFinalSpeed = false; 
+			_finalSpeed = {};
+			
+	   }
+       bool SynchronizeActionImpl::IsSetFinalSpeed() const
+	   {
+			return isSetFinalSpeed;
 	   }
 
         IOpenScenarioFlexElement* TargetDistanceSteadyStateImpl::GetOpenScenarioFlexElement()
@@ -52735,6 +55145,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _coordinateSystem = coordinateSystem;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM);
+			// set the indicator to true
+            isSetCoordinateSystem = true;          
         }
 
         void TimeHeadwayConditionImpl::SetEntityRef(std::shared_ptr<INamedReference<IEntity>> entityRef)
@@ -52753,6 +55165,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _relativeDistanceType = relativeDistanceType;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__RELATIVE_DISTANCE_TYPE);
+			// set the indicator to true
+            isSetRelativeDistanceType = true;          
         }
 
         void TimeHeadwayConditionImpl::SetRule(const Rule rule)
@@ -53166,6 +55580,8 @@ namespace NET_ASAM_OPENSCENARIO
             clonedObject->_value = GetValue();
             // clone indicators
             	clonedObject->isSetAlongRoute = isSetAlongRoute;
+            	clonedObject->isSetCoordinateSystem = isSetCoordinateSystem;
+            	clonedObject->isSetRelativeDistanceType = isSetRelativeDistanceType;
             // clone children
             return clonedObject;
         }
@@ -53274,6 +55690,26 @@ namespace NET_ASAM_OPENSCENARIO
        bool TimeHeadwayConditionImpl::IsSetAlongRoute() const
 	   {
 			return isSetAlongRoute;
+	   }
+       void TimeHeadwayConditionImpl::ResetCoordinateSystem()
+	   {
+	   		isSetCoordinateSystem = false; 
+			_coordinateSystem = {CoordinateSystem::CoordinateSystemEnum::ENTITY};
+			
+	   }
+       bool TimeHeadwayConditionImpl::IsSetCoordinateSystem() const
+	   {
+			return isSetCoordinateSystem;
+	   }
+       void TimeHeadwayConditionImpl::ResetRelativeDistanceType()
+	   {
+	   		isSetRelativeDistanceType = false; 
+			_relativeDistanceType = {RelativeDistanceType::RelativeDistanceTypeEnum::EUCLIDIAN_DISTANCE};
+			
+	   }
+       bool TimeHeadwayConditionImpl::IsSetRelativeDistanceType() const
+	   {
+			return isSetRelativeDistanceType;
 	   }
 
         IOpenScenarioFlexElement* TimeOfDayImpl::GetOpenScenarioFlexElement()
@@ -53846,12 +56282,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _none = none;
             _timing = {};
+			// set the indicator to true
+            isSetNone = true;          
         }
 
         void TimeReferenceImpl::SetTiming(std::shared_ptr<ITimingWriter> timing)
         {
             _timing = timing;
             _none = {};
+			// set the indicator to true
+            isSetTiming = true;          
         }
 
         std::shared_ptr<void> TimeReferenceImpl::GetAdapter(const std::string classifier)
@@ -54049,6 +56489,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void TimeReferenceImpl::ResetNone()
+	   {
+	   		isSetNone = false; 
+			_none = {};
+			
+	   }
+       bool TimeReferenceImpl::IsSetNone() const
+	   {
+			return isSetNone;
+	   }
+       void TimeReferenceImpl::ResetTiming()
+	   {
+	   		isSetTiming = false; 
+			_timing = {};
+			
+	   }
+       bool TimeReferenceImpl::IsSetTiming() const
+	   {
+			return isSetTiming;
+	   }
 
         IOpenScenarioFlexElement* TimeToCollisionConditionImpl::GetOpenScenarioFlexElement()
         {
@@ -54096,6 +56556,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _coordinateSystem = coordinateSystem;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM);
+			// set the indicator to true
+            isSetCoordinateSystem = true;          
         }
 
         void TimeToCollisionConditionImpl::SetFreespace(const bool freespace)
@@ -54108,6 +56570,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _relativeDistanceType = relativeDistanceType;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__RELATIVE_DISTANCE_TYPE);
+			// set the indicator to true
+            isSetRelativeDistanceType = true;          
         }
 
         void TimeToCollisionConditionImpl::SetRule(const Rule rule)
@@ -54500,6 +56964,8 @@ namespace NET_ASAM_OPENSCENARIO
             clonedObject->_value = GetValue();
             // clone indicators
             	clonedObject->isSetAlongRoute = isSetAlongRoute;
+            	clonedObject->isSetCoordinateSystem = isSetCoordinateSystem;
+            	clonedObject->isSetRelativeDistanceType = isSetRelativeDistanceType;
             // clone children
             const auto kTimeToCollisionConditionTarget =  GetWriterTimeToCollisionConditionTarget();
             if (kTimeToCollisionConditionTarget)
@@ -54604,6 +57070,26 @@ namespace NET_ASAM_OPENSCENARIO
 	   {
 			return isSetAlongRoute;
 	   }
+       void TimeToCollisionConditionImpl::ResetCoordinateSystem()
+	   {
+	   		isSetCoordinateSystem = false; 
+			_coordinateSystem = {CoordinateSystem::CoordinateSystemEnum::ENTITY};
+			
+	   }
+       bool TimeToCollisionConditionImpl::IsSetCoordinateSystem() const
+	   {
+			return isSetCoordinateSystem;
+	   }
+       void TimeToCollisionConditionImpl::ResetRelativeDistanceType()
+	   {
+	   		isSetRelativeDistanceType = false; 
+			_relativeDistanceType = {RelativeDistanceType::RelativeDistanceTypeEnum::EUCLIDIAN_DISTANCE};
+			
+	   }
+       bool TimeToCollisionConditionImpl::IsSetRelativeDistanceType() const
+	   {
+			return isSetRelativeDistanceType;
+	   }
 
         IOpenScenarioFlexElement* TimeToCollisionConditionTargetImpl::GetOpenScenarioFlexElement()
         {
@@ -54623,12 +57109,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _position = position;
             _entityRef = {};
+			// set the indicator to true
+            isSetPosition = true;          
         }
 
         void TimeToCollisionConditionTargetImpl::SetEntityRef(std::shared_ptr<IEntityRefWriter> entityRef)
         {
             _entityRef = entityRef;
             _position = {};
+			// set the indicator to true
+            isSetEntityRef = true;          
         }
 
         std::shared_ptr<void> TimeToCollisionConditionTargetImpl::GetAdapter(const std::string classifier)
@@ -54826,6 +57316,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void TimeToCollisionConditionTargetImpl::ResetPosition()
+	   {
+	   		isSetPosition = false; 
+			_position = {};
+			
+	   }
+       bool TimeToCollisionConditionTargetImpl::IsSetPosition() const
+	   {
+			return isSetPosition;
+	   }
+       void TimeToCollisionConditionTargetImpl::ResetEntityRef()
+	   {
+	   		isSetEntityRef = false; 
+			_entityRef = {};
+			
+	   }
+       bool TimeToCollisionConditionTargetImpl::IsSetEntityRef() const
+	   {
+			return isSetEntityRef;
+	   }
 
         IOpenScenarioFlexElement* TimingImpl::GetOpenScenarioFlexElement()
         {
@@ -55196,6 +57706,8 @@ namespace NET_ASAM_OPENSCENARIO
             _trafficSinkAction = {};
             _trafficSwarmAction = {};
             _trafficStopAction = {};
+			// set the indicator to true
+            isSetTrafficSourceAction = true;          
         }
 
         void TrafficActionImpl::SetTrafficSinkAction(std::shared_ptr<ITrafficSinkActionWriter> trafficSinkAction)
@@ -55204,6 +57716,8 @@ namespace NET_ASAM_OPENSCENARIO
             _trafficSourceAction = {};
             _trafficSwarmAction = {};
             _trafficStopAction = {};
+			// set the indicator to true
+            isSetTrafficSinkAction = true;          
         }
 
         void TrafficActionImpl::SetTrafficSwarmAction(std::shared_ptr<ITrafficSwarmActionWriter> trafficSwarmAction)
@@ -55212,6 +57726,8 @@ namespace NET_ASAM_OPENSCENARIO
             _trafficSourceAction = {};
             _trafficSinkAction = {};
             _trafficStopAction = {};
+			// set the indicator to true
+            isSetTrafficSwarmAction = true;          
         }
 
         void TrafficActionImpl::SetTrafficStopAction(std::shared_ptr<ITrafficStopActionWriter> trafficStopAction)
@@ -55220,6 +57736,8 @@ namespace NET_ASAM_OPENSCENARIO
             _trafficSourceAction = {};
             _trafficSinkAction = {};
             _trafficSwarmAction = {};
+			// set the indicator to true
+            isSetTrafficStopAction = true;          
         }
 
         std::shared_ptr<void> TrafficActionImpl::GetAdapter(const std::string classifier)
@@ -55522,6 +58040,46 @@ namespace NET_ASAM_OPENSCENARIO
 	   {
 			return isSetTrafficName;
 	   }
+       void TrafficActionImpl::ResetTrafficSourceAction()
+	   {
+	   		isSetTrafficSourceAction = false; 
+			_trafficSourceAction = {};
+			
+	   }
+       bool TrafficActionImpl::IsSetTrafficSourceAction() const
+	   {
+			return isSetTrafficSourceAction;
+	   }
+       void TrafficActionImpl::ResetTrafficSinkAction()
+	   {
+	   		isSetTrafficSinkAction = false; 
+			_trafficSinkAction = {};
+			
+	   }
+       bool TrafficActionImpl::IsSetTrafficSinkAction() const
+	   {
+			return isSetTrafficSinkAction;
+	   }
+       void TrafficActionImpl::ResetTrafficSwarmAction()
+	   {
+	   		isSetTrafficSwarmAction = false; 
+			_trafficSwarmAction = {};
+			
+	   }
+       bool TrafficActionImpl::IsSetTrafficSwarmAction() const
+	   {
+			return isSetTrafficSwarmAction;
+	   }
+       void TrafficActionImpl::ResetTrafficStopAction()
+	   {
+	   		isSetTrafficStopAction = false; 
+			_trafficStopAction = {};
+			
+	   }
+       bool TrafficActionImpl::IsSetTrafficStopAction() const
+	   {
+			return isSetTrafficStopAction;
+	   }
 
         IOpenScenarioFlexElement* TrafficDefinitionImpl::GetOpenScenarioFlexElement()
         {
@@ -55821,12 +58379,16 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _trafficSignalControllerAction = trafficSignalControllerAction;
             _trafficSignalStateAction = {};
+			// set the indicator to true
+            isSetTrafficSignalControllerAction = true;          
         }
 
         void TrafficSignalActionImpl::SetTrafficSignalStateAction(std::shared_ptr<ITrafficSignalStateActionWriter> trafficSignalStateAction)
         {
             _trafficSignalStateAction = trafficSignalStateAction;
             _trafficSignalControllerAction = {};
+			// set the indicator to true
+            isSetTrafficSignalStateAction = true;          
         }
 
         std::shared_ptr<void> TrafficSignalActionImpl::GetAdapter(const std::string classifier)
@@ -56024,6 +58586,26 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void TrafficSignalActionImpl::ResetTrafficSignalControllerAction()
+	   {
+	   		isSetTrafficSignalControllerAction = false; 
+			_trafficSignalControllerAction = {};
+			
+	   }
+       bool TrafficSignalActionImpl::IsSetTrafficSignalControllerAction() const
+	   {
+			return isSetTrafficSignalControllerAction;
+	   }
+       void TrafficSignalActionImpl::ResetTrafficSignalStateAction()
+	   {
+	   		isSetTrafficSignalStateAction = false; 
+			_trafficSignalStateAction = {};
+			
+	   }
+       bool TrafficSignalActionImpl::IsSetTrafficSignalStateAction() const
+	   {
+			return isSetTrafficSignalStateAction;
+	   }
 
         IOpenScenarioFlexElement* TrafficSignalConditionImpl::GetOpenScenarioFlexElement()
         {
@@ -56338,6 +58920,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _delay = delay;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__DELAY);
+			// set the indicator to true
+            isSetDelay = true;          
         }
 
         void TrafficSignalControllerImpl::SetName(const std::string name)
@@ -56357,6 +58941,8 @@ namespace NET_ASAM_OPENSCENARIO
         void TrafficSignalControllerImpl::SetPhases(std::vector<std::shared_ptr<IPhaseWriter>>& phases)
         {
             _phases = phases;
+			// set the indicator to true
+            isSetPhases = true;          
         }
 
         std::shared_ptr<void> TrafficSignalControllerImpl::GetAdapter(const std::string classifier)
@@ -56585,6 +59171,7 @@ namespace NET_ASAM_OPENSCENARIO
             // Simple type
             clonedObject->_reference = GetReference();
             // clone indicators
+            	clonedObject->isSetDelay = isSetDelay;
             	clonedObject->isSetReference = isSetReference;
             // clone children
             const auto kPhases =  GetWriterPhases();
@@ -56682,6 +59269,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void TrafficSignalControllerImpl::ResetDelay()
+	   {
+	   		isSetDelay = false; 
+			_delay = {0};
+			
+	   }
+       bool TrafficSignalControllerImpl::IsSetDelay() const
+	   {
+			return isSetDelay;
+	   }
        void TrafficSignalControllerImpl::ResetReference()
 	   {
 	   		isSetReference = false; 
@@ -56691,6 +59288,16 @@ namespace NET_ASAM_OPENSCENARIO
        bool TrafficSignalControllerImpl::IsSetReference() const
 	   {
 			return isSetReference;
+	   }
+       void TrafficSignalControllerImpl::ResetPhases()
+	   {
+	   		isSetPhases = false; 
+			_phases = {};
+			
+	   }
+       bool TrafficSignalControllerImpl::IsSetPhases() const
+	   {
+			return isSetPhases;
 	   }
 
         IOpenScenarioFlexElement* TrafficSignalControllerActionImpl::GetOpenScenarioFlexElement()
@@ -56743,6 +59350,8 @@ namespace NET_ASAM_OPENSCENARIO
         void TrafficSignalControllerActionImpl::SetPhaseRef(std::vector<std::shared_ptr<IPhase>>& phaseRef)
         {
             _phaseRef = phaseRef;
+			// set the indicator to true
+            isSetPhaseRef = true;          
         }
 
         std::shared_ptr<void> TrafficSignalControllerActionImpl::GetAdapter(const std::string classifier)
@@ -56995,6 +59604,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void TrafficSignalControllerActionImpl::ResetPhaseRef()
+	   {
+	   		isSetPhaseRef = false; 
+			_phaseRef = {};
+			
+	   }
+       bool TrafficSignalControllerActionImpl::IsSetPhaseRef() const
+	   {
+			return isSetPhaseRef;
+	   }
 
         IOpenScenarioFlexElement* TrafficSignalControllerConditionImpl::GetOpenScenarioFlexElement()
         {
@@ -57046,6 +59665,8 @@ namespace NET_ASAM_OPENSCENARIO
         void TrafficSignalControllerConditionImpl::SetPhaseRef(std::vector<std::shared_ptr<IPhase>>& phaseRef)
         {
             _phaseRef = phaseRef;
+			// set the indicator to true
+            isSetPhaseRef = true;          
         }
 
         std::shared_ptr<void> TrafficSignalControllerConditionImpl::GetAdapter(const std::string classifier)
@@ -57298,6 +59919,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void TrafficSignalControllerConditionImpl::ResetPhaseRef()
+	   {
+	   		isSetPhaseRef = false; 
+			_phaseRef = {};
+			
+	   }
+       bool TrafficSignalControllerConditionImpl::IsSetPhaseRef() const
+	   {
+			return isSetPhaseRef;
+	   }
 
         IOpenScenarioFlexElement* TrafficSignalStateImpl::GetOpenScenarioFlexElement()
         {
@@ -57875,6 +60506,8 @@ namespace NET_ASAM_OPENSCENARIO
         void TrafficSinkActionImpl::SetTrafficDefinition(std::shared_ptr<ITrafficDefinitionWriter> trafficDefinition)
         {
             _trafficDefinition = trafficDefinition;
+			// set the indicator to true
+            isSetTrafficDefinition = true;          
         }
 
         std::shared_ptr<void> TrafficSinkActionImpl::GetAdapter(const std::string classifier)
@@ -58174,6 +60807,16 @@ namespace NET_ASAM_OPENSCENARIO
 	   {
 			return isSetRate;
 	   }
+       void TrafficSinkActionImpl::ResetTrafficDefinition()
+	   {
+	   		isSetTrafficDefinition = false; 
+			_trafficDefinition = {};
+			
+	   }
+       bool TrafficSinkActionImpl::IsSetTrafficDefinition() const
+	   {
+			return isSetTrafficDefinition;
+	   }
 
         IOpenScenarioFlexElement* TrafficSourceActionImpl::GetOpenScenarioFlexElement()
         {
@@ -58217,6 +60860,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _velocity = velocity;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__VELOCITY);
+			// set the indicator to true
+            isSetVelocity = true;          
         }
 
         void TrafficSourceActionImpl::SetPosition(std::shared_ptr<IPositionWriter> position)
@@ -58473,6 +61118,7 @@ namespace NET_ASAM_OPENSCENARIO
             // Simple type
             clonedObject->_velocity = GetVelocity();
             // clone indicators
+            	clonedObject->isSetVelocity = isSetVelocity;
             // clone children
             const auto kPosition =  GetWriterPosition();
             if (kPosition)
@@ -58556,6 +61202,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void TrafficSourceActionImpl::ResetVelocity()
+	   {
+	   		isSetVelocity = false; 
+			_velocity = {0};
+			
+	   }
+       bool TrafficSourceActionImpl::IsSetVelocity() const
+	   {
+			return isSetVelocity;
+	   }
 
         IOpenScenarioFlexElement* TrafficStopActionImpl::GetOpenScenarioFlexElement()
         {
@@ -58783,6 +61439,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _velocity = velocity;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__VELOCITY);
+			// set the indicator to true
+            isSetVelocity = true;          
         }
 
         void TrafficSwarmActionImpl::SetCentralObject(std::shared_ptr<ICentralSwarmObjectWriter> centralObject)
@@ -59149,6 +61807,7 @@ namespace NET_ASAM_OPENSCENARIO
             // Simple type
             clonedObject->_velocity = GetVelocity();
             // clone indicators
+            	clonedObject->isSetVelocity = isSetVelocity;
             // clone children
             const auto kCentralObject =  GetWriterCentralObject();
             if (kCentralObject)
@@ -59254,6 +61913,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void TrafficSwarmActionImpl::ResetVelocity()
+	   {
+	   		isSetVelocity = false; 
+			_velocity = {0};
+			
+	   }
+       bool TrafficSwarmActionImpl::IsSetVelocity() const
+	   {
+			return isSetVelocity;
+	   }
 
         IOpenScenarioFlexElement* TrajectoryImpl::GetOpenScenarioFlexElement()
         {
@@ -59313,6 +61982,8 @@ namespace NET_ASAM_OPENSCENARIO
         void TrajectoryImpl::SetParameterDeclarations(std::vector<std::shared_ptr<IParameterDeclarationWriter>>& parameterDeclarations)
         {
             _parameterDeclarations = parameterDeclarations;
+			// set the indicator to true
+            isSetParameterDeclarations = true;          
         }
 
         void TrajectoryImpl::SetShape(std::shared_ptr<IShapeWriter> shape)
@@ -59645,6 +62316,16 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void TrajectoryImpl::ResetParameterDeclarations()
+	   {
+	   		isSetParameterDeclarations = false; 
+			_parameterDeclarations = {};
+			
+	   }
+       bool TrajectoryImpl::IsSetParameterDeclarations() const
+	   {
+			return isSetParameterDeclarations;
+	   }
 
         IOpenScenarioFlexElement* TrajectoryCatalogLocationImpl::GetOpenScenarioFlexElement()
         {
@@ -60085,11 +62766,15 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _t = t;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__T);
+			// set the indicator to true
+            isSetT = true;          
         }
 
         void TrajectoryPositionImpl::SetOrientation(std::shared_ptr<IOrientationWriter> orientation)
         {
             _orientation = orientation;
+			// set the indicator to true
+            isSetOrientation = true;          
         }
 
         void TrajectoryPositionImpl::SetTrajectoryRef(std::shared_ptr<ITrajectoryRefWriter> trajectoryRef)
@@ -60306,6 +62991,7 @@ namespace NET_ASAM_OPENSCENARIO
             // Simple type
             clonedObject->_t = GetT();
             // clone indicators
+            	clonedObject->isSetT = isSetT;
             // clone children
             const auto kOrientation =  GetWriterOrientation();
             if (kOrientation)
@@ -60383,6 +63069,26 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void TrajectoryPositionImpl::ResetT()
+	   {
+	   		isSetT = false; 
+			_t = {0};
+			
+	   }
+       bool TrajectoryPositionImpl::IsSetT() const
+	   {
+			return isSetT;
+	   }
+       void TrajectoryPositionImpl::ResetOrientation()
+	   {
+	   		isSetOrientation = false; 
+			_orientation = {};
+			
+	   }
+       bool TrajectoryPositionImpl::IsSetOrientation() const
+	   {
+			return isSetOrientation;
+	   }
 
         IOpenScenarioFlexElement* TrajectoryRefImpl::GetOpenScenarioFlexElement()
         {
@@ -61191,6 +63897,8 @@ namespace NET_ASAM_OPENSCENARIO
         void TriggerImpl::SetConditionGroups(std::vector<std::shared_ptr<IConditionGroupWriter>>& conditionGroups)
         {
             _conditionGroups = conditionGroups;
+			// set the indicator to true
+            isSetConditionGroups = true;          
         }
 
         std::shared_ptr<void> TriggerImpl::GetAdapter(const std::string classifier)
@@ -61373,6 +64081,16 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
 
+       void TriggerImpl::ResetConditionGroups()
+	   {
+	   		isSetConditionGroups = false; 
+			_conditionGroups = {};
+			
+	   }
+       bool TriggerImpl::IsSetConditionGroups() const
+	   {
+			return isSetConditionGroups;
+	   }
 
         IOpenScenarioFlexElement* TriggeringEntitiesImpl::GetOpenScenarioFlexElement()
         {
@@ -63654,6 +66372,8 @@ namespace NET_ASAM_OPENSCENARIO
         void VehicleImpl::SetParameterDeclarations(std::vector<std::shared_ptr<IParameterDeclarationWriter>>& parameterDeclarations)
         {
             _parameterDeclarations = parameterDeclarations;
+			// set the indicator to true
+            isSetParameterDeclarations = true;          
         }
 
         void VehicleImpl::SetBoundingBox(std::shared_ptr<IBoundingBoxWriter> boundingBox)
@@ -64184,6 +66904,16 @@ namespace NET_ASAM_OPENSCENARIO
        bool VehicleImpl::IsSetModel3d() const
 	   {
 			return isSetModel3d;
+	   }
+       void VehicleImpl::ResetParameterDeclarations()
+	   {
+	   		isSetParameterDeclarations = false; 
+			_parameterDeclarations = {};
+			
+	   }
+       bool VehicleImpl::IsSetParameterDeclarations() const
+	   {
+			return isSetParameterDeclarations;
 	   }
 
         IOpenScenarioFlexElement* VehicleCatalogLocationImpl::GetOpenScenarioFlexElement()
@@ -65762,21 +68492,29 @@ namespace NET_ASAM_OPENSCENARIO
         void WeatherImpl::SetSun(std::shared_ptr<ISunWriter> sun)
         {
             _sun = sun;
+			// set the indicator to true
+            isSetSun = true;          
         }
 
         void WeatherImpl::SetFog(std::shared_ptr<IFogWriter> fog)
         {
             _fog = fog;
+			// set the indicator to true
+            isSetFog = true;          
         }
 
         void WeatherImpl::SetPrecipitation(std::shared_ptr<IPrecipitationWriter> precipitation)
         {
             _precipitation = precipitation;
+			// set the indicator to true
+            isSetPrecipitation = true;          
         }
 
         void WeatherImpl::SetWind(std::shared_ptr<IWindWriter> wind)
         {
             _wind = wind;
+			// set the indicator to true
+            isSetWind = true;          
         }
 
         std::shared_ptr<void> WeatherImpl::GetAdapter(const std::string classifier)
@@ -66196,6 +68934,46 @@ namespace NET_ASAM_OPENSCENARIO
 	   {
 			return isSetTemperature;
 	   }
+       void WeatherImpl::ResetSun()
+	   {
+	   		isSetSun = false; 
+			_sun = {};
+			
+	   }
+       bool WeatherImpl::IsSetSun() const
+	   {
+			return isSetSun;
+	   }
+       void WeatherImpl::ResetFog()
+	   {
+	   		isSetFog = false; 
+			_fog = {};
+			
+	   }
+       bool WeatherImpl::IsSetFog() const
+	   {
+			return isSetFog;
+	   }
+       void WeatherImpl::ResetPrecipitation()
+	   {
+	   		isSetPrecipitation = false; 
+			_precipitation = {};
+			
+	   }
+       bool WeatherImpl::IsSetPrecipitation() const
+	   {
+			return isSetPrecipitation;
+	   }
+       void WeatherImpl::ResetWind()
+	   {
+	   		isSetWind = false; 
+			_wind = {};
+			
+	   }
+       bool WeatherImpl::IsSetWind() const
+	   {
+			return isSetWind;
+	   }
 
         IOpenScenarioFlexElement* WindImpl::GetOpenScenarioFlexElement()
         {
@@ -66496,18 +69274,24 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _h = h;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__H);
+			// set the indicator to true
+            isSetH = true;          
         }
 
         void WorldPositionImpl::SetP(const double p)
         {
             _p = p;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__P);
+			// set the indicator to true
+            isSetP = true;          
         }
 
         void WorldPositionImpl::SetR(const double r)
         {
             _r = r;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__R);
+			// set the indicator to true
+            isSetR = true;          
         }
 
         void WorldPositionImpl::SetX(const double x)
@@ -66526,6 +69310,8 @@ namespace NET_ASAM_OPENSCENARIO
         {
             _z = z;
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__Z);
+			// set the indicator to true
+            isSetZ = true;          
         }
 
         std::shared_ptr<void> WorldPositionImpl::GetAdapter(const std::string classifier)
@@ -66859,6 +69645,10 @@ namespace NET_ASAM_OPENSCENARIO
             // Simple type
             clonedObject->_z = GetZ();
             // clone indicators
+            	clonedObject->isSetH = isSetH;
+            	clonedObject->isSetP = isSetP;
+            	clonedObject->isSetR = isSetR;
+            	clonedObject->isSetZ = isSetZ;
             // clone children
             return clonedObject;
         }
@@ -66930,6 +69720,46 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 
 
+       void WorldPositionImpl::ResetH()
+	   {
+	   		isSetH = false; 
+			_h = {0};
+			
+	   }
+       bool WorldPositionImpl::IsSetH() const
+	   {
+			return isSetH;
+	   }
+       void WorldPositionImpl::ResetP()
+	   {
+	   		isSetP = false; 
+			_p = {0};
+			
+	   }
+       bool WorldPositionImpl::IsSetP() const
+	   {
+			return isSetP;
+	   }
+       void WorldPositionImpl::ResetR()
+	   {
+	   		isSetR = false; 
+			_r = {0};
+			
+	   }
+       bool WorldPositionImpl::IsSetR() const
+	   {
+			return isSetR;
+	   }
+       void WorldPositionImpl::ResetZ()
+	   {
+	   		isSetZ = false; 
+			_z = {0};
+			
+	   }
+       bool WorldPositionImpl::IsSetZ() const
+	   {
+			return isSetZ;
+	   }
     }
 }
 

--- a/cpp/openScenarioLib/generated/v1_1/impl/ApiClassImplV1_1.h
+++ b/cpp/openScenarioLib/generated/v1_1/impl/ApiClassImplV1_1.h
@@ -65,6 +65,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetValue() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ISteadyState> GetSteadyState() const override;
 
+    bool isSetSteadyState = false;          
 
 
             OPENSCENARIOLIB_EXP void SetValue(const double value) override;
@@ -128,6 +129,8 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<ISteadyStateWriter> GetWriterSteadyState() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetSteadyState() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetSteadyState() const override;          
         };
 
         /**
@@ -622,6 +625,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrigger> GetStartTrigger() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrigger> GetStopTrigger() const override;
 
+    bool isSetStopTrigger = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -690,6 +694,8 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<ITriggerWriter> GetWriterStartTrigger() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITriggerWriter> GetWriterStopTrigger() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetStopTrigger() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetStopTrigger() const override;          
         };
 
         /**
@@ -726,6 +732,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IUserDefinedAction> GetUserDefinedAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPrivateAction> GetPrivateAction() const override;
 
+    bool isSetGlobalAction = false;          
+    bool isSetUserDefinedAction = false;          
+    bool isSetPrivateAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -795,6 +804,12 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IGlobalActionWriter> GetWriterGlobalAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IUserDefinedActionWriter> GetWriterUserDefinedAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPrivateActionWriter> GetWriterPrivateAction() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetGlobalAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetGlobalAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetUserDefinedAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetUserDefinedAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetPrivateAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetPrivateAction() const override;          
         };
 
         /**
@@ -827,8 +842,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool GetLateral() const override;
             OPENSCENARIOLIB_EXP bool GetLongitudinal() const override;
 
-            bool isSetLateral = false;          
-            bool isSetLongitudinal = false;          
+    bool isSetLateral = false;          
+    bool isSetLongitudinal = false;          
 
 
             OPENSCENARIOLIB_EXP void SetLateral(const bool lateral) override;
@@ -937,6 +952,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetEntityRefsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntityRef> GetEntityRefsAtIndex(unsigned int index) const override;
 
+    bool isSetEntityRefs = false;          
 
 
             OPENSCENARIOLIB_EXP void SetSelectTriggeringEntities(const bool selectTriggeringEntities) override;
@@ -999,6 +1015,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsSelectTriggeringEntitiesParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetEntityRefs() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetEntityRefs() const override;          
         };
 
         /**
@@ -1119,8 +1137,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IController> GetController() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReference> GetCatalogReference() const override;
 
-            bool isSetActivateLateral = false;          
-            bool isSetActivateLongitudinal = false;          
+    bool isSetActivateLateral = false;          
+    bool isSetActivateLongitudinal = false;          
+    bool isSetController = false;          
+    bool isSetCatalogReference = false;          
 
 
             OPENSCENARIOLIB_EXP void SetActivateLateral(const bool activateLateral) override;
@@ -1199,6 +1219,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP virtual bool IsSetActivateLateral() const override;          
             OPENSCENARIOLIB_EXP virtual void ResetActivateLongitudinal() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetActivateLongitudinal() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetController() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetController() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetCatalogReference() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCatalogReference() const override;          
         };
 
         /**
@@ -1230,6 +1254,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IRoute> GetRoute() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReference> GetCatalogReference() const override;
 
+    bool isSetRoute = false;          
+    bool isSetCatalogReference = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRoute(std::shared_ptr<IRouteWriter> route) override;
@@ -1288,6 +1314,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IRouteWriter> GetWriterRoute() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReferenceWriter> GetWriterCatalogReference() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetRoute() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRoute() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetCatalogReference() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCatalogReference() const override;          
         };
 
         /**
@@ -1455,6 +1485,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetAdditionalAxlesSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAxle> GetAdditionalAxlesAtIndex(unsigned int index) const override;
 
+    bool isSetAdditionalAxles = false;          
 
 
             OPENSCENARIOLIB_EXP void SetFrontAxle(std::shared_ptr<IAxleWriter> frontAxle) override;
@@ -1515,6 +1546,8 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IAxleWriter> GetWriterFrontAxle() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAxleWriter> GetWriterRearAxle() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetAdditionalAxles() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetAdditionalAxles() const override;          
         };
 
         /**
@@ -1912,6 +1945,13 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalCondition> GetTrafficSignalCondition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalControllerCondition> GetTrafficSignalControllerCondition() const override;
 
+    bool isSetParameterCondition = false;          
+    bool isSetTimeOfDayCondition = false;          
+    bool isSetSimulationTimeCondition = false;          
+    bool isSetStoryboardElementStateCondition = false;          
+    bool isSetUserDefinedValueCondition = false;          
+    bool isSetTrafficSignalCondition = false;          
+    bool isSetTrafficSignalControllerCondition = false;          
 
 
             OPENSCENARIOLIB_EXP void SetParameterCondition(std::shared_ptr<IParameterConditionWriter> parameterCondition) override;
@@ -1985,6 +2025,20 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IUserDefinedValueConditionWriter> GetWriterUserDefinedValueCondition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalConditionWriter> GetWriterTrafficSignalCondition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalControllerConditionWriter> GetWriterTrafficSignalControllerCondition() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetParameterCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetParameterCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTimeOfDayCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTimeOfDayCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetSimulationTimeCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetSimulationTimeCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetStoryboardElementStateCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetStoryboardElementStateCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetUserDefinedValueCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetUserDefinedValueCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrafficSignalCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrafficSignalCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrafficSignalControllerCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrafficSignalControllerCondition() const override;          
         };
 
         /**
@@ -2063,6 +2117,15 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetRoutesSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRoute> GetRoutesAtIndex(unsigned int index) const override;
 
+    bool isSetName = false;          
+    bool isSetVehicles = false;          
+    bool isSetControllers = false;          
+    bool isSetPedestrians = false;          
+    bool isSetMiscObjects = false;          
+    bool isSetEnvironments = false;          
+    bool isSetManeuvers = false;          
+    bool isSetTrajectories = false;          
+    bool isSetRoutes = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -2139,6 +2202,24 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsNameParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetName() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetName() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetVehicles() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetVehicles() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetControllers() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetControllers() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetPedestrians() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetPedestrians() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetMiscObjects() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetMiscObjects() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetEnvironments() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetEnvironments() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetManeuvers() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetManeuvers() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrajectories() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrajectories() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRoutes() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRoutes() const override;          
         };
 
         /**
@@ -2266,6 +2347,14 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryCatalogLocation> GetTrajectoryCatalog() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRouteCatalogLocation> GetRouteCatalog() const override;
 
+    bool isSetVehicleCatalog = false;          
+    bool isSetControllerCatalog = false;          
+    bool isSetPedestrianCatalog = false;          
+    bool isSetMiscObjectCatalog = false;          
+    bool isSetEnvironmentCatalog = false;          
+    bool isSetManeuverCatalog = false;          
+    bool isSetTrajectoryCatalog = false;          
+    bool isSetRouteCatalog = false;          
 
 
             OPENSCENARIOLIB_EXP void SetVehicleCatalog(std::shared_ptr<IVehicleCatalogLocationWriter> vehicleCatalog) override;
@@ -2342,6 +2431,22 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IManeuverCatalogLocationWriter> GetWriterManeuverCatalog() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryCatalogLocationWriter> GetWriterTrajectoryCatalog() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRouteCatalogLocationWriter> GetWriterRouteCatalog() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetVehicleCatalog() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetVehicleCatalog() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetControllerCatalog() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetControllerCatalog() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetPedestrianCatalog() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetPedestrianCatalog() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetMiscObjectCatalog() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetMiscObjectCatalog() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetEnvironmentCatalog() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetEnvironmentCatalog() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetManeuverCatalog() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetManeuverCatalog() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrajectoryCatalog() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrajectoryCatalog() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRouteCatalog() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRouteCatalog() const override;          
         };
 
         /**
@@ -2382,6 +2487,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterAssignment> GetParameterAssignmentsAtIndex(unsigned int index) const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogElement> GetRef() const override;
 
+    bool isSetParameterAssignments = false;          
 
 
             OPENSCENARIOLIB_EXP void SetCatalogName(const std::string catalogName) override;
@@ -2454,6 +2560,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsEntryNameParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetParameterAssignments() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetParameterAssignments() const override;          
         };
 
         /**
@@ -2695,10 +2803,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetStopTime() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetPosition() const override;
 
-            bool isSetCurvatureDot = false;          
-            bool isSetCurvaturePrime = false;          
-            bool isSetStartTime = false;          
-            bool isSetStopTime = false;          
+    bool isSetCurvatureDot = false;          
+    bool isSetCurvaturePrime = false;          
+    bool isSetStartTime = false;          
+    bool isSetStopTime = false;          
 
 
             OPENSCENARIOLIB_EXP void SetCurvature(const double curvature) override;
@@ -2841,6 +2949,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntityRef> GetEntityRef() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IByObjectType> GetByType() const override;
 
+    bool isSetEntityRef = false;          
+    bool isSetByType = false;          
 
 
             OPENSCENARIOLIB_EXP void SetEntityRef(std::shared_ptr<IEntityRefWriter> entityRef) override;
@@ -2899,6 +3009,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntityRefWriter> GetWriterEntityRef() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IByObjectTypeWriter> GetWriterByType() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetEntityRef() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetEntityRef() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetByType() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetByType() const override;          
         };
 
         /**
@@ -2938,6 +3052,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IByEntityCondition> GetByEntityCondition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IByValueCondition> GetByValueCondition() const override;
 
+    bool isSetByEntityCondition = false;          
+    bool isSetByValueCondition = false;          
 
 
             OPENSCENARIOLIB_EXP void SetConditionEdge(const ConditionEdge conditionEdge) override;
@@ -3020,6 +3136,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IByEntityConditionWriter> GetWriterByEntityCondition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IByValueConditionWriter> GetWriterByValueCondition() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetByEntityCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetByEntityCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetByValueCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetByValueCondition() const override;          
         };
 
         /**
@@ -3141,8 +3261,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetWeight() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetPosition() const override;
 
-            bool isSetTime = false;          
-            bool isSetWeight = false;          
+    bool isSetTime = false;          
+    bool isSetWeight = false;          
 
 
             OPENSCENARIOLIB_EXP void SetTime(const double time) override;
@@ -3256,6 +3376,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterDeclaration> GetParameterDeclarationsAtIndex(unsigned int index) const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IProperties> GetProperties() const override;
 
+    bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -3323,6 +3444,8 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IPropertiesWriter> GetWriterProperties() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetParameterDeclarations() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetParameterDeclarations() const override;          
         };
 
         /**
@@ -3356,6 +3479,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IOverrideControllerValueAction> GetOverrideControllerValueAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IActivateControllerAction> GetActivateControllerAction() const override;
 
+    bool isSetAssignControllerAction = false;          
+    bool isSetOverrideControllerValueAction = false;          
+    bool isSetActivateControllerAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAssignControllerAction(std::shared_ptr<IAssignControllerActionWriter> assignControllerAction) override;
@@ -3417,6 +3543,12 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IAssignControllerActionWriter> GetWriterAssignControllerAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOverrideControllerValueActionWriter> GetWriterOverrideControllerValueAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IActivateControllerActionWriter> GetWriterActivateControllerAction() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetAssignControllerAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetAssignControllerAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetOverrideControllerValueAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetOverrideControllerValueAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetActivateControllerAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetActivateControllerAction() const override;          
         };
 
         /**
@@ -3622,6 +3754,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IController> GetController() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReference> GetCatalogReference() const override;
 
+    bool isSetController = false;          
+    bool isSetCatalogReference = false;          
 
 
             OPENSCENARIOLIB_EXP void SetWeight(const double weight) override;
@@ -3688,6 +3822,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IControllerWriter> GetWriterController() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReferenceWriter> GetWriterCatalogReference() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetController() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetController() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetCatalogReference() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCatalogReference() const override;          
         };
 
         /**
@@ -3900,6 +4038,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetDeterministicParameterDistributionsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IDeterministicParameterDistribution> GetDeterministicParameterDistributionsAtIndex(unsigned int index) const override;
 
+    bool isSetDeterministicParameterDistributions = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDeterministicParameterDistributions(std::vector<std::shared_ptr<IDeterministicParameterDistributionWriter>>& deterministicParameterDistributions) override;
@@ -3954,6 +4093,8 @@ namespace NET_ASAM_OPENSCENARIO
             std::string GetModelType() const override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetDeterministicParameterDistributions() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetDeterministicParameterDistributions() const override;          
         };
 
         /**
@@ -4643,7 +4784,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetValue() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetPosition() const override;
 
-            bool isSetAlongRoute = false;          
+    bool isSetAlongRoute = false;          
+    bool isSetCoordinateSystem = false;          
+    bool isSetRelativeDistanceType = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAlongRoute(const bool alongRoute) override;
@@ -4749,6 +4892,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPositionWriter> GetWriterPosition() const override;
             OPENSCENARIOLIB_EXP virtual void ResetAlongRoute() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetAlongRoute() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetCoordinateSystem() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCoordinateSystem() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRelativeDistanceType() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRelativeDistanceType() const override;          
         };
 
         /**
@@ -5144,9 +5291,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetMaxDeceleration() const override;
             OPENSCENARIOLIB_EXP double GetMaxSpeed() const override;
 
-            bool isSetMaxAcceleration = false;          
-            bool isSetMaxDeceleration = false;          
-            bool isSetMaxSpeed = false;          
+    bool isSetMaxAcceleration = false;          
+    bool isSetMaxDeceleration = false;          
+    bool isSetMaxSpeed = false;          
 
 
             OPENSCENARIOLIB_EXP void SetMaxAcceleration(const double maxAcceleration) override;
@@ -5358,6 +5505,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetEntitySelectionsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntitySelection> GetEntitySelectionsAtIndex(unsigned int index) const override;
 
+    bool isSetScenarioObjects = false;          
+    bool isSetEntitySelections = false;          
 
 
             OPENSCENARIOLIB_EXP void SetScenarioObjects(std::vector<std::shared_ptr<IScenarioObjectWriter>>& scenarioObjects) override;
@@ -5414,6 +5563,10 @@ namespace NET_ASAM_OPENSCENARIO
             std::string GetModelType() const override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetScenarioObjects() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetScenarioObjects() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetEntitySelections() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetEntitySelections() const override;          
         };
 
         /**
@@ -5447,6 +5600,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IAddEntityAction> GetAddEntityAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IDeleteEntityAction> GetDeleteEntityAction() const override;
 
+    bool isSetAddEntityAction = false;          
+    bool isSetDeleteEntityAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetEntityRef(std::shared_ptr<INamedReference<IEntity>> entityRef) override;
@@ -5513,6 +5668,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IAddEntityActionWriter> GetWriterAddEntityAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IDeleteEntityActionWriter> GetWriterDeleteEntityAction() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetAddEntityAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetAddEntityAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetDeleteEntityAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetDeleteEntityAction() const override;          
         };
 
         /**
@@ -5566,6 +5725,19 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IDistanceCondition> GetDistanceCondition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeDistanceCondition> GetRelativeDistanceCondition() const override;
 
+    bool isSetEndOfRoadCondition = false;          
+    bool isSetCollisionCondition = false;          
+    bool isSetOffroadCondition = false;          
+    bool isSetTimeHeadwayCondition = false;          
+    bool isSetTimeToCollisionCondition = false;          
+    bool isSetAccelerationCondition = false;          
+    bool isSetStandStillCondition = false;          
+    bool isSetSpeedCondition = false;          
+    bool isSetRelativeSpeedCondition = false;          
+    bool isSetTraveledDistanceCondition = false;          
+    bool isSetReachPositionCondition = false;          
+    bool isSetDistanceCondition = false;          
+    bool isSetRelativeDistanceCondition = false;          
 
 
             OPENSCENARIOLIB_EXP void SetEndOfRoadCondition(std::shared_ptr<IEndOfRoadConditionWriter> endOfRoadCondition) override;
@@ -5657,6 +5829,32 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IReachPositionConditionWriter> GetWriterReachPositionCondition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IDistanceConditionWriter> GetWriterDistanceCondition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeDistanceConditionWriter> GetWriterRelativeDistanceCondition() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetEndOfRoadCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetEndOfRoadCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetCollisionCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCollisionCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetOffroadCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetOffroadCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTimeHeadwayCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTimeHeadwayCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTimeToCollisionCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTimeToCollisionCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetAccelerationCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetAccelerationCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetStandStillCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetStandStillCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetSpeedCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetSpeedCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRelativeSpeedCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRelativeSpeedCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTraveledDistanceCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTraveledDistanceCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetReachPositionCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetReachPositionCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetDistanceCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetDistanceCondition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRelativeDistanceCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRelativeDistanceCondition() const override;          
         };
 
         /**
@@ -5694,6 +5892,11 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IMiscObject> GetMiscObject() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IExternalObjectReference> GetExternalObjectReference() const override;
 
+    bool isSetCatalogReference = false;          
+    bool isSetVehicle = false;          
+    bool isSetPedestrian = false;          
+    bool isSetMiscObject = false;          
+    bool isSetExternalObjectReference = false;          
 
 
             OPENSCENARIOLIB_EXP void SetCatalogReference(std::shared_ptr<ICatalogReferenceWriter> catalogReference) override;
@@ -5761,6 +5964,16 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPedestrianWriter> GetWriterPedestrian() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IMiscObjectWriter> GetWriterMiscObject() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IExternalObjectReferenceWriter> GetWriterExternalObjectReference() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetCatalogReference() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCatalogReference() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetVehicle() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetVehicle() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetPedestrian() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetPedestrian() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetMiscObject() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetMiscObject() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetExternalObjectReference() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetExternalObjectReference() const override;          
         };
 
         /**
@@ -5987,6 +6200,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IWeather> GetWeather() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRoadCondition> GetRoadCondition() const override;
 
+    bool isSetParameterDeclarations = false;          
+    bool isSetTimeOfDay = false;          
+    bool isSetWeather = false;          
+    bool isSetRoadCondition = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -6060,6 +6277,14 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITimeOfDayWriter> GetWriterTimeOfDay() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IWeatherWriter> GetWriterWeather() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRoadConditionWriter> GetWriterRoadCondition() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetParameterDeclarations() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetParameterDeclarations() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTimeOfDay() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTimeOfDay() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetWeather() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetWeather() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRoadCondition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRoadCondition() const override;          
         };
 
         /**
@@ -6091,6 +6316,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IEnvironment> GetEnvironment() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReference> GetCatalogReference() const override;
 
+    bool isSetEnvironment = false;          
+    bool isSetCatalogReference = false;          
 
 
             OPENSCENARIOLIB_EXP void SetEnvironment(std::shared_ptr<IEnvironmentWriter> environment) override;
@@ -6149,6 +6376,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IEnvironmentWriter> GetWriterEnvironment() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReferenceWriter> GetWriterCatalogReference() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetEnvironment() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetEnvironment() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetCatalogReference() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCatalogReference() const override;          
         };
 
         /**
@@ -6276,6 +6507,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IAction> GetActionsAtIndex(unsigned int index) const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrigger> GetStartTrigger() const override;
 
+    bool isSetMaximumExecutionCount = false;          
+    bool isSetStartTrigger = false;          
 
 
             OPENSCENARIOLIB_EXP void SetMaximumExecutionCount(const uint32_t maximumExecutionCount) override;
@@ -6357,6 +6590,10 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<ITriggerWriter> GetWriterStartTrigger() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetMaximumExecutionCount() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetMaximumExecutionCount() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetStartTrigger() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetStartTrigger() const override;          
         };
 
         /**
@@ -6579,6 +6816,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP uint16_t GetRevMinor() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ILicense> GetLicense() const override;
 
+    bool isSetLicense = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAuthor(const std::string author) override;
@@ -6674,6 +6912,8 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<ILicenseWriter> GetWriterLicense() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetLicense() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetLicense() const override;          
         };
 
         /**
@@ -6705,6 +6945,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IAbsoluteSpeed> GetAbsoluteSpeed() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeSpeedToMaster> GetRelativeSpeedToMaster() const override;
 
+    bool isSetAbsoluteSpeed = false;          
+    bool isSetRelativeSpeedToMaster = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAbsoluteSpeed(std::shared_ptr<IAbsoluteSpeedWriter> absoluteSpeed) override;
@@ -6763,6 +7005,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IAbsoluteSpeedWriter> GetWriterAbsoluteSpeed() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeSpeedToMasterWriter> GetWriterRelativeSpeedToMaster() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetAbsoluteSpeed() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetAbsoluteSpeed() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRelativeSpeedToMaster() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRelativeSpeedToMaster() const override;          
         };
 
         /**
@@ -6795,6 +7041,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetVisualRange() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IBoundingBox> GetBoundingBox() const override;
 
+    bool isSetBoundingBox = false;          
 
 
             OPENSCENARIOLIB_EXP void SetVisualRange(const double visualRange) override;
@@ -6858,6 +7105,8 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IBoundingBoxWriter> GetWriterBoundingBox() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetBoundingBox() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetBoundingBox() const override;          
         };
 
         /**
@@ -6898,6 +7147,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryFollowingMode> GetTrajectoryFollowingMode() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryRef> GetTrajectoryRef() const override;
 
+    bool isSetInitialDistanceOffset = false;          
+    bool isSetTrajectory = false;          
+    bool isSetCatalogReference = false;          
+    bool isSetTrajectoryRef = false;          
 
 
             OPENSCENARIOLIB_EXP void SetInitialDistanceOffset(const double initialDistanceOffset) override;
@@ -6973,6 +7226,14 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITimeReferenceWriter> GetWriterTimeReference() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryFollowingModeWriter> GetWriterTrajectoryFollowingMode() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryRefWriter> GetWriterTrajectoryRef() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetInitialDistanceOffset() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetInitialDistanceOffset() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrajectory() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrajectory() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetCatalogReference() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCatalogReference() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrajectoryRef() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrajectoryRef() const override;          
         };
 
         /**
@@ -7009,6 +7270,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetLongitude() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
 
+    bool isSetHeight = false;          
+    bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetHeight(const double height) override;
@@ -7088,6 +7351,10 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientationWriter> GetWriterOrientation() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetHeight() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetHeight() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetOrientation() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetOrientation() const override;          
         };
 
         /**
@@ -7125,6 +7392,11 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IInfrastructureAction> GetInfrastructureAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficAction> GetTrafficAction() const override;
 
+    bool isSetEnvironmentAction = false;          
+    bool isSetEntityAction = false;          
+    bool isSetParameterAction = false;          
+    bool isSetInfrastructureAction = false;          
+    bool isSetTrafficAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetEnvironmentAction(std::shared_ptr<IEnvironmentActionWriter> environmentAction) override;
@@ -7192,6 +7464,16 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterActionWriter> GetWriterParameterAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IInfrastructureActionWriter> GetWriterInfrastructureAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficActionWriter> GetWriterTrafficAction() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetEnvironmentAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetEnvironmentAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetEntityAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetEntityAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetParameterAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetParameterAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetInfrastructureAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetInfrastructureAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrafficAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrafficAction() const override;          
         };
 
         /**
@@ -7407,6 +7689,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPositionInRoadCoordinates> GetFromRoadCoordinates() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPositionInLaneCoordinates> GetFromLaneCoordinates() const override;
 
+    bool isSetFromCurrentEntity = false;          
+    bool isSetFromRoadCoordinates = false;          
+    bool isSetFromLaneCoordinates = false;          
 
 
             OPENSCENARIOLIB_EXP void SetFromCurrentEntity(std::shared_ptr<IPositionOfCurrentEntityWriter> fromCurrentEntity) override;
@@ -7468,6 +7753,12 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPositionOfCurrentEntityWriter> GetWriterFromCurrentEntity() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPositionInRoadCoordinatesWriter> GetWriterFromRoadCoordinates() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPositionInLaneCoordinatesWriter> GetWriterFromLaneCoordinates() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetFromCurrentEntity() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetFromCurrentEntity() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetFromRoadCoordinates() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetFromRoadCoordinates() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetFromLaneCoordinates() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetFromLaneCoordinates() const override;          
         };
 
         /**
@@ -7681,6 +7972,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetPrivatesSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPrivate> GetPrivatesAtIndex(unsigned int index) const override;
 
+    bool isSetGlobalActions = false;          
+    bool isSetUserDefinedActions = false;          
+    bool isSetPrivates = false;          
 
 
             OPENSCENARIOLIB_EXP void SetGlobalActions(std::vector<std::shared_ptr<IGlobalActionWriter>>& globalActions) override;
@@ -7739,6 +8033,12 @@ namespace NET_ASAM_OPENSCENARIO
             std::string GetModelType() const override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetGlobalActions() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetGlobalActions() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetUserDefinedActions() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetUserDefinedActions() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetPrivates() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetPrivates() const override;          
         };
 
         /**
@@ -7863,6 +8163,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITransitionDynamics> GetLaneChangeActionDynamics() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ILaneChangeTarget> GetLaneChangeTarget() const override;
 
+    bool isSetTargetLaneOffset = false;          
 
 
             OPENSCENARIOLIB_EXP void SetTargetLaneOffset(const double targetLaneOffset) override;
@@ -7929,6 +8230,8 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<ITransitionDynamicsWriter> GetWriterLaneChangeActionDynamics() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ILaneChangeTargetWriter> GetWriterLaneChangeTarget() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetTargetLaneOffset() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTargetLaneOffset() const override;          
         };
 
         /**
@@ -7960,6 +8263,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeTargetLane> GetRelativeTargetLane() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAbsoluteTargetLane> GetAbsoluteTargetLane() const override;
 
+    bool isSetRelativeTargetLane = false;          
+    bool isSetAbsoluteTargetLane = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRelativeTargetLane(std::shared_ptr<IRelativeTargetLaneWriter> relativeTargetLane) override;
@@ -8018,6 +8323,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeTargetLaneWriter> GetWriterRelativeTargetLane() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAbsoluteTargetLaneWriter> GetWriterAbsoluteTargetLane() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetRelativeTargetLane() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRelativeTargetLane() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetAbsoluteTargetLane() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetAbsoluteTargetLane() const override;          
         };
 
         /**
@@ -8150,7 +8459,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP DynamicsShape GetDynamicsShape() const override;
             OPENSCENARIOLIB_EXP double GetMaxLateralAcc() const override;
 
-            bool isSetMaxLateralAcc = false;          
+    bool isSetMaxLateralAcc = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDynamicsShape(const DynamicsShape dynamicsShape) override;
@@ -8252,6 +8561,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeTargetLaneOffset> GetRelativeTargetLaneOffset() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAbsoluteTargetLaneOffset> GetAbsoluteTargetLaneOffset() const override;
 
+    bool isSetRelativeTargetLaneOffset = false;          
+    bool isSetAbsoluteTargetLaneOffset = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRelativeTargetLaneOffset(std::shared_ptr<IRelativeTargetLaneOffsetWriter> relativeTargetLaneOffset) override;
@@ -8310,6 +8621,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeTargetLaneOffsetWriter> GetWriterRelativeTargetLaneOffset() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAbsoluteTargetLaneOffsetWriter> GetWriterAbsoluteTargetLaneOffset() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetRelativeTargetLaneOffset() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRelativeTargetLaneOffset() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetAbsoluteTargetLaneOffset() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetAbsoluteTargetLaneOffset() const override;          
         };
 
         /**
@@ -8349,6 +8664,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetS() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
 
+    bool isSetOffset = false;          
+    bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetLaneId(const std::string laneId) override;
@@ -8436,6 +8753,10 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientationWriter> GetWriterOrientation() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetOffset() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetOffset() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetOrientation() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetOrientation() const override;          
         };
 
         /**
@@ -8469,6 +8790,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ILaneOffsetAction> GetLaneOffsetAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ILateralDistanceAction> GetLateralDistanceAction() const override;
 
+    bool isSetLaneChangeAction = false;          
+    bool isSetLaneOffsetAction = false;          
+    bool isSetLateralDistanceAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetLaneChangeAction(std::shared_ptr<ILaneChangeActionWriter> laneChangeAction) override;
@@ -8530,6 +8854,12 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ILaneChangeActionWriter> GetWriterLaneChangeAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ILaneOffsetActionWriter> GetWriterLaneOffsetAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ILateralDistanceActionWriter> GetWriterLateralDistanceAction() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetLaneChangeAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetLaneChangeAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetLaneOffsetAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetLaneOffsetAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetLateralDistanceAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetLateralDistanceAction() const override;          
         };
 
         /**
@@ -8573,6 +8903,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool GetFreespace() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IDynamicConstraints> GetDynamicConstraints() const override;
 
+    bool isSetCoordinateSystem = false;          
+    bool isSetDisplacement = false;          
+    bool isSetDistance = false;          
+    bool isSetDynamicConstraints = false;          
 
 
             OPENSCENARIOLIB_EXP void SetContinuous(const bool continuous) override;
@@ -8676,6 +9010,14 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IDynamicConstraintsWriter> GetWriterDynamicConstraints() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetCoordinateSystem() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCoordinateSystem() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetDisplacement() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetDisplacement() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetDistance() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetDistance() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetDynamicConstraints() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetDynamicConstraints() const override;          
         };
 
         /**
@@ -8712,8 +9054,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::string GetResource() const override;
             OPENSCENARIOLIB_EXP std::string GetSpdxId() const override;
 
-            bool isSetResource = false;          
-            bool isSetSpdxId = false;          
+    bool isSetText = false;          
+    bool isSetResource = false;          
+    bool isSetSpdxId = false;          
 
 
             OPENSCENARIOLIB_EXP void SetText(const std::string text) override;
@@ -8798,6 +9141,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsSpdxIdParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetText() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetText() const override;          
             OPENSCENARIOLIB_EXP virtual void ResetResource() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetResource() const override;          
             OPENSCENARIOLIB_EXP virtual void ResetSpdxId() override;
@@ -8833,6 +9178,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ISpeedAction> GetSpeedAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ILongitudinalDistanceAction> GetLongitudinalDistanceAction() const override;
 
+    bool isSetSpeedAction = false;          
+    bool isSetLongitudinalDistanceAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetSpeedAction(std::shared_ptr<ISpeedActionWriter> speedAction) override;
@@ -8891,6 +9238,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<ISpeedActionWriter> GetWriterSpeedAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ILongitudinalDistanceActionWriter> GetWriterLongitudinalDistanceAction() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetSpeedAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetSpeedAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetLongitudinalDistanceAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetLongitudinalDistanceAction() const override;          
         };
 
         /**
@@ -8936,8 +9287,11 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetTimeGap() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IDynamicConstraints> GetDynamicConstraints() const override;
 
-            bool isSetDistance = false;          
-            bool isSetTimeGap = false;          
+    bool isSetCoordinateSystem = false;          
+    bool isSetDisplacement = false;          
+    bool isSetDistance = false;          
+    bool isSetTimeGap = false;          
+    bool isSetDynamicConstraints = false;          
 
 
             OPENSCENARIOLIB_EXP void SetContinuous(const bool continuous) override;
@@ -9049,10 +9403,16 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IDynamicConstraintsWriter> GetWriterDynamicConstraints() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetCoordinateSystem() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCoordinateSystem() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetDisplacement() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetDisplacement() const override;          
             OPENSCENARIOLIB_EXP virtual void ResetDistance() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetDistance() const override;          
             OPENSCENARIOLIB_EXP virtual void ResetTimeGap() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetTimeGap() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetDynamicConstraints() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetDynamicConstraints() const override;          
         };
 
         /**
@@ -9095,6 +9455,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetEventsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IEvent> GetEventsAtIndex(unsigned int index) const override;
 
+    bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -9161,6 +9522,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsNameParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetParameterDeclarations() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetParameterDeclarations() const override;          
         };
 
         /**
@@ -9292,6 +9655,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetManeuversSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IManeuver> GetManeuversAtIndex(unsigned int index) const override;
 
+    bool isSetCatalogReferences = false;          
+    bool isSetManeuvers = false;          
 
 
             OPENSCENARIOLIB_EXP void SetMaximumExecutionCount(const uint32_t maximumExecutionCount) override;
@@ -9367,6 +9732,10 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IActorsWriter> GetWriterActors() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetCatalogReferences() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCatalogReferences() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetManeuvers() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetManeuvers() const override;          
         };
 
         /**
@@ -9414,7 +9783,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IBoundingBox> GetBoundingBox() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IProperties> GetProperties() const override;
 
-            bool isSetModel3d = false;          
+    bool isSetModel3d = false;          
+    bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetMass(const double mass) override;
@@ -9511,6 +9881,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPropertiesWriter> GetWriterProperties() const override;
             OPENSCENARIOLIB_EXP virtual void ResetModel3d() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetModel3d() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetParameterDeclarations() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetParameterDeclarations() const override;          
         };
 
         /**
@@ -9626,6 +9998,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterAddValueRule> GetAddValue() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterMultiplyByValueRule> GetMultiplyByValue() const override;
 
+    bool isSetAddValue = false;          
+    bool isSetMultiplyByValue = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAddValue(std::shared_ptr<IParameterAddValueRuleWriter> addValue) override;
@@ -9684,6 +10058,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterAddValueRuleWriter> GetWriterAddValue() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterMultiplyByValueRuleWriter> GetWriterMultiplyByValue() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetAddValue() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetAddValue() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetMultiplyByValue() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetMultiplyByValue() const override;          
         };
 
         /**
@@ -9797,6 +10175,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetVariance() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRange> GetRange() const override;
 
+    bool isSetRange = false;          
 
 
             OPENSCENARIOLIB_EXP void SetExpectedValue(const double expectedValue) override;
@@ -9868,6 +10247,8 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IRangeWriter> GetWriterRange() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetRange() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRange() const override;          
         };
 
         /**
@@ -10005,6 +10386,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReference> GetCatalogReference() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IController> GetController() const override;
 
+    bool isSetCatalogReference = false;          
+    bool isSetController = false;          
 
 
             OPENSCENARIOLIB_EXP void SetCatalogReference(std::shared_ptr<ICatalogReferenceWriter> catalogReference) override;
@@ -10063,6 +10446,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReferenceWriter> GetWriterCatalogReference() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IControllerWriter> GetWriterController() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetCatalogReference() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCatalogReference() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetController() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetController() const override;          
         };
 
         /**
@@ -10372,6 +10759,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetR() const override;
             OPENSCENARIOLIB_EXP ReferenceContext GetType() const override;
 
+    bool isSetH = false;          
+    bool isSetP = false;          
+    bool isSetR = false;          
+    bool isSetType = false;          
 
 
             OPENSCENARIOLIB_EXP void SetH(const double h) override;
@@ -10456,6 +10847,14 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsTypeParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetH() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetH() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetP() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetP() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetR() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetR() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetType() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetType() const override;          
         };
 
         /**
@@ -10697,6 +11096,12 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IOverrideSteeringWheelAction> GetSteeringWheel() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOverrideGearAction> GetGear() const override;
 
+    bool isSetThrottle = false;          
+    bool isSetBrake = false;          
+    bool isSetClutch = false;          
+    bool isSetParkingBrake = false;          
+    bool isSetSteeringWheel = false;          
+    bool isSetGear = false;          
 
 
             OPENSCENARIOLIB_EXP void SetThrottle(std::shared_ptr<IOverrideThrottleActionWriter> throttle) override;
@@ -10767,6 +11172,18 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IOverrideParkingBrakeActionWriter> GetWriterParkingBrake() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOverrideSteeringWheelActionWriter> GetWriterSteeringWheel() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOverrideGearActionWriter> GetWriterGear() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetThrottle() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetThrottle() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetBrake() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetBrake() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetClutch() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetClutch() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetParkingBrake() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetParkingBrake() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetSteeringWheel() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetSteeringWheel() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetGear() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetGear() const override;          
         };
 
         /**
@@ -11204,6 +11621,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterSetAction> GetSetAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterModifyAction> GetModifyAction() const override;
 
+    bool isSetSetAction = false;          
+    bool isSetModifyAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetParameterRef(std::shared_ptr<INamedReference<IParameterDeclaration>> parameterRef) override;
@@ -11270,6 +11689,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterSetActionWriter> GetWriterSetAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterModifyActionWriter> GetWriterModifyAction() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetSetAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetSetAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetModifyAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetModifyAction() const override;          
         };
 
         /**
@@ -11608,6 +12031,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetConstraintGroupsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IValueConstraintGroup> GetConstraintGroupsAtIndex(unsigned int index) const override;
 
+    bool isSetConstraintGroups = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -11680,6 +12104,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsValueParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetConstraintGroups() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetConstraintGroups() const override;          
         };
 
         /**
@@ -12253,8 +12679,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IBoundingBox> GetBoundingBox() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IProperties> GetProperties() const override;
 
-            bool isSetModel = false;          
-            bool isSetModel3d = false;          
+    bool isSetModel = false;          
+    bool isSetModel3d = false;          
+    bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetMass(const double mass) override;
@@ -12361,6 +12788,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP virtual bool IsSetModel() const override;          
             OPENSCENARIOLIB_EXP virtual void ResetModel3d() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetModel3d() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetParameterDeclarations() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetParameterDeclarations() const override;          
         };
 
         /**
@@ -12594,6 +13023,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetTrafficSignalStatesSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalState> GetTrafficSignalStatesAtIndex(unsigned int index) const override;
 
+    bool isSetTrafficSignalStates = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDuration(const double duration) override;
@@ -12664,6 +13094,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsNameParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetTrafficSignalStates() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrafficSignalStates() const override;          
         };
 
         /**
@@ -12696,6 +13128,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetExpectedValue() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRange> GetRange() const override;
 
+    bool isSetRange = false;          
 
 
             OPENSCENARIOLIB_EXP void SetExpectedValue(const double expectedValue) override;
@@ -12759,6 +13192,8 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IRangeWriter> GetWriterRange() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetRange() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRange() const override;          
         };
 
         /**
@@ -12893,6 +13328,16 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IGeoPosition> GetGeoPosition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryPosition> GetTrajectoryPosition() const override;
 
+    bool isSetWorldPosition = false;          
+    bool isSetRelativeWorldPosition = false;          
+    bool isSetRelativeObjectPosition = false;          
+    bool isSetRoadPosition = false;          
+    bool isSetRelativeRoadPosition = false;          
+    bool isSetLanePosition = false;          
+    bool isSetRelativeLanePosition = false;          
+    bool isSetRoutePosition = false;          
+    bool isSetGeoPosition = false;          
+    bool isSetTrajectoryPosition = false;          
 
 
             OPENSCENARIOLIB_EXP void SetWorldPosition(std::shared_ptr<IWorldPositionWriter> worldPosition) override;
@@ -12975,6 +13420,26 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IRoutePositionWriter> GetWriterRoutePosition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IGeoPositionWriter> GetWriterGeoPosition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryPositionWriter> GetWriterTrajectoryPosition() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetWorldPosition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetWorldPosition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRelativeWorldPosition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRelativeWorldPosition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRelativeObjectPosition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRelativeObjectPosition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRoadPosition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRoadPosition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRelativeRoadPosition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRelativeRoadPosition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetLanePosition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetLanePosition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRelativeLanePosition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRelativeLanePosition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRoutePosition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRoutePosition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetGeoPosition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetGeoPosition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrajectoryPosition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrajectoryPosition() const override;          
         };
 
         /**
@@ -13010,6 +13475,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetLaneOffset() const override;
             OPENSCENARIOLIB_EXP double GetPathS() const override;
 
+    bool isSetLaneOffset = false;          
 
 
             OPENSCENARIOLIB_EXP void SetLaneId(const std::string laneId) override;
@@ -13086,6 +13552,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsPathSParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetLaneOffset() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetLaneOffset() const override;          
         };
 
         /**
@@ -13309,8 +13777,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetPrecipitationIntensity() const override;
             OPENSCENARIOLIB_EXP PrecipitationType GetPrecipitationType() const override;
 
-            bool isSetIntensity = false;          
-            bool isSetPrecipitationIntensity = false;          
+    bool isSetIntensity = false;          
+    bool isSetPrecipitationIntensity = false;          
 
 
             OPENSCENARIOLIB_EXP void SetIntensity(const double intensity) override;
@@ -13531,6 +13999,14 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITeleportAction> GetTeleportAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRoutingAction> GetRoutingAction() const override;
 
+    bool isSetLongitudinalAction = false;          
+    bool isSetLateralAction = false;          
+    bool isSetVisibilityAction = false;          
+    bool isSetSynchronizeAction = false;          
+    bool isSetActivateControllerAction = false;          
+    bool isSetControllerAction = false;          
+    bool isSetTeleportAction = false;          
+    bool isSetRoutingAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetLongitudinalAction(std::shared_ptr<ILongitudinalActionWriter> longitudinalAction) override;
@@ -13607,6 +14083,22 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IControllerActionWriter> GetWriterControllerAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITeleportActionWriter> GetWriterTeleportAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRoutingActionWriter> GetWriterRoutingAction() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetLongitudinalAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetLongitudinalAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetLateralAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetLateralAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetVisibilityAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetVisibilityAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetSynchronizeAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetSynchronizeAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetActivateControllerAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetActivateControllerAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetControllerAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetControllerAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTeleportAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTeleportAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRoutingAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRoutingAction() const override;          
         };
 
         /**
@@ -13834,6 +14326,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetFilesSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IFile> GetFilesAtIndex(unsigned int index) const override;
 
+    bool isSetProperties = false;          
+    bool isSetFiles = false;          
 
 
             OPENSCENARIOLIB_EXP void SetProperties(std::vector<std::shared_ptr<IPropertyWriter>>& properties) override;
@@ -13890,6 +14384,10 @@ namespace NET_ASAM_OPENSCENARIO
             std::string GetModelType() const override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetProperties() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetProperties() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetFiles() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetFiles() const override;          
         };
 
         /**
@@ -14226,6 +14724,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP Rule GetRule() const override;
             OPENSCENARIOLIB_EXP double GetValue() const override;
 
+    bool isSetCoordinateSystem = false;          
 
 
             OPENSCENARIOLIB_EXP void SetCoordinateSystem(const CoordinateSystem coordinateSystem) override;
@@ -14326,6 +14825,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsValueParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetCoordinateSystem() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCoordinateSystem() const override;          
         };
 
         /**
@@ -14367,8 +14868,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetOffset() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
 
-            bool isSetDs = false;          
-            bool isSetDsLane = false;          
+    bool isSetDs = false;          
+    bool isSetDsLane = false;          
+    bool isSetOffset = false;          
+    bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDLane(const int dLane) override;
@@ -14468,6 +14971,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP virtual bool IsSetDs() const override;          
             OPENSCENARIOLIB_EXP virtual void ResetDsLane() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetDsLane() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetOffset() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetOffset() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetOrientation() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetOrientation() const override;          
         };
 
         /**
@@ -14506,6 +15013,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<INamedReference<IEntity>> GetEntityRef() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
 
+    bool isSetDz = false;          
+    bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDx(const double dx) override;
@@ -14593,6 +15102,10 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientationWriter> GetWriterOrientation() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetDz() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetDz() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetOrientation() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetOrientation() const override;          
         };
 
         /**
@@ -14629,6 +15142,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<INamedReference<IEntity>> GetEntityRef() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
 
+    bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDs(const double ds) override;
@@ -14708,6 +15222,8 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientationWriter> GetWriterOrientation() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetOrientation() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetOrientation() const override;          
         };
 
         /**
@@ -14852,6 +15368,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetValue() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ISteadyState> GetSteadyState() const override;
 
+    bool isSetSteadyState = false;          
 
 
             OPENSCENARIOLIB_EXP void SetSpeedTargetValueType(const SpeedTargetValueType speedTargetValueType) override;
@@ -14923,6 +15440,8 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<ISteadyStateWriter> GetWriterSteadyState() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetSteadyState() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetSteadyState() const override;          
         };
 
         /**
@@ -15282,6 +15801,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<INamedReference<IEntity>> GetEntityRef() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
 
+    bool isSetDz = false;          
+    bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDx(const double dx) override;
@@ -15369,6 +15890,10 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientationWriter> GetWriterOrientation() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetDz() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetDz() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetOrientation() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetOrientation() const override;          
         };
 
         /**
@@ -15401,6 +15926,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetFrictionScaleFactor() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IProperties> GetProperties() const override;
 
+    bool isSetProperties = false;          
 
 
             OPENSCENARIOLIB_EXP void SetFrictionScaleFactor(const double frictionScaleFactor) override;
@@ -15464,6 +15990,8 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IPropertiesWriter> GetWriterProperties() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetProperties() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetProperties() const override;          
         };
 
         /**
@@ -15503,6 +16031,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalController> GetTrafficSignalsAtIndex(unsigned int index) const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IUsedArea> GetUsedArea() const override;
 
+    bool isSetLogicFile = false;          
+    bool isSetSceneGraphFile = false;          
+    bool isSetTrafficSignals = false;          
+    bool isSetUsedArea = false;          
 
 
             OPENSCENARIOLIB_EXP void SetLogicFile(std::shared_ptr<IFileWriter> logicFile) override;
@@ -15566,6 +16098,14 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IFileWriter> GetWriterLogicFile() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IFileWriter> GetWriterSceneGraphFile() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IUsedAreaWriter> GetWriterUsedArea() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetLogicFile() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetLogicFile() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetSceneGraphFile() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetSceneGraphFile() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrafficSignals() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrafficSignals() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetUsedArea() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetUsedArea() const override;          
         };
 
         /**
@@ -15603,6 +16143,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetT() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
 
+    bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRoadId(const std::string roadId) override;
@@ -15682,6 +16223,8 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientationWriter> GetWriterOrientation() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetOrientation() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetOrientation() const override;          
         };
 
         /**
@@ -15727,6 +16270,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetWaypointsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IWaypoint> GetWaypointsAtIndex(unsigned int index) const override;
 
+    bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetClosed(const bool closed) override;
@@ -15801,6 +16345,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsNameParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetParameterDeclarations() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetParameterDeclarations() const override;          
         };
 
         /**
@@ -15918,6 +16464,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IInRoutePosition> GetInRoutePosition() const override;
 
+    bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRouteRef(std::shared_ptr<IRouteRefWriter> routeRef) override;
@@ -15979,6 +16526,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IRouteRefWriter> GetWriterRouteRef() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientationWriter> GetWriterOrientation() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IInRoutePositionWriter> GetWriterInRoutePosition() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetOrientation() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetOrientation() const override;          
         };
 
         /**
@@ -16010,6 +16559,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IRoute> GetRoute() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReference> GetCatalogReference() const override;
 
+    bool isSetRoute = false;          
+    bool isSetCatalogReference = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRoute(std::shared_ptr<IRouteWriter> route) override;
@@ -16068,6 +16619,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IRouteWriter> GetWriterRoute() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReferenceWriter> GetWriterCatalogReference() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetRoute() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRoute() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetCatalogReference() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCatalogReference() const override;          
         };
 
         /**
@@ -16101,6 +16656,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IFollowTrajectoryAction> GetFollowTrajectoryAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAcquirePositionAction> GetAcquirePositionAction() const override;
 
+    bool isSetAssignRouteAction = false;          
+    bool isSetFollowTrajectoryAction = false;          
+    bool isSetAcquirePositionAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAssignRouteAction(std::shared_ptr<IAssignRouteActionWriter> assignRouteAction) override;
@@ -16162,6 +16720,12 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IAssignRouteActionWriter> GetWriterAssignRouteAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IFollowTrajectoryActionWriter> GetWriterFollowTrajectoryAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAcquirePositionActionWriter> GetWriterAcquirePositionAction() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetAssignRouteAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetAssignRouteAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetFollowTrajectoryAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetFollowTrajectoryAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetAcquirePositionAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetAcquirePositionAction() const override;          
         };
 
         /**
@@ -16203,6 +16767,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntities> GetEntities() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IStoryboard> GetStoryboard() const override;
 
+    bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetParameterDeclarations(std::vector<std::shared_ptr<IParameterDeclarationWriter>>& parameterDeclarations) override;
@@ -16271,6 +16836,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IRoadNetworkWriter> GetWriterRoadNetwork() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntitiesWriter> GetWriterEntities() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IStoryboardWriter> GetWriterStoryboard() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetParameterDeclarations() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetParameterDeclarations() const override;          
         };
 
         /**
@@ -16305,6 +16872,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntityObject> GetEntityObject() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IObjectController> GetObjectController() const override;
 
+    bool isSetObjectController = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -16371,6 +16939,8 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntityObjectWriter> GetWriterEntityObject() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IObjectControllerWriter> GetWriterObjectController() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetObjectController() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetObjectController() const override;          
         };
 
         /**
@@ -16410,6 +16980,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetByTypeSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IByType> GetByTypeAtIndex(unsigned int index) const override;
 
+    bool isSetEntityRef = false;          
+    bool isSetByType = false;          
 
 
             OPENSCENARIOLIB_EXP void SetEntityRef(std::vector<std::shared_ptr<IEntityRefWriter>>& entityRef) override;
@@ -16466,6 +17038,10 @@ namespace NET_ASAM_OPENSCENARIO
             std::string GetModelType() const override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetEntityRef() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetEntityRef() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetByType() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetByType() const override;          
         };
 
         /**
@@ -16499,6 +17075,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IClothoid> GetClothoid() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<INurbs> GetNurbs() const override;
 
+    bool isSetPolyline = false;          
+    bool isSetClothoid = false;          
+    bool isSetNurbs = false;          
 
 
             OPENSCENARIOLIB_EXP void SetPolyline(std::shared_ptr<IPolylineWriter> polyline) override;
@@ -16560,6 +17139,12 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPolylineWriter> GetWriterPolyline() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IClothoidWriter> GetWriterClothoid() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<INurbsWriter> GetWriterNurbs() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetPolyline() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetPolyline() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetClothoid() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetClothoid() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetNurbs() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetNurbs() const override;          
         };
 
         /**
@@ -16780,6 +17365,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeTargetSpeed> GetRelativeTargetSpeed() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAbsoluteTargetSpeed> GetAbsoluteTargetSpeed() const override;
 
+    bool isSetRelativeTargetSpeed = false;          
+    bool isSetAbsoluteTargetSpeed = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRelativeTargetSpeed(std::shared_ptr<IRelativeTargetSpeedWriter> relativeTargetSpeed) override;
@@ -16838,6 +17425,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeTargetSpeedWriter> GetWriterRelativeTargetSpeed() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAbsoluteTargetSpeedWriter> GetWriterAbsoluteTargetSpeed() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetRelativeTargetSpeed() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRelativeTargetSpeed() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetAbsoluteTargetSpeed() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetAbsoluteTargetSpeed() const override;          
         };
 
         /**
@@ -17156,7 +17747,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetStochasticDistributionsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IStochasticDistribution> GetStochasticDistributionsAtIndex(unsigned int index) const override;
 
-            bool isSetRandomSeed = false;          
+    bool isSetRandomSeed = false;          
 
 
             OPENSCENARIOLIB_EXP void SetNumberOfTestRuns(const uint32_t numberOfTestRuns) override;
@@ -17475,6 +18066,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetActsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAct> GetActsAtIndex(unsigned int index) const override;
 
+    bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -17541,6 +18133,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsNameParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetParameterDeclarations() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetParameterDeclarations() const override;          
         };
 
         /**
@@ -17897,8 +18491,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetTargetPosition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IFinalSpeed> GetFinalSpeed() const override;
 
-            bool isSetTargetTolerance = false;          
-            bool isSetTargetToleranceMaster = false;          
+    bool isSetTargetTolerance = false;          
+    bool isSetTargetToleranceMaster = false;          
+    bool isSetFinalSpeed = false;          
 
 
             OPENSCENARIOLIB_EXP void SetMasterEntityRef(std::shared_ptr<INamedReference<IEntity>> masterEntityRef) override;
@@ -17988,6 +18583,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP virtual bool IsSetTargetTolerance() const override;          
             OPENSCENARIOLIB_EXP virtual void ResetTargetToleranceMaster() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetTargetToleranceMaster() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetFinalSpeed() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetFinalSpeed() const override;          
         };
 
         /**
@@ -18295,7 +18892,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP Rule GetRule() const override;
             OPENSCENARIOLIB_EXP double GetValue() const override;
 
-            bool isSetAlongRoute = false;          
+    bool isSetAlongRoute = false;          
+    bool isSetCoordinateSystem = false;          
+    bool isSetRelativeDistanceType = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAlongRoute(const bool alongRoute) override;
@@ -18406,6 +19005,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP virtual void ResetAlongRoute() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetAlongRoute() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetCoordinateSystem() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCoordinateSystem() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRelativeDistanceType() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRelativeDistanceType() const override;          
         };
 
         /**
@@ -18638,6 +19241,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<INone> GetNone() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITiming> GetTiming() const override;
 
+    bool isSetNone = false;          
+    bool isSetTiming = false;          
 
 
             OPENSCENARIOLIB_EXP void SetNone(std::shared_ptr<INoneWriter> none) override;
@@ -18696,6 +19301,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<INoneWriter> GetWriterNone() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITimingWriter> GetWriterTiming() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetNone() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetNone() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTiming() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTiming() const override;          
         };
 
         /**
@@ -18739,7 +19348,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetValue() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITimeToCollisionConditionTarget> GetTimeToCollisionConditionTarget() const override;
 
-            bool isSetAlongRoute = false;          
+    bool isSetAlongRoute = false;          
+    bool isSetCoordinateSystem = false;          
+    bool isSetRelativeDistanceType = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAlongRoute(const bool alongRoute) override;
@@ -18845,6 +19456,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITimeToCollisionConditionTargetWriter> GetWriterTimeToCollisionConditionTarget() const override;
             OPENSCENARIOLIB_EXP virtual void ResetAlongRoute() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetAlongRoute() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetCoordinateSystem() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetCoordinateSystem() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetRelativeDistanceType() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetRelativeDistanceType() const override;          
         };
 
         /**
@@ -18876,6 +19491,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetPosition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntityRef> GetEntityRef() const override;
 
+    bool isSetPosition = false;          
+    bool isSetEntityRef = false;          
 
 
             OPENSCENARIOLIB_EXP void SetPosition(std::shared_ptr<IPositionWriter> position) override;
@@ -18934,6 +19551,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IPositionWriter> GetWriterPosition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntityRefWriter> GetWriterEntityRef() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetPosition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetPosition() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetEntityRef() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetEntityRef() const override;          
         };
 
         /**
@@ -19082,7 +19703,11 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSwarmAction> GetTrafficSwarmAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficStopAction> GetTrafficStopAction() const override;
 
-            bool isSetTrafficName = false;          
+    bool isSetTrafficName = false;          
+    bool isSetTrafficSourceAction = false;          
+    bool isSetTrafficSinkAction = false;          
+    bool isSetTrafficSwarmAction = false;          
+    bool isSetTrafficStopAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetTrafficName(const std::string trafficName) override;
@@ -19157,6 +19782,14 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficStopActionWriter> GetWriterTrafficStopAction() const override;
             OPENSCENARIOLIB_EXP virtual void ResetTrafficName() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetTrafficName() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrafficSourceAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrafficSourceAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrafficSinkAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrafficSinkAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrafficSwarmAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrafficSwarmAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrafficStopAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrafficStopAction() const override;          
         };
 
         /**
@@ -19288,6 +19921,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalControllerAction> GetTrafficSignalControllerAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalStateAction> GetTrafficSignalStateAction() const override;
 
+    bool isSetTrafficSignalControllerAction = false;          
+    bool isSetTrafficSignalStateAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetTrafficSignalControllerAction(std::shared_ptr<ITrafficSignalControllerActionWriter> trafficSignalControllerAction) override;
@@ -19346,6 +19981,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalControllerActionWriter> GetWriterTrafficSignalControllerAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalStateActionWriter> GetWriterTrafficSignalStateAction() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetTrafficSignalControllerAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrafficSignalControllerAction() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrafficSignalStateAction() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrafficSignalStateAction() const override;          
         };
 
         /**
@@ -19487,7 +20126,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetPhasesSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPhase> GetPhasesAtIndex(unsigned int index) const override;
 
-            bool isSetReference = false;          
+    bool isSetDelay = false;          
+    bool isSetReference = false;          
+    bool isSetPhases = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDelay(const double delay) override;
@@ -19566,8 +20207,12 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsReferenceParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetDelay() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetDelay() const override;          
             OPENSCENARIOLIB_EXP virtual void ResetReference() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetReference() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetPhases() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetPhases() const override;          
         };
 
         /**
@@ -19605,6 +20250,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetPhaseRefSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPhase> GetPhaseRefAtIndex(unsigned int index) const override;
 
+    bool isSetPhaseRef = false;          
 
 
             OPENSCENARIOLIB_EXP void SetPhase(const std::string phase) override;
@@ -19675,6 +20321,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsTrafficSignalControllerRefParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetPhaseRef() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetPhaseRef() const override;          
         };
 
         /**
@@ -19712,6 +20360,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetPhaseRefSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPhase> GetPhaseRefAtIndex(unsigned int index) const override;
 
+    bool isSetPhaseRef = false;          
 
 
             OPENSCENARIOLIB_EXP void SetPhase(const std::string phase) override;
@@ -19782,6 +20431,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsTrafficSignalControllerRefParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetPhaseRef() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetPhaseRef() const override;          
         };
 
         /**
@@ -20018,7 +20669,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetPosition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficDefinition> GetTrafficDefinition() const override;
 
-            bool isSetRate = false;          
+    bool isSetRate = false;          
+    bool isSetTrafficDefinition = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRadius(const double radius) override;
@@ -20095,6 +20747,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficDefinitionWriter> GetWriterTrafficDefinition() const override;
             OPENSCENARIOLIB_EXP virtual void ResetRate() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetRate() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetTrafficDefinition() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetTrafficDefinition() const override;          
         };
 
         /**
@@ -20133,6 +20787,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetPosition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficDefinition> GetTrafficDefinition() const override;
 
+    bool isSetVelocity = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRadius(const double radius) override;
@@ -20215,6 +20870,8 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IPositionWriter> GetWriterPosition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficDefinitionWriter> GetWriterTrafficDefinition() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetVelocity() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetVelocity() const override;          
         };
 
         /**
@@ -20339,6 +20996,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ICentralSwarmObject> GetCentralObject() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficDefinition> GetTrafficDefinition() const override;
 
+    bool isSetVelocity = false;          
 
 
             OPENSCENARIOLIB_EXP void SetInnerRadius(const double innerRadius) override;
@@ -20445,6 +21103,8 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<ICentralSwarmObjectWriter> GetWriterCentralObject() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficDefinitionWriter> GetWriterTrafficDefinition() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetVelocity() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetVelocity() const override;          
         };
 
         /**
@@ -20486,6 +21146,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterDeclaration> GetParameterDeclarationsAtIndex(unsigned int index) const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IShape> GetShape() const override;
 
+    bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetClosed(const bool closed) override;
@@ -20561,6 +21222,8 @@ namespace NET_ASAM_OPENSCENARIO
 
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IShapeWriter> GetWriterShape() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetParameterDeclarations() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetParameterDeclarations() const override;          
         };
 
         /**
@@ -20770,6 +21433,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryRef> GetTrajectoryRef() const override;
 
+    bool isSetT = false;          
+    bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetS(const double s) override;
@@ -20844,6 +21509,10 @@ namespace NET_ASAM_OPENSCENARIO
             // children
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientationWriter> GetWriterOrientation() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryRefWriter> GetWriterTrajectoryRef() const override;
+            OPENSCENARIOLIB_EXP virtual void ResetT() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetT() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetOrientation() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetOrientation() const override;          
         };
 
         /**
@@ -21166,6 +21835,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetConditionGroupsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IConditionGroup> GetConditionGroupsAtIndex(unsigned int index) const override;
 
+    bool isSetConditionGroups = false;          
 
 
             OPENSCENARIOLIB_EXP void SetConditionGroups(std::vector<std::shared_ptr<IConditionGroupWriter>>& conditionGroups) override;
@@ -21220,6 +21890,8 @@ namespace NET_ASAM_OPENSCENARIO
             std::string GetModelType() const override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetConditionGroups() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetConditionGroups() const override;          
         };
 
         /**
@@ -22109,8 +22781,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IAxles> GetAxles() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IProperties> GetProperties() const override;
 
-            bool isSetMass = false;          
-            bool isSetModel3d = false;          
+    bool isSetMass = false;          
+    bool isSetModel3d = false;          
+    bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetMass(const double mass) override;
@@ -22215,6 +22888,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP virtual bool IsSetMass() const override;          
             OPENSCENARIOLIB_EXP virtual void ResetModel3d() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetModel3d() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetParameterDeclarations() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetParameterDeclarations() const override;          
         };
 
         /**
@@ -22518,7 +23193,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetTime() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetPosition() const override;
 
-            bool isSetTime = false;          
+    bool isSetTime = false;          
 
 
             OPENSCENARIOLIB_EXP void SetTime(const double time) override;
@@ -22830,9 +23505,13 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPrecipitation> GetPrecipitation() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IWind> GetWind() const override;
 
-            bool isSetAtmosphericPressure = false;          
-            bool isSetCloudState = false;          
-            bool isSetTemperature = false;          
+    bool isSetAtmosphericPressure = false;          
+    bool isSetCloudState = false;          
+    bool isSetTemperature = false;          
+    bool isSetSun = false;          
+    bool isSetFog = false;          
+    bool isSetPrecipitation = false;          
+    bool isSetWind = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAtmosphericPressure(const double atmosphericPressure) override;
@@ -22927,6 +23606,14 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP virtual bool IsSetCloudState() const override;          
             OPENSCENARIOLIB_EXP virtual void ResetTemperature() override;
             OPENSCENARIOLIB_EXP virtual bool IsSetTemperature() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetSun() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetSun() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetFog() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetFog() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetPrecipitation() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetPrecipitation() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetWind() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetWind() const override;          
         };
 
         /**
@@ -23067,6 +23754,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetY() const override;
             OPENSCENARIOLIB_EXP double GetZ() const override;
 
+    bool isSetH = false;          
+    bool isSetP = false;          
+    bool isSetR = false;          
+    bool isSetZ = false;          
 
 
             OPENSCENARIOLIB_EXP void SetH(const double h) override;
@@ -23167,6 +23858,14 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool IsZParameterized() override;
 
             // children
+            OPENSCENARIOLIB_EXP virtual void ResetH() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetH() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetP() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetP() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetR() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetR() const override;          
+            OPENSCENARIOLIB_EXP virtual void ResetZ() override;
+            OPENSCENARIOLIB_EXP virtual bool IsSetZ() const override;          
         };
 
 

--- a/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_1/ApiClassInterface.tpl
+++ b/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_1/ApiClassInterface.tpl
@@ -85,15 +85,12 @@ namespace NET_ASAM_OPENSCENARIO
 <%-}}-%>
 
 <%-properties.each{ property ->-%>
-<%-if (defaultValueHelper.hasNoneAsDefault(element.name.toClassName(),property.name.toMemberName())) {-%>
+<%-if (property.lower == 0) {-%>
             /**
             * Retrieves whether property <%=property.name.toMemberName()%> is set
             * @return true when the optional property is set
             */
-            virtual bool IsSet<%=property.name.toClassName()%>() const
-            {
-                return false;
-            }
+            virtual bool IsSet<%=property.name.toClassName()%>() const = 0;
 <%-}}-%>
 
         };

--- a/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_1/ApiClassWriterInterface.tpl
+++ b/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_1/ApiClassWriterInterface.tpl
@@ -100,7 +100,7 @@ namespace NET_ASAM_OPENSCENARIO
 <%-}-%>
 <%-properties = element.umlProperties-%>
 <%-properties.each{ property ->-%>
-<%-if (defaultValueHelper.hasNoneAsDefault(element.name.toClassName(),property.name.toMemberName())) {-%>
+<%-if (property.lower == 0) {-%>
             /**
             * Resets the optional property (IsSet<%=property.name.toClassName()%>() will return false);
             */

--- a/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_1/ImplClass.tpl
+++ b/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_1/ImplClass.tpl
@@ -94,7 +94,7 @@ namespace NET_ASAM_OPENSCENARIO
 
 	<%-properties = element.umlProperties-%>
 	<%-properties.each{ property ->-%>
-	<%-if (defaultValueHelper.hasNoneAsDefault(element.name.toClassName(),property.name.toMemberName())) {-%>
+	<%-if (property.lower == 0) {-%>
             bool isSet<%=property.name.toClassName()%> = false;          
 	<%-}}-%>
 
@@ -192,7 +192,7 @@ namespace NET_ASAM_OPENSCENARIO
 <%-}-%>
 <%-properties = element.umlProperties-%>
 <%-properties.each{ property ->-%>
-<%-if (defaultValueHelper.hasNoneAsDefault(element.name.toClassName(),property.name.toMemberName())) {-%>
+<%-if (property.lower == 0) {-%>
             OPENSCENARIOLIB_EXP virtual void Reset<%=property.name.toClassName()%>() override;
             OPENSCENARIOLIB_EXP virtual bool IsSet<%=property.name.toClassName()%>() const override;          
 <%-}}-%>

--- a/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_1/ImplClassSource.tpl
+++ b/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_1/ImplClassSource.tpl
@@ -112,7 +112,7 @@ namespace NET_ASAM_OPENSCENARIO
 <%-if (property.isParameterizableProperty()){-%>
             //RemoveAttributeParameter(OSC_CONSTANTS::ATTRIBUTE__<%=property.name.toUpperNameFromMemberName()%>);
 <%-}-%>
-<%-if (defaultValueHelper.hasNoneAsDefault(element.name.toClassName(),property.name.toMemberName())) {-%>
+<%-if (property.lower == 0) {-%>
 			// set the indicator to true
             isSet<%=property.name.toClassName()%> = true;          
 <%-}-%>
@@ -368,7 +368,7 @@ namespace NET_ASAM_OPENSCENARIO
             <%-}-%>
             <%-}-%>
             // clone indicators
-            <%-properties.findAll(){property -> defaultValueHelper.hasNoneAsDefault(element.name.toClassName(),property.name.toMemberName())}.each{ property ->-%>          
+            <%-properties.findAll(){property -> property.lower == 0}.each{ property ->-%>          
             	clonedObject->isSet<%=property.name.toClassName()%> = isSet<%=property.name.toClassName()%>;
             <%-}-%>
             // clone children
@@ -543,14 +543,14 @@ namespace NET_ASAM_OPENSCENARIO
 
 <%-properties = element.umlProperties-%>
 <%-properties.each{ property ->-%>
-<%-if (defaultValueHelper.hasNoneAsDefault(element.name.toClassName(),property.name.toMemberName())) {-%>
+<%-if (property.lower == 0) {-%>
        void <%=element.name.toClassName()%>Impl::Reset<%=property.name.toClassName()%>()
 	   {
 	   		isSet<%=property.name.toClassName()%> = false; 
 	   		<%- if (property.isProxy() && !property.isList()){-%>
         	_<%=property.name.toMemberName()%> = nullptr;
 			<%-}else{-%>
-			_<%=property.name.toMemberName()%> = {};
+			_<%=property.name.toMemberName()%> = {<%=defaultValueHelper.getDefaultValue(element.name.toClassName(),property.name.toMemberName())%>};
 			<%-}-%>
 			
 	   }


### PR DESCRIPTION
Signed-off-by: ahege <a.hege@rac.de>

#### Reference to a related issue in the repository
See #111

#### Add a description
See #111

**Some questions to ask**:
What is this change? IsSet- indicator function and Reset- functions are now generated for every optional attribute.
What does it fix? Before the functions are generated only for attributes that are optional and have no default value defined.
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version? Feature, which enables users to find out if an optional attribute is set.
How has it been tested?
Yes.


#### Check the checklist

- [x] My code follows the [contributors guidelines](https://github.com/ahege/openscenario.api.test/blob/master/doc/howtocontribute.rst) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/ahege/openscenario.api.test/blob/master/doc).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.
