### PR TITLE
#116 Added Parser Options and SupressDepreatedWarnings-flag

### DIFF
--- a/cpp/applications/openScenarioTester/res/DoubleLaneChangerUnicode.xosc
+++ b/cpp/applications/openScenarioTester/res/DoubleLaneChangerUnicode.xosc
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Copyright 2020 by ASAM e.V.
+ *
+ * ASAM licenses this file under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License. 
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *-->
+<!DOCTYPE foo [ <!ENTITY myentity "my entity value" > ]> 
+<OpenSCENARIO xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="OpenSCENARIO.xsd" xmlns:m="http://www.w3.org/1998/Math/MathML">	
+  <FileHeader revMajor="0" revMinor="9" date="2001-10-26T21:32:52" description="Größe" author="Andreas Biehn"/>
+  <ParameterDeclarations/>
+  <CatalogLocations>
+    <VehicleCatalog>
+      <Directory path="Catalogs/VehicleCatalogs"/>
+    </VehicleCatalog>
+    <ControllerCatalog>
+      <Directory path="Catalogs/DriverCatalogs"/>
+    </ControllerCatalog>
+    <PedestrianCatalog>
+      <Directory path="Catalogs/ObserverCatalogs"/>
+    </PedestrianCatalog>
+    <MiscObjectCatalog>
+      <Directory path="Catalogs/MiscObjectCatalogs"/>
+    </MiscObjectCatalog>
+    <EnvironmentCatalog>
+      <Directory path="Catalogs/EnvironmentCatalogs"/>
+    </EnvironmentCatalog>
+    <ManeuverCatalog>
+      <Directory path="Catalogs/ManeuverCatalogs"/>
+    </ManeuverCatalog>
+    <TrajectoryCatalog>
+      <Directory path="Catalogs/TrajectoryCatalog"/>
+    </TrajectoryCatalog>
+    <RouteCatalog>
+      <Directory path="Catalogs/RoutingCatalog"/>
+    </RouteCatalog>
+  </CatalogLocations>
+  <RoadNetwork>
+    <LogicFile filepath="Databases/PEGASUS/PEGASUS_A01.xodr"/>
+    <SceneGraphFile filepath="Databases/PEGASUS/PEGASUS_A01.opt.osgb"/>
+  </RoadNetwork>
+  <Entities>
+    <ScenarioObject name="Ego">
+      <CatalogReference catalogName="VechicleCatalog" entryName="AudiA3_blue_147kW&myentity;"/>
+      <ObjectController>
+        <CatalogReference catalogName="DriverCatalog" entryName="DefaultDriver"/>
+      </ObjectController>
+    </ScenarioObject>
+    <ScenarioObject name="A1">
+      <CatalogReference catalogName="VechicleCatalog" entryName="AudiA4_red_147kW"/>
+      <ObjectController>
+        <CatalogReference catalogName="DriverCatalog" entryName="DefaultDriver"/>
+      </ObjectController>
+    </ScenarioObject>
+    <ScenarioObject name="A2">
+      <CatalogReference catalogName="VechicleCatalog" entryName="AudiA4_red_147kW"/>
+      <ObjectController>
+        <CatalogReference catalogName="DriverCatalog" entryName="DefaultDriver"/>
+      </ObjectController>
+    </ScenarioObject>
+  </Entities>
+  <Storyboard>
+    <Init>
+      <Actions>
+        <Private entityRef="Ego">
+          <PrivateAction>
+            <LongitudinalAction>
+              <SpeedAction>
+                <SpeedActionDynamics dynamicsShape="step" value="2" dynamicsDimension="time"/>
+                <SpeedActionTarget>
+                  <AbsoluteTargetSpeed value="3.6111111111111107e+01"/>
+                </SpeedActionTarget>
+              </SpeedAction>
+            </LongitudinalAction>
+          </PrivateAction>
+          <PrivateAction>
+            <TeleportAction>
+              <Position>
+                <WorldPosition x="1.7024039832784507e+02" y="3.4330477905273438e+02" z="0.0000000000000000e+00" h="1.5707963267948966e+00" p="0.0000000000000000e+00" r="0.0000000000000000e+00"/>
+              </Position>
+            </TeleportAction>
+          </PrivateAction>
+        </Private>
+        <Private entityRef="A1">
+          <PrivateAction>
+            <LongitudinalAction>
+              <SpeedAction>
+                <SpeedActionDynamics dynamicsShape="step" value="2" dynamicsDimension="time"/>
+                <SpeedActionTarget>
+                  <AbsoluteTargetSpeed value="4.7222222222222221e+01"/>
+                </SpeedActionTarget>
+              </SpeedAction>
+            </LongitudinalAction>
+          </PrivateAction>
+          <PrivateAction>
+            <TeleportAction>
+              <Position>
+                <WorldPosition x="1.6682571411132812e+02" y="3.3006811523437500e+02" z="0.0000000000000000e+00" h="1.5707963267948966e+00" p="0.0000000000000000e+00" r="0.0000000000000000e+00"/>
+              </Position>
+            </TeleportAction>
+          </PrivateAction>
+        </Private>
+        <Private entityRef="A2">
+          <PrivateAction>
+            <LongitudinalAction>
+              <SpeedAction>
+                <SpeedActionDynamics dynamicsShape="step" value="2" dynamicsDimension="time"/>
+                <SpeedActionTarget>
+                  <AbsoluteTargetSpeed value="3.6111111111111107e+01"/>
+                </SpeedActionTarget>
+              </SpeedAction>
+            </LongitudinalAction>
+          </PrivateAction>
+          <PrivateAction>
+            <TeleportAction>
+              <Position>
+                <WorldPosition x="1.7024039832784507e+02" y="3.4330477905273438e+02" z="0.0000000000000000e+00" h="1.5707963267948966e+00" p="0.0000000000000000e+00" r="0.0000000000000000e+00"/>
+              </Position>
+            </TeleportAction>
+          </PrivateAction>
+        </Private>
+      </Actions>
+    </Init>
+    <Story name="MyStory">
+      <ParameterDeclarations>
+        <ParameterDeclaration parameterType="string" name="$owner" value="A1"/>
+      </ParameterDeclarations>
+      <Act name="MyAct">
+        <ManeuverGroup maximumExecutionCount="1" name="MySequence">
+          <Actors selectTriggeringEntities="false">
+            <EntityRef entityRef="$owner"/>
+          </Actors>
+          <Maneuver name="MyDoubleLaneChangeManeuver">
+            <Event name="MyLaneChangeRightEvent" priority="overwrite" maximumExecutionCount="2">
+              <Action name="MyLaneChangeRightAction">
+                <PrivateAction>
+                  <LateralAction>
+                    <LaneChangeAction>
+                      <LaneChangeActionDynamics dynamicsShape="sinusoidal" value="2.0" dynamicsDimension="time"/>
+                      <LaneChangeTarget>
+                        <RelativeTargetLane entityRef="$owner" value="-1"/>
+                      </LaneChangeTarget>
+                    </LaneChangeAction>
+                  </LateralAction>
+                </PrivateAction>
+              </Action>
+              <Action name="AcquirePositionAction">
+                <PrivateAction>
+                  <RoutingAction>
+						<AcquirePositionAction>
+							<Position>
+								<RelativeLanePosition dLane="1" ds="1" entityRef="Ego"/>
+							</Position>
+						</AcquirePositionAction>
+					</RoutingAction>
+					</PrivateAction>
+              </Action>
+              <StartTrigger>
+                <ConditionGroup>
+                  <Condition name="MyStartCondition1" delay="0" conditionEdge="rising">
+                    <ByEntityCondition>
+                      <TriggeringEntities triggeringEntitiesRule="any">
+                        <EntityRef entityRef="$owner"/>
+                      </TriggeringEntities>
+                      <EntityCondition>
+                        <DistanceCondition value="5.0000000000000000e+00" freespace="false" alongRoute="false" rule="greaterThan">
+                          <Position>
+                            <RelativeObjectPosition entityRef="Ego" dx="0.0000000000000000e+00" dy="0.0000000000000000e+00"/>
+                          </Position>
+                        </DistanceCondition>
+                      </EntityCondition>
+                    </ByEntityCondition>
+                  </Condition>
+                </ConditionGroup>
+              </StartTrigger>
+            </Event>
+            <Event name="MyLaneChangeLeftEvent" priority="overwrite">
+              <Action name="MyLaneChangeLeftAction">
+                <PrivateAction>
+                  <LateralAction>
+                    <LaneChangeAction>
+                      <LaneChangeActionDynamics dynamicsShape="sinusoidal" value="2" dynamicsDimension="time"/>
+                      <LaneChangeTarget>
+                        <RelativeTargetLane entityRef="$owner" value="1"/>
+                      </LaneChangeTarget>
+                    </LaneChangeAction>
+                  </LateralAction>
+                </PrivateAction>
+              </Action>
+              <StartTrigger>
+                <ConditionGroup>
+                  <Condition name="MyStartCondition2" delay="0" conditionEdge="rising">
+                    <ByValueCondition>
+                      <StoryboardElementStateCondition storyboardElementType="action" storyboardElementRef="MyLaneChangeRightAction" state="completeState"/>
+                    </ByValueCondition>
+                  </Condition>
+                </ConditionGroup>
+              </StartTrigger>
+            </Event>
+          </Maneuver>
+        </ManeuverGroup>
+        <StartTrigger>
+          <ConditionGroup>
+            <Condition name="" delay="0" conditionEdge="rising">
+              <ByValueCondition>
+                <SimulationTimeCondition value="0" rule="equalTo"/>
+              </ByValueCondition>
+            </Condition>
+          </ConditionGroup>
+        </StartTrigger>
+      </Act>
+    </Story>
+    <StopTrigger/>
+  </Storyboard>
+</OpenSCENARIO>

--- a/cpp/applications/openScenarioTester/src/OpenScenarioTester.cpp
+++ b/cpp/applications/openScenarioTester/src/OpenScenarioTester.cpp
@@ -61,6 +61,9 @@ bool TestV1_1(std::string basePath )
 	NET_ASAM_OPENSCENARIO::v1_1::TestParameterValidation testParametervalidation(basePath);
 
 	auto result = true;
+
+	result = testFiles.TestUnicode() && result;
+
 	result = testAlks.TestScenarios() && result;
 	result = testInjectedParameters.TestInjectionsForSuccess() && result;
 	result = testFiles.TestExpressionsSuccess() && result;

--- a/cpp/applications/openScenarioTester/src/OpenScenarioTester.cpp
+++ b/cpp/applications/openScenarioTester/src/OpenScenarioTester.cpp
@@ -61,8 +61,6 @@ bool TestV1_1(std::string basePath )
 	NET_ASAM_OPENSCENARIO::v1_1::TestParameterValidation testParametervalidation(basePath);
 
 	auto result = true;
-	result = testParametervalidation.TestValidation() && result;
-	
 	result = testAlks.TestScenarios() && result;
 	result = testInjectedParameters.TestInjectionsForSuccess() && result;
 	result = testFiles.TestExpressionsSuccess() && result;
@@ -126,6 +124,8 @@ bool TestV1_1(std::string basePath )
 	result = testWriterApi.TestBomFile() && result;
 	
 	result = testDeprecated.TestDeprecatedSuccess() && result;
+	result = testDeprecated.TestDeprecatedSupress() && result;
+
 
 	result = testAlks.TestCatalogs() && result;
 	result = testAlks.TestVariations() && result; 

--- a/cpp/applications/openScenarioTester/src/TestDeprecatedV1_1.cpp
+++ b/cpp/applications/openScenarioTester/src/TestDeprecatedV1_1.cpp
@@ -34,7 +34,7 @@ namespace NET_ASAM_OPENSCENARIO
 
 		bool TestDeprecated::TestDeprecatedSuccess()
 		{
-		
+			ClearMessageLogger();
 			// Creating a message logger to pick up the messages
 			auto msgLogger = std::dynamic_pointer_cast<NET_ASAM_OPENSCENARIO::IParserMessageLogger>(_messageLogger);
 
@@ -77,7 +77,7 @@ namespace NET_ASAM_OPENSCENARIO
 		}
 		bool TestDeprecated::TestDeprecatedSupress()
 		{
-
+			ClearMessageLogger();
 			// Creating a message logger to pick up the messages
 			auto msgLogger = std::dynamic_pointer_cast<NET_ASAM_OPENSCENARIO::IParserMessageLogger>(_messageLogger);
 

--- a/cpp/applications/openScenarioTester/src/TestDeprecatedV1_1.cpp
+++ b/cpp/applications/openScenarioTester/src/TestDeprecatedV1_1.cpp
@@ -75,7 +75,25 @@ namespace NET_ASAM_OPENSCENARIO
 				res = res && Assert(false, ASSERT_LOCATION);
 			return res;
 		}
+		bool TestDeprecated::TestDeprecatedSupress()
+		{
 
+			// Creating a message logger to pick up the messages
+			auto msgLogger = std::dynamic_pointer_cast<NET_ASAM_OPENSCENARIO::IParserMessageLogger>(_messageLogger);
+
+			// Instantiating the factory
+			std::string fileName = _executablePath + "/" + kInputDir + "DoubleLaneChangerDeprecated.xosc";
+			auto loaderFactory = XmlScenarioLoaderFactory(fileName, true);
+
+			// Creating the loader
+			auto loader = loaderFactory.CreateLoader(std::make_shared<NET_ASAM_OPENSCENARIO::FileResourceLocator>());
+
+			// Loading 
+			auto openScenario = std::static_pointer_cast<IOpenScenario>(loader->Load(_messageLogger)->GetAdapter(typeid(IOpenScenario).name()));
+
+			return Assert(_messageLogger->GetMessagesFilteredByWorseOrEqualToErrorLevel(NET_ASAM_OPENSCENARIO::WARNING).empty(), ASSERT_LOCATION);
+
+		}
 
 		
 	}

--- a/cpp/applications/openScenarioTester/src/TestDeprecatedV1_1.h
+++ b/cpp/applications/openScenarioTester/src/TestDeprecatedV1_1.h
@@ -29,7 +29,7 @@ namespace NET_ASAM_OPENSCENARIO
 			TestDeprecated(std::string& executablePath);
 			
 			bool TestDeprecatedSuccess();
-			
+			bool TestDeprecatedSupress();
 		};
 	}
 }

--- a/cpp/applications/openScenarioTester/src/TestFilesV1_1.cpp
+++ b/cpp/applications/openScenarioTester/src/TestFilesV1_1.cpp
@@ -466,6 +466,34 @@ namespace NET_ASAM_OPENSCENARIO
 			}
 		}
 
+		bool TestFiles::TestUnicode()
+		{
+			
+			try
+			{
+				ClearMessageLogger();
+				auto openScenario = std::dynamic_pointer_cast<IOpenScenario>(ExecuteParsing(_executablePath + "/" + kInputDir + "DoubleLaneChangerUnicode.xosc"));
+				bool res = Assert(_messageLogger->GetMessagesFilteredByWorseOrEqualToErrorLevel(NET_ASAM_OPENSCENARIO::ERROR).empty(), ASSERT_LOCATION);
+				if (!res)
+				{
+					auto filterByErrorLevelLogger = _messageLogger->GetMessagesFilteredByErrorLevel(NET_ASAM_OPENSCENARIO::ERROR);
+					for (auto it = filterByErrorLevelLogger.begin(); it != filterByErrorLevelLogger.end(); ++it) {
+						std::cout << it->ToString() << "\n";
+					}
+				}
+				auto description = openScenario->GetFileHeader()->GetDescription();
+				
+				res = Assert(description == "Größe", ASSERT_LOCATION) && res;
+				
+				return res;
+			}
+			catch (NET_ASAM_OPENSCENARIO::ScenarioLoaderException& e)
+			{
+				std::cout << e.what() << std::endl;
+				return Assert(false, ASSERT_LOCATION);
+			}
+		}
+
 		bool TestFiles::TestMultiChoiceElement()
 		{
 			try

--- a/cpp/applications/openScenarioTester/src/TestFilesV1_1.h
+++ b/cpp/applications/openScenarioTester/src/TestFilesV1_1.h
@@ -58,7 +58,9 @@ namespace NET_ASAM_OPENSCENARIO
 			bool TestCustomCommandAction();
 
 			bool TestFileNotFound() const;
-			
+
+			bool TestUnicode();
+
 			bool TestMultiChoiceElement();
 		};
 	}

--- a/cpp/openScenarioLib/CMakeLists.txt
+++ b/cpp/openScenarioLib/CMakeLists.txt
@@ -275,6 +275,7 @@ set( HEADERS_COMMON_EXPRESSION
 )
 
 set( HEADERS_COMMON_PARSER
+    "src/parser/ParserOptions.h"
     "src/parser/ParserHelper.h"
     "src/parser/ParserContext.h"
     "src/parser/WrappedListParser.h"
@@ -417,7 +418,6 @@ set( HEADERS_PARSER_1_1
 
 set( HEADERS_CHECKER_1_1
     "src/v1_1/checker/VersionCheckerRuleV1_1.h"
-    "src/v1_1/checker/ParameterDeclarationCheckerV1_1.h"
 )
 
 set( HEADERS_GENERATED_1_1_API
@@ -528,6 +528,7 @@ set( SOURCES_PARSER
     "src/parser/WrappedListParser.cpp"
     "src/parser/XmlModelGroupParser.cpp"
     "src/parser/ParserContext.cpp"
+    "src/parser/ParserOptions.cpp"
     "src/parser/ParserHelper.cpp"
     "src/parser/XmlParserException.cpp"
 )
@@ -582,7 +583,6 @@ set( SOURCES_V1_1_CATALOG
 )
 
 set( SOURCES_V1_1_CHECKER
-    "src/v1_1/checker/ParameterDeclarationCheckerV1_1.cpp"
     "src/v1_1/checker/VersionCheckerRuleV1_1.cpp"
 )
 

--- a/cpp/openScenarioLib/generated/v1_0/xmlParser/XmlParsers1V1_0.cpp
+++ b/cpp/openScenarioLib/generated/v1_0/xmlParser/XmlParsers1V1_0.cpp
@@ -35,7 +35,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AbsoluteSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            AbsoluteSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AbsoluteSpeedXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -44,7 +44,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -73,7 +73,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -84,10 +84,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        AbsoluteSpeedXmlParser::AbsoluteSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AbsoluteSpeedXmlParser::AbsoluteSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -97,7 +97,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AbsoluteTargetLaneXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            AbsoluteTargetLaneXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AbsoluteTargetLaneXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -106,7 +106,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -135,7 +135,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -146,10 +146,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        AbsoluteTargetLaneXmlParser::AbsoluteTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AbsoluteTargetLaneXmlParser::AbsoluteTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -159,7 +159,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AbsoluteTargetLaneOffsetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            AbsoluteTargetLaneOffsetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AbsoluteTargetLaneOffsetXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -168,7 +168,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -197,7 +197,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -208,10 +208,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        AbsoluteTargetLaneOffsetXmlParser::AbsoluteTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AbsoluteTargetLaneOffsetXmlParser::AbsoluteTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -221,7 +221,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AbsoluteTargetSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            AbsoluteTargetSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AbsoluteTargetSpeedXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -230,7 +230,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -259,7 +259,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -270,10 +270,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        AbsoluteTargetSpeedXmlParser::AbsoluteTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AbsoluteTargetSpeedXmlParser::AbsoluteTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -283,7 +283,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AccelerationConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            AccelerationConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AccelerationConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -292,7 +292,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -330,11 +330,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -363,7 +363,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -374,10 +374,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        AccelerationConditionXmlParser::AccelerationConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AccelerationConditionXmlParser::AccelerationConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -387,7 +387,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AcquirePositionActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            AcquirePositionActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AcquirePositionActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -400,13 +400,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> AcquirePositionActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        AcquirePositionActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AcquirePositionActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AcquirePositionActionXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -443,10 +443,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        AcquirePositionActionXmlParser::AcquirePositionActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AcquirePositionActionXmlParser::AcquirePositionActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -456,7 +456,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ActXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ActXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ActXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -465,7 +465,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -494,22 +494,22 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ActXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementManeuverGroupsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStartTriggerParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStopTriggerParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementManeuverGroupsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStartTriggerParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStopTriggerParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ActXmlParser::SubElementManeuverGroupsParser::SubElementManeuverGroupsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ActXmlParser::SubElementManeuverGroupsParser::SubElementManeuverGroupsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _maneuverGroupXmlParser = std::make_shared<ManeuverGroupXmlParser>(messageLogger, filename);
+            _maneuverGroupXmlParser = std::make_shared<ManeuverGroupXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ActXmlParser::SubElementManeuverGroupsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -546,9 +546,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__MANEUVER_GROUP
                     };
         }
-        ActXmlParser::SubElementStartTriggerParser::SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ActXmlParser::SubElementStartTriggerParser::SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename);
+            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ActXmlParser::SubElementStartTriggerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -584,9 +584,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__START_TRIGGER
                     };
         }
-        ActXmlParser::SubElementStopTriggerParser::SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ActXmlParser::SubElementStopTriggerParser::SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename);
+            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ActXmlParser::SubElementStopTriggerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -623,10 +623,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ActXmlParser::ActXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ActXmlParser::ActXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -636,7 +636,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -646,7 +646,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -675,22 +675,22 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementGlobalActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementUserDefinedActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPrivateActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementGlobalActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementUserDefinedActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPrivateActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ActionXmlParser::SubElementGlobalActionParser::SubElementGlobalActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ActionXmlParser::SubElementGlobalActionParser::SubElementGlobalActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _globalActionXmlParser = std::make_shared<GlobalActionXmlParser>(messageLogger, filename);
+            _globalActionXmlParser = std::make_shared<GlobalActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ActionXmlParser::SubElementGlobalActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -726,9 +726,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__GLOBAL_ACTION
                     };
         }
-        ActionXmlParser::SubElementUserDefinedActionParser::SubElementUserDefinedActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ActionXmlParser::SubElementUserDefinedActionParser::SubElementUserDefinedActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _userDefinedActionXmlParser = std::make_shared<UserDefinedActionXmlParser>(messageLogger, filename);
+            _userDefinedActionXmlParser = std::make_shared<UserDefinedActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ActionXmlParser::SubElementUserDefinedActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -764,9 +764,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__USER_DEFINED_ACTION
                     };
         }
-        ActionXmlParser::SubElementPrivateActionParser::SubElementPrivateActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ActionXmlParser::SubElementPrivateActionParser::SubElementPrivateActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _privateActionXmlParser = std::make_shared<PrivateActionXmlParser>(messageLogger, filename);
+            _privateActionXmlParser = std::make_shared<PrivateActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ActionXmlParser::SubElementPrivateActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -803,10 +803,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ActionXmlParser::ActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ActionXmlParser::ActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -816,7 +816,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ActivateControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ActivateControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ActivateControllerActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -825,7 +825,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeLateral: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLateral(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLateral(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -854,11 +854,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LATERAL, std::make_shared<AttributeLateral>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LATERAL, std::make_shared<AttributeLateral>(_messageLogger, _filename, _parserOptions)));
             class AttributeLongitudinal: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLongitudinal(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLongitudinal(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -887,7 +887,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LONGITUDINAL, std::make_shared<AttributeLongitudinal>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LONGITUDINAL, std::make_shared<AttributeLongitudinal>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -898,10 +898,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ActivateControllerActionXmlParser::ActivateControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ActivateControllerActionXmlParser::ActivateControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -911,7 +911,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ActorsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ActorsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ActorsXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -920,7 +920,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeSelectTriggeringEntities: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeSelectTriggeringEntities(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeSelectTriggeringEntities(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -949,20 +949,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SELECT_TRIGGERING_ENTITIES, std::make_shared<AttributeSelectTriggeringEntities>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SELECT_TRIGGERING_ENTITIES, std::make_shared<AttributeSelectTriggeringEntities>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ActorsXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEntityRefsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEntityRefsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ActorsXmlParser::SubElementEntityRefsParser::SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ActorsXmlParser::SubElementEntityRefsParser::SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename);
+            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ActorsXmlParser::SubElementEntityRefsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1000,10 +1000,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ActorsXmlParser::ActorsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ActorsXmlParser::ActorsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1013,7 +1013,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AddEntityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            AddEntityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AddEntityActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -1026,13 +1026,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> AddEntityActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        AddEntityActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AddEntityActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AddEntityActionXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1069,10 +1069,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        AddEntityActionXmlParser::AddEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AddEntityActionXmlParser::AddEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1082,7 +1082,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AssignControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            AssignControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AssignControllerActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -1095,14 +1095,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> AssignControllerActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementControllerParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementControllerParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        AssignControllerActionXmlParser::SubElementControllerParser::SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AssignControllerActionXmlParser::SubElementControllerParser::SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename);
+            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AssignControllerActionXmlParser::SubElementControllerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1138,9 +1138,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CONTROLLER
                     };
         }
-        AssignControllerActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AssignControllerActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AssignControllerActionXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1178,10 +1178,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        AssignControllerActionXmlParser::AssignControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AssignControllerActionXmlParser::AssignControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1191,7 +1191,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AssignRouteActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            AssignRouteActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AssignRouteActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -1204,14 +1204,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> AssignRouteActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRouteParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRouteParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        AssignRouteActionXmlParser::SubElementRouteParser::SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AssignRouteActionXmlParser::SubElementRouteParser::SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _routeXmlParser = std::make_shared<RouteXmlParser>(messageLogger, filename);
+            _routeXmlParser = std::make_shared<RouteXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AssignRouteActionXmlParser::SubElementRouteParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1247,9 +1247,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ROUTE
                     };
         }
-        AssignRouteActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AssignRouteActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AssignRouteActionXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1287,10 +1287,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        AssignRouteActionXmlParser::AssignRouteActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AssignRouteActionXmlParser::AssignRouteActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1300,7 +1300,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AxleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            AxleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AxleXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1309,7 +1309,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMaxSteering: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxSteering(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxSteering(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1338,11 +1338,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_STEERING, std::make_shared<AttributeMaxSteering>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_STEERING, std::make_shared<AttributeMaxSteering>(_messageLogger, _filename, _parserOptions)));
             class AttributePositionX: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePositionX(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePositionX(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1371,11 +1371,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__POSITION_X, std::make_shared<AttributePositionX>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__POSITION_X, std::make_shared<AttributePositionX>(_messageLogger, _filename, _parserOptions)));
             class AttributePositionZ: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePositionZ(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePositionZ(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1404,11 +1404,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__POSITION_Z, std::make_shared<AttributePositionZ>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__POSITION_Z, std::make_shared<AttributePositionZ>(_messageLogger, _filename, _parserOptions)));
             class AttributeTrackWidth: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTrackWidth(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTrackWidth(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1437,11 +1437,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRACK_WIDTH, std::make_shared<AttributeTrackWidth>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRACK_WIDTH, std::make_shared<AttributeTrackWidth>(_messageLogger, _filename, _parserOptions)));
             class AttributeWheelDiameter: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeWheelDiameter(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeWheelDiameter(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1470,7 +1470,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WHEEL_DIAMETER, std::make_shared<AttributeWheelDiameter>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WHEEL_DIAMETER, std::make_shared<AttributeWheelDiameter>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -1481,10 +1481,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        AxleXmlParser::AxleXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AxleXmlParser::AxleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1494,7 +1494,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AxlesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            AxlesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AxlesXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1506,15 +1506,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> AxlesXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementFrontAxleParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRearAxleParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementAdditionalAxlesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementFrontAxleParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRearAxleParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementAdditionalAxlesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        AxlesXmlParser::SubElementFrontAxleParser::SubElementFrontAxleParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AxlesXmlParser::SubElementFrontAxleParser::SubElementFrontAxleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _axleXmlParser = std::make_shared<AxleXmlParser>(messageLogger, filename);
+            _axleXmlParser = std::make_shared<AxleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AxlesXmlParser::SubElementFrontAxleParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1550,9 +1550,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__FRONT_AXLE
                     };
         }
-        AxlesXmlParser::SubElementRearAxleParser::SubElementRearAxleParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AxlesXmlParser::SubElementRearAxleParser::SubElementRearAxleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _axleXmlParser = std::make_shared<AxleXmlParser>(messageLogger, filename);
+            _axleXmlParser = std::make_shared<AxleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AxlesXmlParser::SubElementRearAxleParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1588,9 +1588,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__REAR_AXLE
                     };
         }
-        AxlesXmlParser::SubElementAdditionalAxlesParser::SubElementAdditionalAxlesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AxlesXmlParser::SubElementAdditionalAxlesParser::SubElementAdditionalAxlesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _axleXmlParser = std::make_shared<AxleXmlParser>(messageLogger, filename);
+            _axleXmlParser = std::make_shared<AxleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AxlesXmlParser::SubElementAdditionalAxlesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1628,10 +1628,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        AxlesXmlParser::AxlesXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AxlesXmlParser::AxlesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1641,7 +1641,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            BoundingBoxXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            BoundingBoxXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> BoundingBoxXmlParser::GetAttributeNameToAttributeParserMap()
@@ -1654,14 +1654,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> BoundingBoxXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementCenterParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementDimensionsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementCenterParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementDimensionsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        BoundingBoxXmlParser::SubElementCenterParser::SubElementCenterParser(IParserMessageLogger& messageLogger, std::string& filename)
+        BoundingBoxXmlParser::SubElementCenterParser::SubElementCenterParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _centerXmlParser = std::make_shared<CenterXmlParser>(messageLogger, filename);
+            _centerXmlParser = std::make_shared<CenterXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void BoundingBoxXmlParser::SubElementCenterParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1697,9 +1697,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CENTER
                     };
         }
-        BoundingBoxXmlParser::SubElementDimensionsParser::SubElementDimensionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        BoundingBoxXmlParser::SubElementDimensionsParser::SubElementDimensionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _dimensionsXmlParser = std::make_shared<DimensionsXmlParser>(messageLogger, filename);
+            _dimensionsXmlParser = std::make_shared<DimensionsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void BoundingBoxXmlParser::SubElementDimensionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1736,10 +1736,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        BoundingBoxXmlParser::BoundingBoxXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        BoundingBoxXmlParser::BoundingBoxXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1749,7 +1749,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ByEntityConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ByEntityConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ByEntityConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -1762,14 +1762,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ByEntityConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTriggeringEntitiesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementEntityConditionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTriggeringEntitiesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementEntityConditionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ByEntityConditionXmlParser::SubElementTriggeringEntitiesParser::SubElementTriggeringEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByEntityConditionXmlParser::SubElementTriggeringEntitiesParser::SubElementTriggeringEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _triggeringEntitiesXmlParser = std::make_shared<TriggeringEntitiesXmlParser>(messageLogger, filename);
+            _triggeringEntitiesXmlParser = std::make_shared<TriggeringEntitiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByEntityConditionXmlParser::SubElementTriggeringEntitiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1805,9 +1805,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRIGGERING_ENTITIES
                     };
         }
-        ByEntityConditionXmlParser::SubElementEntityConditionParser::SubElementEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByEntityConditionXmlParser::SubElementEntityConditionParser::SubElementEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityConditionXmlParser = std::make_shared<EntityConditionXmlParser>(messageLogger, filename);
+            _entityConditionXmlParser = std::make_shared<EntityConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByEntityConditionXmlParser::SubElementEntityConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1844,10 +1844,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ByEntityConditionXmlParser::ByEntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ByEntityConditionXmlParser::ByEntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1857,7 +1857,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ByObjectTypeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ByObjectTypeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ByObjectTypeXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1866,7 +1866,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1904,7 +1904,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TYPE, std::make_shared<AttributeType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TYPE, std::make_shared<AttributeType>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -1915,10 +1915,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ByObjectTypeXmlParser::ByObjectTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ByObjectTypeXmlParser::ByObjectTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1928,7 +1928,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ByTypeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ByTypeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ByTypeXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1937,7 +1937,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeObjectType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeObjectType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeObjectType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1975,7 +1975,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OBJECT_TYPE, std::make_shared<AttributeObjectType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OBJECT_TYPE, std::make_shared<AttributeObjectType>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -1986,10 +1986,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ByTypeXmlParser::ByTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ByTypeXmlParser::ByTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1999,7 +1999,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ByValueConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ByValueConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ByValueConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -2012,19 +2012,19 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ByValueConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementParameterConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTimeOfDayConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementSimulationTimeConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStoryboardElementStateConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementUserDefinedValueConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficSignalConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficSignalControllerConditionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementParameterConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTimeOfDayConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementSimulationTimeConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStoryboardElementStateConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementUserDefinedValueConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficSignalConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficSignalControllerConditionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ByValueConditionXmlParser::SubElementParameterConditionParser::SubElementParameterConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByValueConditionXmlParser::SubElementParameterConditionParser::SubElementParameterConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterConditionXmlParser = std::make_shared<ParameterConditionXmlParser>(messageLogger, filename);
+            _parameterConditionXmlParser = std::make_shared<ParameterConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByValueConditionXmlParser::SubElementParameterConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2060,9 +2060,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PARAMETER_CONDITION
                     };
         }
-        ByValueConditionXmlParser::SubElementTimeOfDayConditionParser::SubElementTimeOfDayConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByValueConditionXmlParser::SubElementTimeOfDayConditionParser::SubElementTimeOfDayConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _timeOfDayConditionXmlParser = std::make_shared<TimeOfDayConditionXmlParser>(messageLogger, filename);
+            _timeOfDayConditionXmlParser = std::make_shared<TimeOfDayConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByValueConditionXmlParser::SubElementTimeOfDayConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2098,9 +2098,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TIME_OF_DAY_CONDITION
                     };
         }
-        ByValueConditionXmlParser::SubElementSimulationTimeConditionParser::SubElementSimulationTimeConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByValueConditionXmlParser::SubElementSimulationTimeConditionParser::SubElementSimulationTimeConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _simulationTimeConditionXmlParser = std::make_shared<SimulationTimeConditionXmlParser>(messageLogger, filename);
+            _simulationTimeConditionXmlParser = std::make_shared<SimulationTimeConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByValueConditionXmlParser::SubElementSimulationTimeConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2136,9 +2136,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SIMULATION_TIME_CONDITION
                     };
         }
-        ByValueConditionXmlParser::SubElementStoryboardElementStateConditionParser::SubElementStoryboardElementStateConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByValueConditionXmlParser::SubElementStoryboardElementStateConditionParser::SubElementStoryboardElementStateConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _storyboardElementStateConditionXmlParser = std::make_shared<StoryboardElementStateConditionXmlParser>(messageLogger, filename);
+            _storyboardElementStateConditionXmlParser = std::make_shared<StoryboardElementStateConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByValueConditionXmlParser::SubElementStoryboardElementStateConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2174,9 +2174,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__STORYBOARD_ELEMENT_STATE_CONDITION
                     };
         }
-        ByValueConditionXmlParser::SubElementUserDefinedValueConditionParser::SubElementUserDefinedValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByValueConditionXmlParser::SubElementUserDefinedValueConditionParser::SubElementUserDefinedValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _userDefinedValueConditionXmlParser = std::make_shared<UserDefinedValueConditionXmlParser>(messageLogger, filename);
+            _userDefinedValueConditionXmlParser = std::make_shared<UserDefinedValueConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByValueConditionXmlParser::SubElementUserDefinedValueConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2212,9 +2212,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__USER_DEFINED_VALUE_CONDITION
                     };
         }
-        ByValueConditionXmlParser::SubElementTrafficSignalConditionParser::SubElementTrafficSignalConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByValueConditionXmlParser::SubElementTrafficSignalConditionParser::SubElementTrafficSignalConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSignalConditionXmlParser = std::make_shared<TrafficSignalConditionXmlParser>(messageLogger, filename);
+            _trafficSignalConditionXmlParser = std::make_shared<TrafficSignalConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByValueConditionXmlParser::SubElementTrafficSignalConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2250,9 +2250,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAFFIC_SIGNAL_CONDITION
                     };
         }
-        ByValueConditionXmlParser::SubElementTrafficSignalControllerConditionParser::SubElementTrafficSignalControllerConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByValueConditionXmlParser::SubElementTrafficSignalControllerConditionParser::SubElementTrafficSignalControllerConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSignalControllerConditionXmlParser = std::make_shared<TrafficSignalControllerConditionXmlParser>(messageLogger, filename);
+            _trafficSignalControllerConditionXmlParser = std::make_shared<TrafficSignalControllerConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByValueConditionXmlParser::SubElementTrafficSignalControllerConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2289,10 +2289,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ByValueConditionXmlParser::ByValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ByValueConditionXmlParser::ByValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2302,7 +2302,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            CatalogXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            CatalogXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> CatalogXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2311,7 +2311,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2340,27 +2340,27 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> CatalogXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementVehiclesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementControllersParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPedestriansParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementMiscObjectsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementEnvironmentsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementManeuversParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrajectoriesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRoutesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementVehiclesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementControllersParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPedestriansParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementMiscObjectsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementEnvironmentsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementManeuversParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrajectoriesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRoutesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        CatalogXmlParser::SubElementVehiclesParser::SubElementVehiclesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementVehiclesParser::SubElementVehiclesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _vehicleXmlParser = std::make_shared<VehicleXmlParser>(messageLogger, filename);
+            _vehicleXmlParser = std::make_shared<VehicleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementVehiclesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2397,9 +2397,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__VEHICLE
                     };
         }
-        CatalogXmlParser::SubElementControllersParser::SubElementControllersParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementControllersParser::SubElementControllersParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename);
+            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementControllersParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2436,9 +2436,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CONTROLLER
                     };
         }
-        CatalogXmlParser::SubElementPedestriansParser::SubElementPedestriansParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementPedestriansParser::SubElementPedestriansParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _pedestrianXmlParser = std::make_shared<PedestrianXmlParser>(messageLogger, filename);
+            _pedestrianXmlParser = std::make_shared<PedestrianXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementPedestriansParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2475,9 +2475,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PEDESTRIAN
                     };
         }
-        CatalogXmlParser::SubElementMiscObjectsParser::SubElementMiscObjectsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementMiscObjectsParser::SubElementMiscObjectsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _miscObjectXmlParser = std::make_shared<MiscObjectXmlParser>(messageLogger, filename);
+            _miscObjectXmlParser = std::make_shared<MiscObjectXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementMiscObjectsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2514,9 +2514,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__MISC_OBJECT
                     };
         }
-        CatalogXmlParser::SubElementEnvironmentsParser::SubElementEnvironmentsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementEnvironmentsParser::SubElementEnvironmentsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _environmentXmlParser = std::make_shared<EnvironmentXmlParser>(messageLogger, filename);
+            _environmentXmlParser = std::make_shared<EnvironmentXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementEnvironmentsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2553,9 +2553,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENVIRONMENT
                     };
         }
-        CatalogXmlParser::SubElementManeuversParser::SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementManeuversParser::SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _maneuverXmlParser = std::make_shared<ManeuverXmlParser>(messageLogger, filename);
+            _maneuverXmlParser = std::make_shared<ManeuverXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementManeuversParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2592,9 +2592,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__MANEUVER
                     };
         }
-        CatalogXmlParser::SubElementTrajectoriesParser::SubElementTrajectoriesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementTrajectoriesParser::SubElementTrajectoriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trajectoryXmlParser = std::make_shared<TrajectoryXmlParser>(messageLogger, filename);
+            _trajectoryXmlParser = std::make_shared<TrajectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementTrajectoriesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2631,9 +2631,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAJECTORY
                     };
         }
-        CatalogXmlParser::SubElementRoutesParser::SubElementRoutesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementRoutesParser::SubElementRoutesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _routeXmlParser = std::make_shared<RouteXmlParser>(messageLogger, filename);
+            _routeXmlParser = std::make_shared<RouteXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementRoutesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2671,10 +2671,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        CatalogXmlParser::CatalogXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        CatalogXmlParser::CatalogXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2684,19 +2684,19 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            CatalogDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            CatalogDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
 
         std::vector<std::shared_ptr<IElementParser>> CatalogDefinitionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementCatalogParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementCatalogParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        CatalogDefinitionXmlParser::SubElementCatalogParser::SubElementCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogDefinitionXmlParser::SubElementCatalogParser::SubElementCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogXmlParser = std::make_shared<CatalogXmlParser>(messageLogger, filename);
+            _catalogXmlParser = std::make_shared<CatalogXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogDefinitionXmlParser::SubElementCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2733,10 +2733,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        CatalogDefinitionXmlParser::CatalogDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        CatalogDefinitionXmlParser::CatalogDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2746,7 +2746,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            CatalogLocationsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            CatalogLocationsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> CatalogLocationsXmlParser::GetAttributeNameToAttributeParserMap()
@@ -2759,20 +2759,20 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> CatalogLocationsXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementVehicleCatalogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementControllerCatalogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPedestrianCatalogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementMiscObjectCatalogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementEnvironmentCatalogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementManeuverCatalogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrajectoryCatalogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRouteCatalogParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementVehicleCatalogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementControllerCatalogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPedestrianCatalogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementMiscObjectCatalogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementEnvironmentCatalogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementManeuverCatalogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrajectoryCatalogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRouteCatalogParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        CatalogLocationsXmlParser::SubElementVehicleCatalogParser::SubElementVehicleCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementVehicleCatalogParser::SubElementVehicleCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _vehicleCatalogLocationXmlParser = std::make_shared<VehicleCatalogLocationXmlParser>(messageLogger, filename);
+            _vehicleCatalogLocationXmlParser = std::make_shared<VehicleCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementVehicleCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2808,9 +2808,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__VEHICLE_CATALOG
                     };
         }
-        CatalogLocationsXmlParser::SubElementControllerCatalogParser::SubElementControllerCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementControllerCatalogParser::SubElementControllerCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerCatalogLocationXmlParser = std::make_shared<ControllerCatalogLocationXmlParser>(messageLogger, filename);
+            _controllerCatalogLocationXmlParser = std::make_shared<ControllerCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementControllerCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2846,9 +2846,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CONTROLLER_CATALOG
                     };
         }
-        CatalogLocationsXmlParser::SubElementPedestrianCatalogParser::SubElementPedestrianCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementPedestrianCatalogParser::SubElementPedestrianCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _pedestrianCatalogLocationXmlParser = std::make_shared<PedestrianCatalogLocationXmlParser>(messageLogger, filename);
+            _pedestrianCatalogLocationXmlParser = std::make_shared<PedestrianCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementPedestrianCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2884,9 +2884,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PEDESTRIAN_CATALOG
                     };
         }
-        CatalogLocationsXmlParser::SubElementMiscObjectCatalogParser::SubElementMiscObjectCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementMiscObjectCatalogParser::SubElementMiscObjectCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _miscObjectCatalogLocationXmlParser = std::make_shared<MiscObjectCatalogLocationXmlParser>(messageLogger, filename);
+            _miscObjectCatalogLocationXmlParser = std::make_shared<MiscObjectCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementMiscObjectCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2922,9 +2922,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__MISC_OBJECT_CATALOG
                     };
         }
-        CatalogLocationsXmlParser::SubElementEnvironmentCatalogParser::SubElementEnvironmentCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementEnvironmentCatalogParser::SubElementEnvironmentCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _environmentCatalogLocationXmlParser = std::make_shared<EnvironmentCatalogLocationXmlParser>(messageLogger, filename);
+            _environmentCatalogLocationXmlParser = std::make_shared<EnvironmentCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementEnvironmentCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2960,9 +2960,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENVIRONMENT_CATALOG
                     };
         }
-        CatalogLocationsXmlParser::SubElementManeuverCatalogParser::SubElementManeuverCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementManeuverCatalogParser::SubElementManeuverCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _maneuverCatalogLocationXmlParser = std::make_shared<ManeuverCatalogLocationXmlParser>(messageLogger, filename);
+            _maneuverCatalogLocationXmlParser = std::make_shared<ManeuverCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementManeuverCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2998,9 +2998,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__MANEUVER_CATALOG
                     };
         }
-        CatalogLocationsXmlParser::SubElementTrajectoryCatalogParser::SubElementTrajectoryCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementTrajectoryCatalogParser::SubElementTrajectoryCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trajectoryCatalogLocationXmlParser = std::make_shared<TrajectoryCatalogLocationXmlParser>(messageLogger, filename);
+            _trajectoryCatalogLocationXmlParser = std::make_shared<TrajectoryCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementTrajectoryCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3036,9 +3036,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAJECTORY_CATALOG
                     };
         }
-        CatalogLocationsXmlParser::SubElementRouteCatalogParser::SubElementRouteCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementRouteCatalogParser::SubElementRouteCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _routeCatalogLocationXmlParser = std::make_shared<RouteCatalogLocationXmlParser>(messageLogger, filename);
+            _routeCatalogLocationXmlParser = std::make_shared<RouteCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementRouteCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3075,10 +3075,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        CatalogLocationsXmlParser::CatalogLocationsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        CatalogLocationsXmlParser::CatalogLocationsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3088,7 +3088,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            CatalogReferenceXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            CatalogReferenceXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> CatalogReferenceXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3097,7 +3097,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeCatalogName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCatalogName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCatalogName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3126,11 +3126,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CATALOG_NAME, std::make_shared<AttributeCatalogName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CATALOG_NAME, std::make_shared<AttributeCatalogName>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntryName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntryName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntryName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3159,20 +3159,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTRY_NAME, std::make_shared<AttributeEntryName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTRY_NAME, std::make_shared<AttributeEntryName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> CatalogReferenceXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterAssignmentsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_ASSIGNMENTS) );
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterAssignmentsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_ASSIGNMENTS, _parserOptions) );
             return result;
         }
 
-        CatalogReferenceXmlParser::SubElementParameterAssignmentsParser::SubElementParameterAssignmentsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogReferenceXmlParser::SubElementParameterAssignmentsParser::SubElementParameterAssignmentsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterAssignmentXmlParser = std::make_shared<ParameterAssignmentXmlParser>(messageLogger, filename);
+            _parameterAssignmentXmlParser = std::make_shared<ParameterAssignmentXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogReferenceXmlParser::SubElementParameterAssignmentsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3207,10 +3207,10 @@ namespace NET_ASAM_OPENSCENARIO
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_ASSIGNMENT};
         }
   
-        CatalogReferenceXmlParser::CatalogReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        CatalogReferenceXmlParser::CatalogReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3220,7 +3220,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            CenterXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            CenterXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> CenterXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3229,7 +3229,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeX: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeX(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeX(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3258,11 +3258,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__X, std::make_shared<AttributeX>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__X, std::make_shared<AttributeX>(_messageLogger, _filename, _parserOptions)));
             class AttributeY: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeY(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeY(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3291,11 +3291,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Y, std::make_shared<AttributeY>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Y, std::make_shared<AttributeY>(_messageLogger, _filename, _parserOptions)));
             class AttributeZ: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeZ(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeZ(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3324,7 +3324,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Z, std::make_shared<AttributeZ>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Z, std::make_shared<AttributeZ>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -3335,10 +3335,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        CenterXmlParser::CenterXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        CenterXmlParser::CenterXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3348,7 +3348,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            CentralSwarmObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            CentralSwarmObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> CentralSwarmObjectXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3357,7 +3357,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3388,7 +3388,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -3399,10 +3399,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        CentralSwarmObjectXmlParser::CentralSwarmObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        CentralSwarmObjectXmlParser::CentralSwarmObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3412,7 +3412,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ClothoidXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ClothoidXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ClothoidXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3421,7 +3421,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeCurvature: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCurvature(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCurvature(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3450,11 +3450,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CURVATURE, std::make_shared<AttributeCurvature>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CURVATURE, std::make_shared<AttributeCurvature>(_messageLogger, _filename, _parserOptions)));
             class AttributeCurvatureDot: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCurvatureDot(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCurvatureDot(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3483,11 +3483,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CURVATURE_DOT, std::make_shared<AttributeCurvatureDot>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CURVATURE_DOT, std::make_shared<AttributeCurvatureDot>(_messageLogger, _filename, _parserOptions)));
             class AttributeLength: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLength(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLength(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3516,11 +3516,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LENGTH, std::make_shared<AttributeLength>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LENGTH, std::make_shared<AttributeLength>(_messageLogger, _filename, _parserOptions)));
             class AttributeStartTime: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeStartTime(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeStartTime(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3549,11 +3549,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__START_TIME, std::make_shared<AttributeStartTime>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__START_TIME, std::make_shared<AttributeStartTime>(_messageLogger, _filename, _parserOptions)));
             class AttributeStopTime: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeStopTime(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeStopTime(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3582,20 +3582,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STOP_TIME, std::make_shared<AttributeStopTime>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STOP_TIME, std::make_shared<AttributeStopTime>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ClothoidXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ClothoidXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ClothoidXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ClothoidXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3632,10 +3632,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ClothoidXmlParser::ClothoidXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ClothoidXmlParser::ClothoidXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3645,7 +3645,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            CollisionConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            CollisionConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> CollisionConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -3658,14 +3658,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> CollisionConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEntityRefParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementByTypeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEntityRefParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementByTypeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        CollisionConditionXmlParser::SubElementEntityRefParser::SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CollisionConditionXmlParser::SubElementEntityRefParser::SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename);
+            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CollisionConditionXmlParser::SubElementEntityRefParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3701,9 +3701,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENTITY_REF
                     };
         }
-        CollisionConditionXmlParser::SubElementByTypeParser::SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CollisionConditionXmlParser::SubElementByTypeParser::SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _byObjectTypeXmlParser = std::make_shared<ByObjectTypeXmlParser>(messageLogger, filename);
+            _byObjectTypeXmlParser = std::make_shared<ByObjectTypeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CollisionConditionXmlParser::SubElementByTypeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3740,10 +3740,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        CollisionConditionXmlParser::CollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        CollisionConditionXmlParser::CollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3753,7 +3753,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -3763,7 +3763,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeConditionEdge: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeConditionEdge(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeConditionEdge(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3801,11 +3801,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONDITION_EDGE, std::make_shared<AttributeConditionEdge>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONDITION_EDGE, std::make_shared<AttributeConditionEdge>(_messageLogger, _filename, _parserOptions)));
             class AttributeDelay: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDelay(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDelay(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3834,11 +3834,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DELAY, std::make_shared<AttributeDelay>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DELAY, std::make_shared<AttributeDelay>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3867,21 +3867,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementByEntityConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementByValueConditionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementByEntityConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementByValueConditionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ConditionXmlParser::SubElementByEntityConditionParser::SubElementByEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ConditionXmlParser::SubElementByEntityConditionParser::SubElementByEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _byEntityConditionXmlParser = std::make_shared<ByEntityConditionXmlParser>(messageLogger, filename);
+            _byEntityConditionXmlParser = std::make_shared<ByEntityConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ConditionXmlParser::SubElementByEntityConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3917,9 +3917,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__BY_ENTITY_CONDITION
                     };
         }
-        ConditionXmlParser::SubElementByValueConditionParser::SubElementByValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ConditionXmlParser::SubElementByValueConditionParser::SubElementByValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _byValueConditionXmlParser = std::make_shared<ByValueConditionXmlParser>(messageLogger, filename);
+            _byValueConditionXmlParser = std::make_shared<ByValueConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ConditionXmlParser::SubElementByValueConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3956,10 +3956,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ConditionXmlParser::ConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ConditionXmlParser::ConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3969,7 +3969,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ConditionGroupXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ConditionGroupXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ConditionGroupXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3981,13 +3981,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ConditionGroupXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementConditionsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementConditionsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ConditionGroupXmlParser::SubElementConditionsParser::SubElementConditionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ConditionGroupXmlParser::SubElementConditionsParser::SubElementConditionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _conditionXmlParser = std::make_shared<ConditionXmlParser>(messageLogger, filename);
+            _conditionXmlParser = std::make_shared<ConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ConditionGroupXmlParser::SubElementConditionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4025,10 +4025,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ConditionGroupXmlParser::ConditionGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ConditionGroupXmlParser::ConditionGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4038,7 +4038,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ControlPointXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ControlPointXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ControlPointXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4047,7 +4047,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeTime: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTime(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTime(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4076,11 +4076,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TIME, std::make_shared<AttributeTime>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TIME, std::make_shared<AttributeTime>(_messageLogger, _filename, _parserOptions)));
             class AttributeWeight: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4109,20 +4109,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ControlPointXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ControlPointXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControlPointXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControlPointXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4159,10 +4159,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ControlPointXmlParser::ControlPointXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ControlPointXmlParser::ControlPointXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4172,7 +4172,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ControllerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ControllerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ControllerXmlParser::GetAttributeNameToAttributeParserMap()
@@ -4182,7 +4182,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4211,21 +4211,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ControllerXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ControllerXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4259,9 +4259,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        ControllerXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename);
+            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerXmlParser::SubElementPropertiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4298,10 +4298,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ControllerXmlParser::ControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ControllerXmlParser::ControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4311,7 +4311,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ControllerActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -4324,14 +4324,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ControllerActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementAssignControllerActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementOverrideControllerValueActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementAssignControllerActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementOverrideControllerValueActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ControllerActionXmlParser::SubElementAssignControllerActionParser::SubElementAssignControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerActionXmlParser::SubElementAssignControllerActionParser::SubElementAssignControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _assignControllerActionXmlParser = std::make_shared<AssignControllerActionXmlParser>(messageLogger, filename);
+            _assignControllerActionXmlParser = std::make_shared<AssignControllerActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerActionXmlParser::SubElementAssignControllerActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4367,9 +4367,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ASSIGN_CONTROLLER_ACTION
                     };
         }
-        ControllerActionXmlParser::SubElementOverrideControllerValueActionParser::SubElementOverrideControllerValueActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerActionXmlParser::SubElementOverrideControllerValueActionParser::SubElementOverrideControllerValueActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _overrideControllerValueActionXmlParser = std::make_shared<OverrideControllerValueActionXmlParser>(messageLogger, filename);
+            _overrideControllerValueActionXmlParser = std::make_shared<OverrideControllerValueActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerActionXmlParser::SubElementOverrideControllerValueActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4406,10 +4406,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ControllerActionXmlParser::ControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ControllerActionXmlParser::ControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4419,7 +4419,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ControllerCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ControllerCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ControllerCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -4432,13 +4432,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ControllerCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ControllerCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4475,10 +4475,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ControllerCatalogLocationXmlParser::ControllerCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ControllerCatalogLocationXmlParser::ControllerCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4488,7 +4488,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ControllerDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ControllerDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ControllerDistributionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4500,13 +4500,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ControllerDistributionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementControllerDistributionEntriesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementControllerDistributionEntriesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ControllerDistributionXmlParser::SubElementControllerDistributionEntriesParser::SubElementControllerDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerDistributionXmlParser::SubElementControllerDistributionEntriesParser::SubElementControllerDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerDistributionEntryXmlParser = std::make_shared<ControllerDistributionEntryXmlParser>(messageLogger, filename);
+            _controllerDistributionEntryXmlParser = std::make_shared<ControllerDistributionEntryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerDistributionXmlParser::SubElementControllerDistributionEntriesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4544,10 +4544,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ControllerDistributionXmlParser::ControllerDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ControllerDistributionXmlParser::ControllerDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4557,7 +4557,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ControllerDistributionEntryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ControllerDistributionEntryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ControllerDistributionEntryXmlParser::GetAttributeNameToAttributeParserMap()
@@ -4567,7 +4567,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeWeight: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4596,21 +4596,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ControllerDistributionEntryXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementControllerParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementControllerParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ControllerDistributionEntryXmlParser::SubElementControllerParser::SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerDistributionEntryXmlParser::SubElementControllerParser::SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename);
+            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerDistributionEntryXmlParser::SubElementControllerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4646,9 +4646,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CONTROLLER
                     };
         }
-        ControllerDistributionEntryXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerDistributionEntryXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerDistributionEntryXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4686,10 +4686,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ControllerDistributionEntryXmlParser::ControllerDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ControllerDistributionEntryXmlParser::ControllerDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4711,7 +4711,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4740,7 +4740,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TYPE, std::make_shared<AttributeType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TYPE, std::make_shared<AttributeType>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
         void CustomCommandActionXmlParser::SetContentProperty(const std::string content, std::shared_ptr<BaseImpl> object)
@@ -4749,8 +4749,8 @@ namespace NET_ASAM_OPENSCENARIO
             typedObject->SetContent(content);
         }
   
-        CustomCommandActionXmlParser::CustomCommandActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlSimpleContentParser(messageLogger, filename) {}
+        CustomCommandActionXmlParser::CustomCommandActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlSimpleContentParser(messageLogger, filename, parserOptions) {}
         
 
         /**
@@ -4759,7 +4759,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DeleteEntityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            DeleteEntityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DeleteEntityActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4775,10 +4775,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        DeleteEntityActionXmlParser::DeleteEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DeleteEntityActionXmlParser::DeleteEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4788,7 +4788,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DimensionsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            DimensionsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DimensionsXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4797,7 +4797,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeHeight: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeHeight(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeHeight(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4826,11 +4826,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__HEIGHT, std::make_shared<AttributeHeight>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__HEIGHT, std::make_shared<AttributeHeight>(_messageLogger, _filename, _parserOptions)));
             class AttributeLength: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLength(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLength(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4859,11 +4859,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LENGTH, std::make_shared<AttributeLength>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LENGTH, std::make_shared<AttributeLength>(_messageLogger, _filename, _parserOptions)));
             class AttributeWidth: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeWidth(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeWidth(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4892,7 +4892,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WIDTH, std::make_shared<AttributeWidth>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WIDTH, std::make_shared<AttributeWidth>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -4903,10 +4903,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        DimensionsXmlParser::DimensionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DimensionsXmlParser::DimensionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4916,7 +4916,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DirectoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            DirectoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DirectoryXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4925,7 +4925,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributePath: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePath(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePath(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4954,7 +4954,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PATH, std::make_shared<AttributePath>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PATH, std::make_shared<AttributePath>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -4965,10 +4965,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        DirectoryXmlParser::DirectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DirectoryXmlParser::DirectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4978,7 +4978,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DistanceConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            DistanceConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DistanceConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -4988,7 +4988,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeAlongRoute: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeAlongRoute(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeAlongRoute(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5017,11 +5017,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<AttributeAlongRoute>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<AttributeAlongRoute>(_messageLogger, _filename, _parserOptions)));
             class AttributeFreespace: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5050,11 +5050,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5092,11 +5092,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5125,20 +5125,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> DistanceConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        DistanceConditionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DistanceConditionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DistanceConditionXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5175,10 +5175,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        DistanceConditionXmlParser::DistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DistanceConditionXmlParser::DistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5188,7 +5188,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DynamicConstraintsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            DynamicConstraintsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DynamicConstraintsXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -5197,7 +5197,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMaxAcceleration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxAcceleration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxAcceleration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5226,11 +5226,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_ACCELERATION, std::make_shared<AttributeMaxAcceleration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_ACCELERATION, std::make_shared<AttributeMaxAcceleration>(_messageLogger, _filename, _parserOptions)));
             class AttributeMaxDeceleration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxDeceleration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxDeceleration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5259,11 +5259,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_DECELERATION, std::make_shared<AttributeMaxDeceleration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_DECELERATION, std::make_shared<AttributeMaxDeceleration>(_messageLogger, _filename, _parserOptions)));
             class AttributeMaxSpeed: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxSpeed(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxSpeed(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5292,7 +5292,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_SPEED, std::make_shared<AttributeMaxSpeed>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_SPEED, std::make_shared<AttributeMaxSpeed>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -5303,10 +5303,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        DynamicConstraintsXmlParser::DynamicConstraintsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DynamicConstraintsXmlParser::DynamicConstraintsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5316,7 +5316,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EndOfRoadConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            EndOfRoadConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EndOfRoadConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -5325,7 +5325,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDuration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5354,7 +5354,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -5365,10 +5365,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        EndOfRoadConditionXmlParser::EndOfRoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EndOfRoadConditionXmlParser::EndOfRoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5378,7 +5378,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EntitiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            EntitiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EntitiesXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -5390,14 +5390,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> EntitiesXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementScenarioObjectsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementEntitySelectionsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementScenarioObjectsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementEntitySelectionsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EntitiesXmlParser::SubElementScenarioObjectsParser::SubElementScenarioObjectsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntitiesXmlParser::SubElementScenarioObjectsParser::SubElementScenarioObjectsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _scenarioObjectXmlParser = std::make_shared<ScenarioObjectXmlParser>(messageLogger, filename);
+            _scenarioObjectXmlParser = std::make_shared<ScenarioObjectXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntitiesXmlParser::SubElementScenarioObjectsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5434,9 +5434,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SCENARIO_OBJECT
                     };
         }
-        EntitiesXmlParser::SubElementEntitySelectionsParser::SubElementEntitySelectionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntitiesXmlParser::SubElementEntitySelectionsParser::SubElementEntitySelectionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entitySelectionXmlParser = std::make_shared<EntitySelectionXmlParser>(messageLogger, filename);
+            _entitySelectionXmlParser = std::make_shared<EntitySelectionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntitiesXmlParser::SubElementEntitySelectionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5474,10 +5474,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EntitiesXmlParser::EntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EntitiesXmlParser::EntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5487,7 +5487,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EntityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            EntityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EntityActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -5497,7 +5497,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5528,21 +5528,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> EntityActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementAddEntityActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementDeleteEntityActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementAddEntityActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementDeleteEntityActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EntityActionXmlParser::SubElementAddEntityActionParser::SubElementAddEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityActionXmlParser::SubElementAddEntityActionParser::SubElementAddEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _addEntityActionXmlParser = std::make_shared<AddEntityActionXmlParser>(messageLogger, filename);
+            _addEntityActionXmlParser = std::make_shared<AddEntityActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityActionXmlParser::SubElementAddEntityActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5578,9 +5578,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ADD_ENTITY_ACTION
                     };
         }
-        EntityActionXmlParser::SubElementDeleteEntityActionParser::SubElementDeleteEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityActionXmlParser::SubElementDeleteEntityActionParser::SubElementDeleteEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _deleteEntityActionXmlParser = std::make_shared<DeleteEntityActionXmlParser>(messageLogger, filename);
+            _deleteEntityActionXmlParser = std::make_shared<DeleteEntityActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityActionXmlParser::SubElementDeleteEntityActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5617,10 +5617,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EntityActionXmlParser::EntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EntityActionXmlParser::EntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5630,7 +5630,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EntityConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            EntityConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EntityConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -5643,25 +5643,25 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> EntityConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEndOfRoadConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCollisionConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementOffroadConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTimeHeadwayConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTimeToCollisionConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementAccelerationConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStandStillConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementSpeedConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRelativeSpeedConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTraveledDistanceConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementReachPositionConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementDistanceConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRelativeDistanceConditionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEndOfRoadConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCollisionConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementOffroadConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTimeHeadwayConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTimeToCollisionConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementAccelerationConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStandStillConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementSpeedConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRelativeSpeedConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTraveledDistanceConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementReachPositionConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementDistanceConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRelativeDistanceConditionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EntityConditionXmlParser::SubElementEndOfRoadConditionParser::SubElementEndOfRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementEndOfRoadConditionParser::SubElementEndOfRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _endOfRoadConditionXmlParser = std::make_shared<EndOfRoadConditionXmlParser>(messageLogger, filename);
+            _endOfRoadConditionXmlParser = std::make_shared<EndOfRoadConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementEndOfRoadConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5697,9 +5697,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__END_OF_ROAD_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementCollisionConditionParser::SubElementCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementCollisionConditionParser::SubElementCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _collisionConditionXmlParser = std::make_shared<CollisionConditionXmlParser>(messageLogger, filename);
+            _collisionConditionXmlParser = std::make_shared<CollisionConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementCollisionConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5735,9 +5735,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__COLLISION_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementOffroadConditionParser::SubElementOffroadConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementOffroadConditionParser::SubElementOffroadConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _offroadConditionXmlParser = std::make_shared<OffroadConditionXmlParser>(messageLogger, filename);
+            _offroadConditionXmlParser = std::make_shared<OffroadConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementOffroadConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5773,9 +5773,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__OFFROAD_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementTimeHeadwayConditionParser::SubElementTimeHeadwayConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementTimeHeadwayConditionParser::SubElementTimeHeadwayConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _timeHeadwayConditionXmlParser = std::make_shared<TimeHeadwayConditionXmlParser>(messageLogger, filename);
+            _timeHeadwayConditionXmlParser = std::make_shared<TimeHeadwayConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementTimeHeadwayConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5811,9 +5811,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TIME_HEADWAY_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementTimeToCollisionConditionParser::SubElementTimeToCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementTimeToCollisionConditionParser::SubElementTimeToCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _timeToCollisionConditionXmlParser = std::make_shared<TimeToCollisionConditionXmlParser>(messageLogger, filename);
+            _timeToCollisionConditionXmlParser = std::make_shared<TimeToCollisionConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementTimeToCollisionConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5849,9 +5849,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TIME_TO_COLLISION_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementAccelerationConditionParser::SubElementAccelerationConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementAccelerationConditionParser::SubElementAccelerationConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _accelerationConditionXmlParser = std::make_shared<AccelerationConditionXmlParser>(messageLogger, filename);
+            _accelerationConditionXmlParser = std::make_shared<AccelerationConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementAccelerationConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5887,9 +5887,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ACCELERATION_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementStandStillConditionParser::SubElementStandStillConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementStandStillConditionParser::SubElementStandStillConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _standStillConditionXmlParser = std::make_shared<StandStillConditionXmlParser>(messageLogger, filename);
+            _standStillConditionXmlParser = std::make_shared<StandStillConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementStandStillConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5925,9 +5925,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__STAND_STILL_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementSpeedConditionParser::SubElementSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementSpeedConditionParser::SubElementSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _speedConditionXmlParser = std::make_shared<SpeedConditionXmlParser>(messageLogger, filename);
+            _speedConditionXmlParser = std::make_shared<SpeedConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementSpeedConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5963,9 +5963,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SPEED_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementRelativeSpeedConditionParser::SubElementRelativeSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementRelativeSpeedConditionParser::SubElementRelativeSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeSpeedConditionXmlParser = std::make_shared<RelativeSpeedConditionXmlParser>(messageLogger, filename);
+            _relativeSpeedConditionXmlParser = std::make_shared<RelativeSpeedConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementRelativeSpeedConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6001,9 +6001,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_SPEED_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementTraveledDistanceConditionParser::SubElementTraveledDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementTraveledDistanceConditionParser::SubElementTraveledDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _traveledDistanceConditionXmlParser = std::make_shared<TraveledDistanceConditionXmlParser>(messageLogger, filename);
+            _traveledDistanceConditionXmlParser = std::make_shared<TraveledDistanceConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementTraveledDistanceConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6039,9 +6039,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAVELED_DISTANCE_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementReachPositionConditionParser::SubElementReachPositionConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementReachPositionConditionParser::SubElementReachPositionConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _reachPositionConditionXmlParser = std::make_shared<ReachPositionConditionXmlParser>(messageLogger, filename);
+            _reachPositionConditionXmlParser = std::make_shared<ReachPositionConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementReachPositionConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6077,9 +6077,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__REACH_POSITION_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementDistanceConditionParser::SubElementDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementDistanceConditionParser::SubElementDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _distanceConditionXmlParser = std::make_shared<DistanceConditionXmlParser>(messageLogger, filename);
+            _distanceConditionXmlParser = std::make_shared<DistanceConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementDistanceConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6115,9 +6115,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__DISTANCE_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementRelativeDistanceConditionParser::SubElementRelativeDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementRelativeDistanceConditionParser::SubElementRelativeDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeDistanceConditionXmlParser = std::make_shared<RelativeDistanceConditionXmlParser>(messageLogger, filename);
+            _relativeDistanceConditionXmlParser = std::make_shared<RelativeDistanceConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementRelativeDistanceConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6154,10 +6154,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EntityConditionXmlParser::EntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EntityConditionXmlParser::EntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6167,23 +6167,23 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EntityObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            EntityObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
 
         std::vector<std::shared_ptr<IElementParser>> EntityObjectXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementVehicleParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPedestrianParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementMiscObjectParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementVehicleParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPedestrianParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementMiscObjectParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EntityObjectXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityObjectXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityObjectXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6220,9 +6220,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CATALOG_REFERENCE
                     };
         }
-        EntityObjectXmlParser::SubElementVehicleParser::SubElementVehicleParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityObjectXmlParser::SubElementVehicleParser::SubElementVehicleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _vehicleXmlParser = std::make_shared<VehicleXmlParser>(messageLogger, filename);
+            _vehicleXmlParser = std::make_shared<VehicleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityObjectXmlParser::SubElementVehicleParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6258,9 +6258,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__VEHICLE
                     };
         }
-        EntityObjectXmlParser::SubElementPedestrianParser::SubElementPedestrianParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityObjectXmlParser::SubElementPedestrianParser::SubElementPedestrianParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _pedestrianXmlParser = std::make_shared<PedestrianXmlParser>(messageLogger, filename);
+            _pedestrianXmlParser = std::make_shared<PedestrianXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityObjectXmlParser::SubElementPedestrianParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6296,9 +6296,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PEDESTRIAN
                     };
         }
-        EntityObjectXmlParser::SubElementMiscObjectParser::SubElementMiscObjectParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityObjectXmlParser::SubElementMiscObjectParser::SubElementMiscObjectParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _miscObjectXmlParser = std::make_shared<MiscObjectXmlParser>(messageLogger, filename);
+            _miscObjectXmlParser = std::make_shared<MiscObjectXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityObjectXmlParser::SubElementMiscObjectParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6335,10 +6335,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EntityObjectXmlParser::EntityObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        EntityObjectXmlParser::EntityObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6348,7 +6348,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EntityRefXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            EntityRefXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EntityRefXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -6357,7 +6357,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6388,7 +6388,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -6399,10 +6399,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        EntityRefXmlParser::EntityRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EntityRefXmlParser::EntityRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6412,7 +6412,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EntitySelectionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            EntitySelectionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EntitySelectionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -6421,7 +6421,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6450,20 +6450,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> EntitySelectionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementMembersParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementMembersParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EntitySelectionXmlParser::SubElementMembersParser::SubElementMembersParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntitySelectionXmlParser::SubElementMembersParser::SubElementMembersParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _selectedEntitiesXmlParser = std::make_shared<SelectedEntitiesXmlParser>(messageLogger, filename);
+            _selectedEntitiesXmlParser = std::make_shared<SelectedEntitiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntitySelectionXmlParser::SubElementMembersParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6500,10 +6500,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EntitySelectionXmlParser::EntitySelectionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EntitySelectionXmlParser::EntitySelectionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6513,7 +6513,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EnvironmentXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            EnvironmentXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EnvironmentXmlParser::GetAttributeNameToAttributeParserMap()
@@ -6523,7 +6523,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6552,23 +6552,23 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> EnvironmentXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementTimeOfDayParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementWeatherParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRoadConditionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementTimeOfDayParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementWeatherParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRoadConditionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EnvironmentXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EnvironmentXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EnvironmentXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6602,9 +6602,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        EnvironmentXmlParser::SubElementTimeOfDayParser::SubElementTimeOfDayParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EnvironmentXmlParser::SubElementTimeOfDayParser::SubElementTimeOfDayParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _timeOfDayXmlParser = std::make_shared<TimeOfDayXmlParser>(messageLogger, filename);
+            _timeOfDayXmlParser = std::make_shared<TimeOfDayXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EnvironmentXmlParser::SubElementTimeOfDayParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6640,9 +6640,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TIME_OF_DAY
                     };
         }
-        EnvironmentXmlParser::SubElementWeatherParser::SubElementWeatherParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EnvironmentXmlParser::SubElementWeatherParser::SubElementWeatherParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _weatherXmlParser = std::make_shared<WeatherXmlParser>(messageLogger, filename);
+            _weatherXmlParser = std::make_shared<WeatherXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EnvironmentXmlParser::SubElementWeatherParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6678,9 +6678,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__WEATHER
                     };
         }
-        EnvironmentXmlParser::SubElementRoadConditionParser::SubElementRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EnvironmentXmlParser::SubElementRoadConditionParser::SubElementRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _roadConditionXmlParser = std::make_shared<RoadConditionXmlParser>(messageLogger, filename);
+            _roadConditionXmlParser = std::make_shared<RoadConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EnvironmentXmlParser::SubElementRoadConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6717,10 +6717,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EnvironmentXmlParser::EnvironmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EnvironmentXmlParser::EnvironmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6730,7 +6730,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EnvironmentActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            EnvironmentActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EnvironmentActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -6743,14 +6743,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> EnvironmentActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEnvironmentParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEnvironmentParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EnvironmentActionXmlParser::SubElementEnvironmentParser::SubElementEnvironmentParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EnvironmentActionXmlParser::SubElementEnvironmentParser::SubElementEnvironmentParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _environmentXmlParser = std::make_shared<EnvironmentXmlParser>(messageLogger, filename);
+            _environmentXmlParser = std::make_shared<EnvironmentXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EnvironmentActionXmlParser::SubElementEnvironmentParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6786,9 +6786,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENVIRONMENT
                     };
         }
-        EnvironmentActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EnvironmentActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EnvironmentActionXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6826,10 +6826,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EnvironmentActionXmlParser::EnvironmentActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EnvironmentActionXmlParser::EnvironmentActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6839,7 +6839,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EnvironmentCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            EnvironmentCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EnvironmentCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -6852,13 +6852,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> EnvironmentCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EnvironmentCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EnvironmentCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EnvironmentCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6895,10 +6895,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EnvironmentCatalogLocationXmlParser::EnvironmentCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EnvironmentCatalogLocationXmlParser::EnvironmentCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6908,7 +6908,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EventXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            EventXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EventXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -6917,7 +6917,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMaximumExecutionCount: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaximumExecutionCount(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaximumExecutionCount(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6946,11 +6946,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAXIMUM_EXECUTION_COUNT, std::make_shared<AttributeMaximumExecutionCount>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAXIMUM_EXECUTION_COUNT, std::make_shared<AttributeMaximumExecutionCount>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6979,11 +6979,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributePriority: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePriority(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePriority(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7021,21 +7021,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PRIORITY, std::make_shared<AttributePriority>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PRIORITY, std::make_shared<AttributePriority>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> EventXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementActionsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStartTriggerParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementActionsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStartTriggerParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EventXmlParser::SubElementActionsParser::SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EventXmlParser::SubElementActionsParser::SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _actionXmlParser = std::make_shared<ActionXmlParser>(messageLogger, filename);
+            _actionXmlParser = std::make_shared<ActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EventXmlParser::SubElementActionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7072,9 +7072,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ACTION
                     };
         }
-        EventXmlParser::SubElementStartTriggerParser::SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EventXmlParser::SubElementStartTriggerParser::SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename);
+            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EventXmlParser::SubElementStartTriggerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7111,10 +7111,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EventXmlParser::EventXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EventXmlParser::EventXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7124,7 +7124,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            FileXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            FileXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> FileXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -7133,7 +7133,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeFilepath: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFilepath(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFilepath(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7162,7 +7162,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FILEPATH, std::make_shared<AttributeFilepath>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FILEPATH, std::make_shared<AttributeFilepath>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -7173,10 +7173,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        FileXmlParser::FileXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        FileXmlParser::FileXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7186,7 +7186,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            FileHeaderXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            FileHeaderXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> FileHeaderXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -7195,7 +7195,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeAuthor: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeAuthor(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeAuthor(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7224,11 +7224,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__AUTHOR, std::make_shared<AttributeAuthor>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__AUTHOR, std::make_shared<AttributeAuthor>(_messageLogger, _filename, _parserOptions)));
             class AttributeDate: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDate(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDate(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7257,11 +7257,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DATE, std::make_shared<AttributeDate>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DATE, std::make_shared<AttributeDate>(_messageLogger, _filename, _parserOptions)));
             class AttributeDescription: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDescription(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDescription(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7290,11 +7290,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DESCRIPTION, std::make_shared<AttributeDescription>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DESCRIPTION, std::make_shared<AttributeDescription>(_messageLogger, _filename, _parserOptions)));
             class AttributeRevMajor: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRevMajor(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRevMajor(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7323,11 +7323,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__REV_MAJOR, std::make_shared<AttributeRevMajor>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__REV_MAJOR, std::make_shared<AttributeRevMajor>(_messageLogger, _filename, _parserOptions)));
             class AttributeRevMinor: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRevMinor(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRevMinor(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7356,7 +7356,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__REV_MINOR, std::make_shared<AttributeRevMinor>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__REV_MINOR, std::make_shared<AttributeRevMinor>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -7367,10 +7367,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        FileHeaderXmlParser::FileHeaderXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        FileHeaderXmlParser::FileHeaderXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7380,7 +7380,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            FinalSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            FinalSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> FinalSpeedXmlParser::GetAttributeNameToAttributeParserMap()
@@ -7393,14 +7393,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> FinalSpeedXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementAbsoluteSpeedParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRelativeSpeedToMasterParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementAbsoluteSpeedParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRelativeSpeedToMasterParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        FinalSpeedXmlParser::SubElementAbsoluteSpeedParser::SubElementAbsoluteSpeedParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FinalSpeedXmlParser::SubElementAbsoluteSpeedParser::SubElementAbsoluteSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _absoluteSpeedXmlParser = std::make_shared<AbsoluteSpeedXmlParser>(messageLogger, filename);
+            _absoluteSpeedXmlParser = std::make_shared<AbsoluteSpeedXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FinalSpeedXmlParser::SubElementAbsoluteSpeedParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7436,9 +7436,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ABSOLUTE_SPEED
                     };
         }
-        FinalSpeedXmlParser::SubElementRelativeSpeedToMasterParser::SubElementRelativeSpeedToMasterParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FinalSpeedXmlParser::SubElementRelativeSpeedToMasterParser::SubElementRelativeSpeedToMasterParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeSpeedToMasterXmlParser = std::make_shared<RelativeSpeedToMasterXmlParser>(messageLogger, filename);
+            _relativeSpeedToMasterXmlParser = std::make_shared<RelativeSpeedToMasterXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FinalSpeedXmlParser::SubElementRelativeSpeedToMasterParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7475,10 +7475,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        FinalSpeedXmlParser::FinalSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        FinalSpeedXmlParser::FinalSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7488,7 +7488,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            FogXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            FogXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> FogXmlParser::GetAttributeNameToAttributeParserMap()
@@ -7498,7 +7498,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeVisualRange: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeVisualRange(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeVisualRange(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7527,20 +7527,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VISUAL_RANGE, std::make_shared<AttributeVisualRange>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VISUAL_RANGE, std::make_shared<AttributeVisualRange>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> FogXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        FogXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FogXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename);
+            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FogXmlParser::SubElementBoundingBoxParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7577,10 +7577,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        FogXmlParser::FogXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        FogXmlParser::FogXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7590,7 +7590,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            FollowTrajectoryActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            FollowTrajectoryActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> FollowTrajectoryActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -7603,16 +7603,16 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> FollowTrajectoryActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTrajectoryParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTimeReferenceParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrajectoryFollowingModeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTrajectoryParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTimeReferenceParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrajectoryFollowingModeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        FollowTrajectoryActionXmlParser::SubElementTrajectoryParser::SubElementTrajectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FollowTrajectoryActionXmlParser::SubElementTrajectoryParser::SubElementTrajectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trajectoryXmlParser = std::make_shared<TrajectoryXmlParser>(messageLogger, filename);
+            _trajectoryXmlParser = std::make_shared<TrajectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FollowTrajectoryActionXmlParser::SubElementTrajectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7648,9 +7648,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAJECTORY
                     };
         }
-        FollowTrajectoryActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FollowTrajectoryActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FollowTrajectoryActionXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7687,9 +7687,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CATALOG_REFERENCE
                     };
         }
-        FollowTrajectoryActionXmlParser::SubElementTimeReferenceParser::SubElementTimeReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FollowTrajectoryActionXmlParser::SubElementTimeReferenceParser::SubElementTimeReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _timeReferenceXmlParser = std::make_shared<TimeReferenceXmlParser>(messageLogger, filename);
+            _timeReferenceXmlParser = std::make_shared<TimeReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FollowTrajectoryActionXmlParser::SubElementTimeReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7725,9 +7725,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TIME_REFERENCE
                     };
         }
-        FollowTrajectoryActionXmlParser::SubElementTrajectoryFollowingModeParser::SubElementTrajectoryFollowingModeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FollowTrajectoryActionXmlParser::SubElementTrajectoryFollowingModeParser::SubElementTrajectoryFollowingModeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trajectoryFollowingModeXmlParser = std::make_shared<TrajectoryFollowingModeXmlParser>(messageLogger, filename);
+            _trajectoryFollowingModeXmlParser = std::make_shared<TrajectoryFollowingModeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FollowTrajectoryActionXmlParser::SubElementTrajectoryFollowingModeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7764,10 +7764,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        FollowTrajectoryActionXmlParser::FollowTrajectoryActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        FollowTrajectoryActionXmlParser::FollowTrajectoryActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7777,7 +7777,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            GlobalActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            GlobalActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> GlobalActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -7790,17 +7790,17 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> GlobalActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEnvironmentActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementEntityActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementParameterActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementInfrastructureActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEnvironmentActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementEntityActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementParameterActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementInfrastructureActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        GlobalActionXmlParser::SubElementEnvironmentActionParser::SubElementEnvironmentActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        GlobalActionXmlParser::SubElementEnvironmentActionParser::SubElementEnvironmentActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _environmentActionXmlParser = std::make_shared<EnvironmentActionXmlParser>(messageLogger, filename);
+            _environmentActionXmlParser = std::make_shared<EnvironmentActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void GlobalActionXmlParser::SubElementEnvironmentActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7836,9 +7836,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENVIRONMENT_ACTION
                     };
         }
-        GlobalActionXmlParser::SubElementEntityActionParser::SubElementEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        GlobalActionXmlParser::SubElementEntityActionParser::SubElementEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityActionXmlParser = std::make_shared<EntityActionXmlParser>(messageLogger, filename);
+            _entityActionXmlParser = std::make_shared<EntityActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void GlobalActionXmlParser::SubElementEntityActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7874,9 +7874,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENTITY_ACTION
                     };
         }
-        GlobalActionXmlParser::SubElementParameterActionParser::SubElementParameterActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        GlobalActionXmlParser::SubElementParameterActionParser::SubElementParameterActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterActionXmlParser = std::make_shared<ParameterActionXmlParser>(messageLogger, filename);
+            _parameterActionXmlParser = std::make_shared<ParameterActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void GlobalActionXmlParser::SubElementParameterActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7912,9 +7912,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PARAMETER_ACTION
                     };
         }
-        GlobalActionXmlParser::SubElementInfrastructureActionParser::SubElementInfrastructureActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        GlobalActionXmlParser::SubElementInfrastructureActionParser::SubElementInfrastructureActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _infrastructureActionXmlParser = std::make_shared<InfrastructureActionXmlParser>(messageLogger, filename);
+            _infrastructureActionXmlParser = std::make_shared<InfrastructureActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void GlobalActionXmlParser::SubElementInfrastructureActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7950,9 +7950,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__INFRASTRUCTURE_ACTION
                     };
         }
-        GlobalActionXmlParser::SubElementTrafficActionParser::SubElementTrafficActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        GlobalActionXmlParser::SubElementTrafficActionParser::SubElementTrafficActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficActionXmlParser = std::make_shared<TrafficActionXmlParser>(messageLogger, filename);
+            _trafficActionXmlParser = std::make_shared<TrafficActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void GlobalActionXmlParser::SubElementTrafficActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7989,10 +7989,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        GlobalActionXmlParser::GlobalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        GlobalActionXmlParser::GlobalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8002,7 +8002,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            InRoutePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            InRoutePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> InRoutePositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -8015,15 +8015,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> InRoutePositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementFromCurrentEntityParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementFromRoadCoordinatesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementFromLaneCoordinatesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementFromCurrentEntityParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementFromRoadCoordinatesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementFromLaneCoordinatesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        InRoutePositionXmlParser::SubElementFromCurrentEntityParser::SubElementFromCurrentEntityParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InRoutePositionXmlParser::SubElementFromCurrentEntityParser::SubElementFromCurrentEntityParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionOfCurrentEntityXmlParser = std::make_shared<PositionOfCurrentEntityXmlParser>(messageLogger, filename);
+            _positionOfCurrentEntityXmlParser = std::make_shared<PositionOfCurrentEntityXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InRoutePositionXmlParser::SubElementFromCurrentEntityParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8059,9 +8059,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__FROM_CURRENT_ENTITY
                     };
         }
-        InRoutePositionXmlParser::SubElementFromRoadCoordinatesParser::SubElementFromRoadCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InRoutePositionXmlParser::SubElementFromRoadCoordinatesParser::SubElementFromRoadCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionInRoadCoordinatesXmlParser = std::make_shared<PositionInRoadCoordinatesXmlParser>(messageLogger, filename);
+            _positionInRoadCoordinatesXmlParser = std::make_shared<PositionInRoadCoordinatesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InRoutePositionXmlParser::SubElementFromRoadCoordinatesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8097,9 +8097,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__FROM_ROAD_COORDINATES
                     };
         }
-        InRoutePositionXmlParser::SubElementFromLaneCoordinatesParser::SubElementFromLaneCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InRoutePositionXmlParser::SubElementFromLaneCoordinatesParser::SubElementFromLaneCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionInLaneCoordinatesXmlParser = std::make_shared<PositionInLaneCoordinatesXmlParser>(messageLogger, filename);
+            _positionInLaneCoordinatesXmlParser = std::make_shared<PositionInLaneCoordinatesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InRoutePositionXmlParser::SubElementFromLaneCoordinatesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8136,10 +8136,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        InRoutePositionXmlParser::InRoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        InRoutePositionXmlParser::InRoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8149,7 +8149,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            InfrastructureActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            InfrastructureActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> InfrastructureActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -8162,13 +8162,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> InfrastructureActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTrafficSignalActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTrafficSignalActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        InfrastructureActionXmlParser::SubElementTrafficSignalActionParser::SubElementTrafficSignalActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InfrastructureActionXmlParser::SubElementTrafficSignalActionParser::SubElementTrafficSignalActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSignalActionXmlParser = std::make_shared<TrafficSignalActionXmlParser>(messageLogger, filename);
+            _trafficSignalActionXmlParser = std::make_shared<TrafficSignalActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InfrastructureActionXmlParser::SubElementTrafficSignalActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8205,10 +8205,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        InfrastructureActionXmlParser::InfrastructureActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        InfrastructureActionXmlParser::InfrastructureActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8218,7 +8218,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            InitXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            InitXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> InitXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8230,13 +8230,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> InitXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementActionsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementActionsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        InitXmlParser::SubElementActionsParser::SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InitXmlParser::SubElementActionsParser::SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _initActionsXmlParser = std::make_shared<InitActionsXmlParser>(messageLogger, filename);
+            _initActionsXmlParser = std::make_shared<InitActionsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InitXmlParser::SubElementActionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8273,10 +8273,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        InitXmlParser::InitXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        InitXmlParser::InitXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8286,7 +8286,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            InitActionsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            InitActionsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> InitActionsXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8298,15 +8298,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> InitActionsXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementGlobalActionsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementUserDefinedActionsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPrivatesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementGlobalActionsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementUserDefinedActionsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPrivatesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        InitActionsXmlParser::SubElementGlobalActionsParser::SubElementGlobalActionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InitActionsXmlParser::SubElementGlobalActionsParser::SubElementGlobalActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _globalActionXmlParser = std::make_shared<GlobalActionXmlParser>(messageLogger, filename);
+            _globalActionXmlParser = std::make_shared<GlobalActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InitActionsXmlParser::SubElementGlobalActionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8343,9 +8343,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__GLOBAL_ACTION
                     };
         }
-        InitActionsXmlParser::SubElementUserDefinedActionsParser::SubElementUserDefinedActionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InitActionsXmlParser::SubElementUserDefinedActionsParser::SubElementUserDefinedActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _userDefinedActionXmlParser = std::make_shared<UserDefinedActionXmlParser>(messageLogger, filename);
+            _userDefinedActionXmlParser = std::make_shared<UserDefinedActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InitActionsXmlParser::SubElementUserDefinedActionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8382,9 +8382,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__USER_DEFINED_ACTION
                     };
         }
-        InitActionsXmlParser::SubElementPrivatesParser::SubElementPrivatesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InitActionsXmlParser::SubElementPrivatesParser::SubElementPrivatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _privateXmlParser = std::make_shared<PrivateXmlParser>(messageLogger, filename);
+            _privateXmlParser = std::make_shared<PrivateXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InitActionsXmlParser::SubElementPrivatesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8422,10 +8422,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        InitActionsXmlParser::InitActionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        InitActionsXmlParser::InitActionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8435,7 +8435,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            KnotXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            KnotXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> KnotXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8444,7 +8444,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8473,7 +8473,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -8484,10 +8484,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        KnotXmlParser::KnotXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        KnotXmlParser::KnotXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8497,7 +8497,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LaneChangeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            LaneChangeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LaneChangeActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -8507,7 +8507,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeTargetLaneOffset: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTargetLaneOffset(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTargetLaneOffset(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8536,21 +8536,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TARGET_LANE_OFFSET, std::make_shared<AttributeTargetLaneOffset>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TARGET_LANE_OFFSET, std::make_shared<AttributeTargetLaneOffset>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> LaneChangeActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementLaneChangeActionDynamicsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementLaneChangeTargetParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementLaneChangeActionDynamicsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementLaneChangeTargetParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LaneChangeActionXmlParser::SubElementLaneChangeActionDynamicsParser::SubElementLaneChangeActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneChangeActionXmlParser::SubElementLaneChangeActionDynamicsParser::SubElementLaneChangeActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _transitionDynamicsXmlParser = std::make_shared<TransitionDynamicsXmlParser>(messageLogger, filename);
+            _transitionDynamicsXmlParser = std::make_shared<TransitionDynamicsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneChangeActionXmlParser::SubElementLaneChangeActionDynamicsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8586,9 +8586,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LANE_CHANGE_ACTION_DYNAMICS
                     };
         }
-        LaneChangeActionXmlParser::SubElementLaneChangeTargetParser::SubElementLaneChangeTargetParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneChangeActionXmlParser::SubElementLaneChangeTargetParser::SubElementLaneChangeTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _laneChangeTargetXmlParser = std::make_shared<LaneChangeTargetXmlParser>(messageLogger, filename);
+            _laneChangeTargetXmlParser = std::make_shared<LaneChangeTargetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneChangeActionXmlParser::SubElementLaneChangeTargetParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8625,10 +8625,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LaneChangeActionXmlParser::LaneChangeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LaneChangeActionXmlParser::LaneChangeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8638,7 +8638,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LaneChangeTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            LaneChangeTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LaneChangeTargetXmlParser::GetAttributeNameToAttributeParserMap()
@@ -8651,14 +8651,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> LaneChangeTargetXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRelativeTargetLaneParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementAbsoluteTargetLaneParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRelativeTargetLaneParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementAbsoluteTargetLaneParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LaneChangeTargetXmlParser::SubElementRelativeTargetLaneParser::SubElementRelativeTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneChangeTargetXmlParser::SubElementRelativeTargetLaneParser::SubElementRelativeTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeTargetLaneXmlParser = std::make_shared<RelativeTargetLaneXmlParser>(messageLogger, filename);
+            _relativeTargetLaneXmlParser = std::make_shared<RelativeTargetLaneXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneChangeTargetXmlParser::SubElementRelativeTargetLaneParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8694,9 +8694,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_TARGET_LANE
                     };
         }
-        LaneChangeTargetXmlParser::SubElementAbsoluteTargetLaneParser::SubElementAbsoluteTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneChangeTargetXmlParser::SubElementAbsoluteTargetLaneParser::SubElementAbsoluteTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _absoluteTargetLaneXmlParser = std::make_shared<AbsoluteTargetLaneXmlParser>(messageLogger, filename);
+            _absoluteTargetLaneXmlParser = std::make_shared<AbsoluteTargetLaneXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneChangeTargetXmlParser::SubElementAbsoluteTargetLaneParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8733,10 +8733,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LaneChangeTargetXmlParser::LaneChangeTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LaneChangeTargetXmlParser::LaneChangeTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8746,7 +8746,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LaneOffsetActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            LaneOffsetActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LaneOffsetActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -8756,7 +8756,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeContinuous: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8785,21 +8785,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> LaneOffsetActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementLaneOffsetActionDynamicsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementLaneOffsetTargetParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementLaneOffsetActionDynamicsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementLaneOffsetTargetParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LaneOffsetActionXmlParser::SubElementLaneOffsetActionDynamicsParser::SubElementLaneOffsetActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneOffsetActionXmlParser::SubElementLaneOffsetActionDynamicsParser::SubElementLaneOffsetActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _laneOffsetActionDynamicsXmlParser = std::make_shared<LaneOffsetActionDynamicsXmlParser>(messageLogger, filename);
+            _laneOffsetActionDynamicsXmlParser = std::make_shared<LaneOffsetActionDynamicsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneOffsetActionXmlParser::SubElementLaneOffsetActionDynamicsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8835,9 +8835,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LANE_OFFSET_ACTION_DYNAMICS
                     };
         }
-        LaneOffsetActionXmlParser::SubElementLaneOffsetTargetParser::SubElementLaneOffsetTargetParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneOffsetActionXmlParser::SubElementLaneOffsetTargetParser::SubElementLaneOffsetTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _laneOffsetTargetXmlParser = std::make_shared<LaneOffsetTargetXmlParser>(messageLogger, filename);
+            _laneOffsetTargetXmlParser = std::make_shared<LaneOffsetTargetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneOffsetActionXmlParser::SubElementLaneOffsetTargetParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8874,10 +8874,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LaneOffsetActionXmlParser::LaneOffsetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LaneOffsetActionXmlParser::LaneOffsetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8887,7 +8887,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LaneOffsetActionDynamicsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            LaneOffsetActionDynamicsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LaneOffsetActionDynamicsXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8896,7 +8896,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDynamicsShape: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDynamicsShape(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDynamicsShape(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8934,11 +8934,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DYNAMICS_SHAPE, std::make_shared<AttributeDynamicsShape>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DYNAMICS_SHAPE, std::make_shared<AttributeDynamicsShape>(_messageLogger, _filename, _parserOptions)));
             class AttributeMaxLateralAcc: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxLateralAcc(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxLateralAcc(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8967,7 +8967,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_LATERAL_ACC, std::make_shared<AttributeMaxLateralAcc>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_LATERAL_ACC, std::make_shared<AttributeMaxLateralAcc>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -8978,10 +8978,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        LaneOffsetActionDynamicsXmlParser::LaneOffsetActionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LaneOffsetActionDynamicsXmlParser::LaneOffsetActionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8991,7 +8991,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LaneOffsetTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            LaneOffsetTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LaneOffsetTargetXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9004,14 +9004,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> LaneOffsetTargetXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRelativeTargetLaneOffsetParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementAbsoluteTargetLaneOffsetParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRelativeTargetLaneOffsetParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementAbsoluteTargetLaneOffsetParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LaneOffsetTargetXmlParser::SubElementRelativeTargetLaneOffsetParser::SubElementRelativeTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneOffsetTargetXmlParser::SubElementRelativeTargetLaneOffsetParser::SubElementRelativeTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeTargetLaneOffsetXmlParser = std::make_shared<RelativeTargetLaneOffsetXmlParser>(messageLogger, filename);
+            _relativeTargetLaneOffsetXmlParser = std::make_shared<RelativeTargetLaneOffsetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneOffsetTargetXmlParser::SubElementRelativeTargetLaneOffsetParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9047,9 +9047,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_TARGET_LANE_OFFSET
                     };
         }
-        LaneOffsetTargetXmlParser::SubElementAbsoluteTargetLaneOffsetParser::SubElementAbsoluteTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneOffsetTargetXmlParser::SubElementAbsoluteTargetLaneOffsetParser::SubElementAbsoluteTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _absoluteTargetLaneOffsetXmlParser = std::make_shared<AbsoluteTargetLaneOffsetXmlParser>(messageLogger, filename);
+            _absoluteTargetLaneOffsetXmlParser = std::make_shared<AbsoluteTargetLaneOffsetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneOffsetTargetXmlParser::SubElementAbsoluteTargetLaneOffsetParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9086,10 +9086,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LaneOffsetTargetXmlParser::LaneOffsetTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LaneOffsetTargetXmlParser::LaneOffsetTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9099,7 +9099,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LanePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            LanePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LanePositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9109,7 +9109,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeLaneId: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLaneId(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLaneId(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9138,11 +9138,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LANE_ID, std::make_shared<AttributeLaneId>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LANE_ID, std::make_shared<AttributeLaneId>(_messageLogger, _filename, _parserOptions)));
             class AttributeOffset: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9171,11 +9171,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename, _parserOptions)));
             class AttributeRoadId: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRoadId(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRoadId(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9204,11 +9204,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ROAD_ID, std::make_shared<AttributeRoadId>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ROAD_ID, std::make_shared<AttributeRoadId>(_messageLogger, _filename, _parserOptions)));
             class AttributeS: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeS(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeS(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9237,20 +9237,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__S, std::make_shared<AttributeS>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__S, std::make_shared<AttributeS>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> LanePositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LanePositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LanePositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LanePositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9287,10 +9287,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LanePositionXmlParser::LanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LanePositionXmlParser::LanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9300,7 +9300,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LateralActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            LateralActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LateralActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9313,15 +9313,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> LateralActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementLaneChangeActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementLaneOffsetActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementLateralDistanceActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementLaneChangeActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementLaneOffsetActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementLateralDistanceActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LateralActionXmlParser::SubElementLaneChangeActionParser::SubElementLaneChangeActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LateralActionXmlParser::SubElementLaneChangeActionParser::SubElementLaneChangeActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _laneChangeActionXmlParser = std::make_shared<LaneChangeActionXmlParser>(messageLogger, filename);
+            _laneChangeActionXmlParser = std::make_shared<LaneChangeActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LateralActionXmlParser::SubElementLaneChangeActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9357,9 +9357,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LANE_CHANGE_ACTION
                     };
         }
-        LateralActionXmlParser::SubElementLaneOffsetActionParser::SubElementLaneOffsetActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LateralActionXmlParser::SubElementLaneOffsetActionParser::SubElementLaneOffsetActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _laneOffsetActionXmlParser = std::make_shared<LaneOffsetActionXmlParser>(messageLogger, filename);
+            _laneOffsetActionXmlParser = std::make_shared<LaneOffsetActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LateralActionXmlParser::SubElementLaneOffsetActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9395,9 +9395,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LANE_OFFSET_ACTION
                     };
         }
-        LateralActionXmlParser::SubElementLateralDistanceActionParser::SubElementLateralDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LateralActionXmlParser::SubElementLateralDistanceActionParser::SubElementLateralDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _lateralDistanceActionXmlParser = std::make_shared<LateralDistanceActionXmlParser>(messageLogger, filename);
+            _lateralDistanceActionXmlParser = std::make_shared<LateralDistanceActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LateralActionXmlParser::SubElementLateralDistanceActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9434,10 +9434,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LateralActionXmlParser::LateralActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LateralActionXmlParser::LateralActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9447,7 +9447,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LateralDistanceActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            LateralDistanceActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LateralDistanceActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9457,7 +9457,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeContinuous: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9486,11 +9486,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename, _parserOptions)));
             class AttributeDistance: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDistance(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDistance(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9519,11 +9519,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DISTANCE, std::make_shared<AttributeDistance>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DISTANCE, std::make_shared<AttributeDistance>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9554,11 +9554,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeFreespace: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9587,20 +9587,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> LateralDistanceActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDynamicConstraintsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDynamicConstraintsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LateralDistanceActionXmlParser::SubElementDynamicConstraintsParser::SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LateralDistanceActionXmlParser::SubElementDynamicConstraintsParser::SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _dynamicConstraintsXmlParser = std::make_shared<DynamicConstraintsXmlParser>(messageLogger, filename);
+            _dynamicConstraintsXmlParser = std::make_shared<DynamicConstraintsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LateralDistanceActionXmlParser::SubElementDynamicConstraintsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9637,10 +9637,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LateralDistanceActionXmlParser::LateralDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LateralDistanceActionXmlParser::LateralDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9650,7 +9650,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LongitudinalActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            LongitudinalActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LongitudinalActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9663,14 +9663,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> LongitudinalActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementSpeedActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementLongitudinalDistanceActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementSpeedActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementLongitudinalDistanceActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LongitudinalActionXmlParser::SubElementSpeedActionParser::SubElementSpeedActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LongitudinalActionXmlParser::SubElementSpeedActionParser::SubElementSpeedActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _speedActionXmlParser = std::make_shared<SpeedActionXmlParser>(messageLogger, filename);
+            _speedActionXmlParser = std::make_shared<SpeedActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LongitudinalActionXmlParser::SubElementSpeedActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9706,9 +9706,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SPEED_ACTION
                     };
         }
-        LongitudinalActionXmlParser::SubElementLongitudinalDistanceActionParser::SubElementLongitudinalDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LongitudinalActionXmlParser::SubElementLongitudinalDistanceActionParser::SubElementLongitudinalDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _longitudinalDistanceActionXmlParser = std::make_shared<LongitudinalDistanceActionXmlParser>(messageLogger, filename);
+            _longitudinalDistanceActionXmlParser = std::make_shared<LongitudinalDistanceActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LongitudinalActionXmlParser::SubElementLongitudinalDistanceActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9745,10 +9745,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LongitudinalActionXmlParser::LongitudinalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LongitudinalActionXmlParser::LongitudinalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9758,7 +9758,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LongitudinalDistanceActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            LongitudinalDistanceActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LongitudinalDistanceActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9768,7 +9768,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeContinuous: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9797,11 +9797,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename, _parserOptions)));
             class AttributeDistance: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDistance(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDistance(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9830,11 +9830,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DISTANCE, std::make_shared<AttributeDistance>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DISTANCE, std::make_shared<AttributeDistance>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9865,11 +9865,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeFreespace: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9898,11 +9898,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename, _parserOptions)));
             class AttributeTimeGap: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTimeGap(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTimeGap(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9931,20 +9931,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TIME_GAP, std::make_shared<AttributeTimeGap>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TIME_GAP, std::make_shared<AttributeTimeGap>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> LongitudinalDistanceActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDynamicConstraintsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDynamicConstraintsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LongitudinalDistanceActionXmlParser::SubElementDynamicConstraintsParser::SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LongitudinalDistanceActionXmlParser::SubElementDynamicConstraintsParser::SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _dynamicConstraintsXmlParser = std::make_shared<DynamicConstraintsXmlParser>(messageLogger, filename);
+            _dynamicConstraintsXmlParser = std::make_shared<DynamicConstraintsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LongitudinalDistanceActionXmlParser::SubElementDynamicConstraintsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9981,10 +9981,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LongitudinalDistanceActionXmlParser::LongitudinalDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LongitudinalDistanceActionXmlParser::LongitudinalDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9994,7 +9994,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ManeuverXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ManeuverXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ManeuverXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10003,7 +10003,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10032,21 +10032,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ManeuverXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementEventsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementEventsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ManeuverXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ManeuverXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ManeuverXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10080,9 +10080,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        ManeuverXmlParser::SubElementEventsParser::SubElementEventsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ManeuverXmlParser::SubElementEventsParser::SubElementEventsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _eventXmlParser = std::make_shared<EventXmlParser>(messageLogger, filename);
+            _eventXmlParser = std::make_shared<EventXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ManeuverXmlParser::SubElementEventsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10120,10 +10120,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ManeuverXmlParser::ManeuverXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ManeuverXmlParser::ManeuverXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10133,7 +10133,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ManeuverCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ManeuverCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ManeuverCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -10146,13 +10146,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ManeuverCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ManeuverCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ManeuverCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ManeuverCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10189,10 +10189,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ManeuverCatalogLocationXmlParser::ManeuverCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ManeuverCatalogLocationXmlParser::ManeuverCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10202,7 +10202,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ManeuverGroupXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ManeuverGroupXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ManeuverGroupXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10211,7 +10211,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMaximumExecutionCount: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaximumExecutionCount(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaximumExecutionCount(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10240,11 +10240,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAXIMUM_EXECUTION_COUNT, std::make_shared<AttributeMaximumExecutionCount>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAXIMUM_EXECUTION_COUNT, std::make_shared<AttributeMaximumExecutionCount>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10273,22 +10273,22 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ManeuverGroupXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementActorsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferencesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementManeuversParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementActorsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferencesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementManeuversParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ManeuverGroupXmlParser::SubElementActorsParser::SubElementActorsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ManeuverGroupXmlParser::SubElementActorsParser::SubElementActorsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _actorsXmlParser = std::make_shared<ActorsXmlParser>(messageLogger, filename);
+            _actorsXmlParser = std::make_shared<ActorsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ManeuverGroupXmlParser::SubElementActorsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10324,9 +10324,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ACTORS
                     };
         }
-        ManeuverGroupXmlParser::SubElementCatalogReferencesParser::SubElementCatalogReferencesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ManeuverGroupXmlParser::SubElementCatalogReferencesParser::SubElementCatalogReferencesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ManeuverGroupXmlParser::SubElementCatalogReferencesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10364,9 +10364,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CATALOG_REFERENCE
                     };
         }
-        ManeuverGroupXmlParser::SubElementManeuversParser::SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ManeuverGroupXmlParser::SubElementManeuversParser::SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _maneuverXmlParser = std::make_shared<ManeuverXmlParser>(messageLogger, filename);
+            _maneuverXmlParser = std::make_shared<ManeuverXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ManeuverGroupXmlParser::SubElementManeuversParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10404,10 +10404,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ManeuverGroupXmlParser::ManeuverGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ManeuverGroupXmlParser::ManeuverGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10417,7 +10417,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            MiscObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            MiscObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> MiscObjectXmlParser::GetAttributeNameToAttributeParserMap()
@@ -10427,7 +10427,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMass: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMass(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMass(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10456,11 +10456,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MASS, std::make_shared<AttributeMass>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MASS, std::make_shared<AttributeMass>(_messageLogger, _filename, _parserOptions)));
             class AttributeMiscObjectCategory: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMiscObjectCategory(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMiscObjectCategory(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10498,11 +10498,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MISC_OBJECT_CATEGORY, std::make_shared<AttributeMiscObjectCategory>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MISC_OBJECT_CATEGORY, std::make_shared<AttributeMiscObjectCategory>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10531,22 +10531,22 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> MiscObjectXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        MiscObjectXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        MiscObjectXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void MiscObjectXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10580,9 +10580,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        MiscObjectXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename)
+        MiscObjectXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename);
+            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void MiscObjectXmlParser::SubElementBoundingBoxParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10618,9 +10618,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__BOUNDING_BOX
                     };
         }
-        MiscObjectXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        MiscObjectXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename);
+            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void MiscObjectXmlParser::SubElementPropertiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10657,10 +10657,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        MiscObjectXmlParser::MiscObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        MiscObjectXmlParser::MiscObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10670,7 +10670,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            MiscObjectCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            MiscObjectCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> MiscObjectCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -10683,13 +10683,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> MiscObjectCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        MiscObjectCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        MiscObjectCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void MiscObjectCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10726,10 +10726,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        MiscObjectCatalogLocationXmlParser::MiscObjectCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        MiscObjectCatalogLocationXmlParser::MiscObjectCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10739,7 +10739,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ModifyRuleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ModifyRuleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ModifyRuleXmlParser::GetAttributeNameToAttributeParserMap()
@@ -10752,14 +10752,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ModifyRuleXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementAddValueParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementMultiplyByValueParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementAddValueParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementMultiplyByValueParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ModifyRuleXmlParser::SubElementAddValueParser::SubElementAddValueParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ModifyRuleXmlParser::SubElementAddValueParser::SubElementAddValueParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterAddValueRuleXmlParser = std::make_shared<ParameterAddValueRuleXmlParser>(messageLogger, filename);
+            _parameterAddValueRuleXmlParser = std::make_shared<ParameterAddValueRuleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ModifyRuleXmlParser::SubElementAddValueParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10795,9 +10795,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ADD_VALUE
                     };
         }
-        ModifyRuleXmlParser::SubElementMultiplyByValueParser::SubElementMultiplyByValueParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ModifyRuleXmlParser::SubElementMultiplyByValueParser::SubElementMultiplyByValueParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterMultiplyByValueRuleXmlParser = std::make_shared<ParameterMultiplyByValueRuleXmlParser>(messageLogger, filename);
+            _parameterMultiplyByValueRuleXmlParser = std::make_shared<ParameterMultiplyByValueRuleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ModifyRuleXmlParser::SubElementMultiplyByValueParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10834,10 +10834,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ModifyRuleXmlParser::ModifyRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ModifyRuleXmlParser::ModifyRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10847,7 +10847,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            NoneXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            NoneXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> NoneXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10863,10 +10863,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        NoneXmlParser::NoneXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        NoneXmlParser::NoneXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10876,7 +10876,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            NurbsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            NurbsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> NurbsXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10885,7 +10885,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeOrder: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeOrder(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeOrder(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10914,21 +10914,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ORDER, std::make_shared<AttributeOrder>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ORDER, std::make_shared<AttributeOrder>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> NurbsXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementControlPointsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementKnotsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementControlPointsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementKnotsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        NurbsXmlParser::SubElementControlPointsParser::SubElementControlPointsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        NurbsXmlParser::SubElementControlPointsParser::SubElementControlPointsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controlPointXmlParser = std::make_shared<ControlPointXmlParser>(messageLogger, filename);
+            _controlPointXmlParser = std::make_shared<ControlPointXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void NurbsXmlParser::SubElementControlPointsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10965,9 +10965,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CONTROL_POINT
                     };
         }
-        NurbsXmlParser::SubElementKnotsParser::SubElementKnotsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        NurbsXmlParser::SubElementKnotsParser::SubElementKnotsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _knotXmlParser = std::make_shared<KnotXmlParser>(messageLogger, filename);
+            _knotXmlParser = std::make_shared<KnotXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void NurbsXmlParser::SubElementKnotsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11005,10 +11005,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        NurbsXmlParser::NurbsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        NurbsXmlParser::NurbsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11018,7 +11018,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ObjectControllerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ObjectControllerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ObjectControllerXmlParser::GetAttributeNameToAttributeParserMap()
@@ -11031,14 +11031,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ObjectControllerXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementControllerParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementControllerParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ObjectControllerXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ObjectControllerXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ObjectControllerXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11075,9 +11075,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CATALOG_REFERENCE
                     };
         }
-        ObjectControllerXmlParser::SubElementControllerParser::SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ObjectControllerXmlParser::SubElementControllerParser::SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename);
+            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ObjectControllerXmlParser::SubElementControllerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11114,10 +11114,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ObjectControllerXmlParser::ObjectControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ObjectControllerXmlParser::ObjectControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11127,7 +11127,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OffroadConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OffroadConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OffroadConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11136,7 +11136,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDuration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11165,7 +11165,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -11176,10 +11176,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OffroadConditionXmlParser::OffroadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OffroadConditionXmlParser::OffroadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11189,7 +11189,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OpenScenarioXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OpenScenarioXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OpenScenarioXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11201,14 +11201,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> OpenScenarioXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementFileHeaderParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementOpenScenarioCategoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementFileHeaderParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementOpenScenarioCategoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        OpenScenarioXmlParser::SubElementFileHeaderParser::SubElementFileHeaderParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OpenScenarioXmlParser::SubElementFileHeaderParser::SubElementFileHeaderParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _fileHeaderXmlParser = std::make_shared<FileHeaderXmlParser>(messageLogger, filename);
+            _fileHeaderXmlParser = std::make_shared<FileHeaderXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OpenScenarioXmlParser::SubElementFileHeaderParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11244,9 +11244,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__FILE_HEADER
                     };
         }
-        OpenScenarioXmlParser::SubElementOpenScenarioCategoryParser::SubElementOpenScenarioCategoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OpenScenarioXmlParser::SubElementOpenScenarioCategoryParser::SubElementOpenScenarioCategoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _openScenarioCategoryXmlParser = std::make_shared<OpenScenarioCategoryXmlParser>(messageLogger, filename);
+            _openScenarioCategoryXmlParser = std::make_shared<OpenScenarioCategoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OpenScenarioXmlParser::SubElementOpenScenarioCategoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11287,10 +11287,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        OpenScenarioXmlParser::OpenScenarioXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OpenScenarioXmlParser::OpenScenarioXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11300,21 +11300,21 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OpenScenarioCategoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            OpenScenarioCategoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
 
         std::vector<std::shared_ptr<IElementParser>> OpenScenarioCategoryXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementScenarioDefinitionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogDefinitionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementScenarioDefinitionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogDefinitionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        OpenScenarioCategoryXmlParser::SubElementScenarioDefinitionParser::SubElementScenarioDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OpenScenarioCategoryXmlParser::SubElementScenarioDefinitionParser::SubElementScenarioDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _scenarioDefinitionXmlParser = std::make_shared<ScenarioDefinitionXmlParser>(messageLogger, filename);
+            _scenarioDefinitionXmlParser = std::make_shared<ScenarioDefinitionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OpenScenarioCategoryXmlParser::SubElementScenarioDefinitionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11352,9 +11352,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CATALOG_LOCATIONS
                     };
         }
-        OpenScenarioCategoryXmlParser::SubElementCatalogDefinitionParser::SubElementCatalogDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OpenScenarioCategoryXmlParser::SubElementCatalogDefinitionParser::SubElementCatalogDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogDefinitionXmlParser = std::make_shared<CatalogDefinitionXmlParser>(messageLogger, filename);
+            _catalogDefinitionXmlParser = std::make_shared<CatalogDefinitionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OpenScenarioCategoryXmlParser::SubElementCatalogDefinitionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11391,10 +11391,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        OpenScenarioCategoryXmlParser::OpenScenarioCategoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        OpenScenarioCategoryXmlParser::OpenScenarioCategoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11404,7 +11404,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OrientationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OrientationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OrientationXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11413,7 +11413,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeH: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeH(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeH(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11442,11 +11442,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__H, std::make_shared<AttributeH>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__H, std::make_shared<AttributeH>(_messageLogger, _filename, _parserOptions)));
             class AttributeP: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeP(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeP(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11475,11 +11475,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__P, std::make_shared<AttributeP>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__P, std::make_shared<AttributeP>(_messageLogger, _filename, _parserOptions)));
             class AttributeR: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeR(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeR(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11508,11 +11508,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__R, std::make_shared<AttributeR>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__R, std::make_shared<AttributeR>(_messageLogger, _filename, _parserOptions)));
             class AttributeType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11550,7 +11550,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TYPE, std::make_shared<AttributeType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TYPE, std::make_shared<AttributeType>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -11561,10 +11561,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OrientationXmlParser::OrientationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OrientationXmlParser::OrientationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11574,7 +11574,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OverrideBrakeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OverrideBrakeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OverrideBrakeActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11583,7 +11583,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeActive: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11612,11 +11612,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11645,7 +11645,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -11656,10 +11656,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OverrideBrakeActionXmlParser::OverrideBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OverrideBrakeActionXmlParser::OverrideBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11669,7 +11669,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OverrideClutchActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OverrideClutchActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OverrideClutchActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11678,7 +11678,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeActive: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11707,11 +11707,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11740,7 +11740,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -11751,10 +11751,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OverrideClutchActionXmlParser::OverrideClutchActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OverrideClutchActionXmlParser::OverrideClutchActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11764,7 +11764,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OverrideControllerValueActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            OverrideControllerValueActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OverrideControllerValueActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -11777,18 +11777,18 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> OverrideControllerValueActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementThrottleParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementBrakeParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementClutchParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementParkingBrakeParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementSteeringWheelParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementGearParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementThrottleParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementBrakeParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementClutchParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementParkingBrakeParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementSteeringWheelParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementGearParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        OverrideControllerValueActionXmlParser::SubElementThrottleParser::SubElementThrottleParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OverrideControllerValueActionXmlParser::SubElementThrottleParser::SubElementThrottleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _overrideThrottleActionXmlParser = std::make_shared<OverrideThrottleActionXmlParser>(messageLogger, filename);
+            _overrideThrottleActionXmlParser = std::make_shared<OverrideThrottleActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OverrideControllerValueActionXmlParser::SubElementThrottleParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11824,9 +11824,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__THROTTLE
                     };
         }
-        OverrideControllerValueActionXmlParser::SubElementBrakeParser::SubElementBrakeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OverrideControllerValueActionXmlParser::SubElementBrakeParser::SubElementBrakeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _overrideBrakeActionXmlParser = std::make_shared<OverrideBrakeActionXmlParser>(messageLogger, filename);
+            _overrideBrakeActionXmlParser = std::make_shared<OverrideBrakeActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OverrideControllerValueActionXmlParser::SubElementBrakeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11862,9 +11862,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__BRAKE
                     };
         }
-        OverrideControllerValueActionXmlParser::SubElementClutchParser::SubElementClutchParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OverrideControllerValueActionXmlParser::SubElementClutchParser::SubElementClutchParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _overrideClutchActionXmlParser = std::make_shared<OverrideClutchActionXmlParser>(messageLogger, filename);
+            _overrideClutchActionXmlParser = std::make_shared<OverrideClutchActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OverrideControllerValueActionXmlParser::SubElementClutchParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11900,9 +11900,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CLUTCH
                     };
         }
-        OverrideControllerValueActionXmlParser::SubElementParkingBrakeParser::SubElementParkingBrakeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OverrideControllerValueActionXmlParser::SubElementParkingBrakeParser::SubElementParkingBrakeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _overrideParkingBrakeActionXmlParser = std::make_shared<OverrideParkingBrakeActionXmlParser>(messageLogger, filename);
+            _overrideParkingBrakeActionXmlParser = std::make_shared<OverrideParkingBrakeActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OverrideControllerValueActionXmlParser::SubElementParkingBrakeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11938,9 +11938,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PARKING_BRAKE
                     };
         }
-        OverrideControllerValueActionXmlParser::SubElementSteeringWheelParser::SubElementSteeringWheelParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OverrideControllerValueActionXmlParser::SubElementSteeringWheelParser::SubElementSteeringWheelParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _overrideSteeringWheelActionXmlParser = std::make_shared<OverrideSteeringWheelActionXmlParser>(messageLogger, filename);
+            _overrideSteeringWheelActionXmlParser = std::make_shared<OverrideSteeringWheelActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OverrideControllerValueActionXmlParser::SubElementSteeringWheelParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11976,9 +11976,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__STEERING_WHEEL
                     };
         }
-        OverrideControllerValueActionXmlParser::SubElementGearParser::SubElementGearParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OverrideControllerValueActionXmlParser::SubElementGearParser::SubElementGearParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _overrideGearActionXmlParser = std::make_shared<OverrideGearActionXmlParser>(messageLogger, filename);
+            _overrideGearActionXmlParser = std::make_shared<OverrideGearActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OverrideControllerValueActionXmlParser::SubElementGearParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12015,10 +12015,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        OverrideControllerValueActionXmlParser::OverrideControllerValueActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OverrideControllerValueActionXmlParser::OverrideControllerValueActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12028,7 +12028,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OverrideGearActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OverrideGearActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OverrideGearActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -12037,7 +12037,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeActive: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12066,11 +12066,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename, _parserOptions)));
             class AttributeNumber: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeNumber(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeNumber(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12099,7 +12099,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NUMBER, std::make_shared<AttributeNumber>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NUMBER, std::make_shared<AttributeNumber>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -12110,10 +12110,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OverrideGearActionXmlParser::OverrideGearActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OverrideGearActionXmlParser::OverrideGearActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12123,7 +12123,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OverrideParkingBrakeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OverrideParkingBrakeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OverrideParkingBrakeActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -12132,7 +12132,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeActive: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12161,11 +12161,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12194,7 +12194,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -12205,10 +12205,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OverrideParkingBrakeActionXmlParser::OverrideParkingBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OverrideParkingBrakeActionXmlParser::OverrideParkingBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12218,7 +12218,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OverrideSteeringWheelActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OverrideSteeringWheelActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OverrideSteeringWheelActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -12227,7 +12227,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeActive: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12256,11 +12256,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12289,7 +12289,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -12300,10 +12300,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OverrideSteeringWheelActionXmlParser::OverrideSteeringWheelActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OverrideSteeringWheelActionXmlParser::OverrideSteeringWheelActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12313,7 +12313,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OverrideThrottleActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OverrideThrottleActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OverrideThrottleActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -12322,7 +12322,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeActive: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12351,11 +12351,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12384,7 +12384,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -12395,10 +12395,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OverrideThrottleActionXmlParser::OverrideThrottleActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OverrideThrottleActionXmlParser::OverrideThrottleActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 

--- a/cpp/openScenarioLib/generated/v1_0/xmlParser/XmlParsers2V1_0.cpp
+++ b/cpp/openScenarioLib/generated/v1_0/xmlParser/XmlParsers2V1_0.cpp
@@ -35,7 +35,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ParameterActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -45,7 +45,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeParameterRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeParameterRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeParameterRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -76,21 +76,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_REF, std::make_shared<AttributeParameterRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_REF, std::make_shared<AttributeParameterRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ParameterActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementSetActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementModifyActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementSetActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementModifyActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ParameterActionXmlParser::SubElementSetActionParser::SubElementSetActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ParameterActionXmlParser::SubElementSetActionParser::SubElementSetActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterSetActionXmlParser = std::make_shared<ParameterSetActionXmlParser>(messageLogger, filename);
+            _parameterSetActionXmlParser = std::make_shared<ParameterSetActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ParameterActionXmlParser::SubElementSetActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -126,9 +126,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SET_ACTION
                     };
         }
-        ParameterActionXmlParser::SubElementModifyActionParser::SubElementModifyActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ParameterActionXmlParser::SubElementModifyActionParser::SubElementModifyActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterModifyActionXmlParser = std::make_shared<ParameterModifyActionXmlParser>(messageLogger, filename);
+            _parameterModifyActionXmlParser = std::make_shared<ParameterModifyActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ParameterActionXmlParser::SubElementModifyActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -165,10 +165,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ParameterActionXmlParser::ParameterActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterActionXmlParser::ParameterActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -178,7 +178,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterAddValueRuleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterAddValueRuleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterAddValueRuleXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -187,7 +187,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -216,7 +216,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -227,10 +227,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ParameterAddValueRuleXmlParser::ParameterAddValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterAddValueRuleXmlParser::ParameterAddValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -240,7 +240,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterAssignmentXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterAssignmentXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterAssignmentXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -249,7 +249,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeParameterRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeParameterRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeParameterRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -269,11 +269,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_REF, std::make_shared<AttributeParameterRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_REF, std::make_shared<AttributeParameterRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -302,7 +302,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -313,10 +313,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ParameterAssignmentXmlParser::ParameterAssignmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterAssignmentXmlParser::ParameterAssignmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -326,7 +326,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -335,7 +335,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeParameterRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeParameterRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeParameterRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -366,11 +366,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_REF, std::make_shared<AttributeParameterRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_REF, std::make_shared<AttributeParameterRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -408,11 +408,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -441,7 +441,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -452,10 +452,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ParameterConditionXmlParser::ParameterConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterConditionXmlParser::ParameterConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -465,7 +465,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterDeclarationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterDeclarationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterDeclarationXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -474,7 +474,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -492,11 +492,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeParameterType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeParameterType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeParameterType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -534,11 +534,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_TYPE, std::make_shared<AttributeParameterType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_TYPE, std::make_shared<AttributeParameterType>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -567,7 +567,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -578,10 +578,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ParameterDeclarationXmlParser::ParameterDeclarationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterDeclarationXmlParser::ParameterDeclarationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -591,7 +591,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterModifyActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ParameterModifyActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterModifyActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -604,13 +604,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ParameterModifyActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRuleParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRuleParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ParameterModifyActionXmlParser::SubElementRuleParser::SubElementRuleParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ParameterModifyActionXmlParser::SubElementRuleParser::SubElementRuleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _modifyRuleXmlParser = std::make_shared<ModifyRuleXmlParser>(messageLogger, filename);
+            _modifyRuleXmlParser = std::make_shared<ModifyRuleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ParameterModifyActionXmlParser::SubElementRuleParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -647,10 +647,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ParameterModifyActionXmlParser::ParameterModifyActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterModifyActionXmlParser::ParameterModifyActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -660,7 +660,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterMultiplyByValueRuleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterMultiplyByValueRuleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterMultiplyByValueRuleXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -669,7 +669,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -698,7 +698,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -709,10 +709,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ParameterMultiplyByValueRuleXmlParser::ParameterMultiplyByValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterMultiplyByValueRuleXmlParser::ParameterMultiplyByValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -722,7 +722,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterSetActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterSetActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterSetActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -731,7 +731,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -760,7 +760,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -771,10 +771,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ParameterSetActionXmlParser::ParameterSetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterSetActionXmlParser::ParameterSetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -784,7 +784,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PedestrianXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            PedestrianXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PedestrianXmlParser::GetAttributeNameToAttributeParserMap()
@@ -794,7 +794,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMass: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMass(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMass(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -823,11 +823,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MASS, std::make_shared<AttributeMass>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MASS, std::make_shared<AttributeMass>(_messageLogger, _filename, _parserOptions)));
             class AttributeModel: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeModel(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeModel(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -856,11 +856,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MODEL, std::make_shared<AttributeModel>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MODEL, std::make_shared<AttributeModel>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -889,11 +889,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributePedestrianCategory: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePedestrianCategory(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePedestrianCategory(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -931,22 +931,22 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PEDESTRIAN_CATEGORY, std::make_shared<AttributePedestrianCategory>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PEDESTRIAN_CATEGORY, std::make_shared<AttributePedestrianCategory>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> PedestrianXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PedestrianXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PedestrianXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PedestrianXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -980,9 +980,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        PedestrianXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PedestrianXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename);
+            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PedestrianXmlParser::SubElementBoundingBoxParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1018,9 +1018,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__BOUNDING_BOX
                     };
         }
-        PedestrianXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PedestrianXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename);
+            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PedestrianXmlParser::SubElementPropertiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1057,10 +1057,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PedestrianXmlParser::PedestrianXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PedestrianXmlParser::PedestrianXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1070,7 +1070,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PedestrianCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            PedestrianCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PedestrianCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -1083,13 +1083,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> PedestrianCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PedestrianCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PedestrianCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PedestrianCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1126,10 +1126,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PedestrianCatalogLocationXmlParser::PedestrianCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PedestrianCatalogLocationXmlParser::PedestrianCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1139,7 +1139,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PerformanceXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PerformanceXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PerformanceXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1148,7 +1148,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMaxAcceleration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxAcceleration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxAcceleration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1177,11 +1177,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_ACCELERATION, std::make_shared<AttributeMaxAcceleration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_ACCELERATION, std::make_shared<AttributeMaxAcceleration>(_messageLogger, _filename, _parserOptions)));
             class AttributeMaxDeceleration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxDeceleration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxDeceleration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1210,11 +1210,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_DECELERATION, std::make_shared<AttributeMaxDeceleration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_DECELERATION, std::make_shared<AttributeMaxDeceleration>(_messageLogger, _filename, _parserOptions)));
             class AttributeMaxSpeed: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxSpeed(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxSpeed(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1243,7 +1243,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_SPEED, std::make_shared<AttributeMaxSpeed>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_SPEED, std::make_shared<AttributeMaxSpeed>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -1254,10 +1254,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        PerformanceXmlParser::PerformanceXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PerformanceXmlParser::PerformanceXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1267,7 +1267,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PhaseXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PhaseXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PhaseXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1276,7 +1276,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDuration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1305,11 +1305,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1338,20 +1338,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> PhaseXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTrafficSignalStatesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTrafficSignalStatesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PhaseXmlParser::SubElementTrafficSignalStatesParser::SubElementTrafficSignalStatesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PhaseXmlParser::SubElementTrafficSignalStatesParser::SubElementTrafficSignalStatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSignalStateXmlParser = std::make_shared<TrafficSignalStateXmlParser>(messageLogger, filename);
+            _trafficSignalStateXmlParser = std::make_shared<TrafficSignalStateXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PhaseXmlParser::SubElementTrafficSignalStatesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1389,10 +1389,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PhaseXmlParser::PhaseXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PhaseXmlParser::PhaseXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1402,7 +1402,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PolylineXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PolylineXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PolylineXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1414,13 +1414,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> PolylineXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementVerticesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementVerticesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PolylineXmlParser::SubElementVerticesParser::SubElementVerticesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PolylineXmlParser::SubElementVerticesParser::SubElementVerticesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _vertexXmlParser = std::make_shared<VertexXmlParser>(messageLogger, filename);
+            _vertexXmlParser = std::make_shared<VertexXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PolylineXmlParser::SubElementVerticesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1458,10 +1458,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PolylineXmlParser::PolylineXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PolylineXmlParser::PolylineXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1471,7 +1471,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            PositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -1484,20 +1484,20 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> PositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementWorldPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRelativeWorldPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRelativeObjectPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRoadPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRelativeRoadPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementLanePositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRelativeLanePositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRoutePositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementWorldPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRelativeWorldPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRelativeObjectPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRoadPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRelativeRoadPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementLanePositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRelativeLanePositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRoutePositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PositionXmlParser::SubElementWorldPositionParser::SubElementWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementWorldPositionParser::SubElementWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _worldPositionXmlParser = std::make_shared<WorldPositionXmlParser>(messageLogger, filename);
+            _worldPositionXmlParser = std::make_shared<WorldPositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementWorldPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1533,9 +1533,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__WORLD_POSITION
                     };
         }
-        PositionXmlParser::SubElementRelativeWorldPositionParser::SubElementRelativeWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementRelativeWorldPositionParser::SubElementRelativeWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeWorldPositionXmlParser = std::make_shared<RelativeWorldPositionXmlParser>(messageLogger, filename);
+            _relativeWorldPositionXmlParser = std::make_shared<RelativeWorldPositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementRelativeWorldPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1571,9 +1571,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_WORLD_POSITION
                     };
         }
-        PositionXmlParser::SubElementRelativeObjectPositionParser::SubElementRelativeObjectPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementRelativeObjectPositionParser::SubElementRelativeObjectPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeObjectPositionXmlParser = std::make_shared<RelativeObjectPositionXmlParser>(messageLogger, filename);
+            _relativeObjectPositionXmlParser = std::make_shared<RelativeObjectPositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementRelativeObjectPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1609,9 +1609,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_OBJECT_POSITION
                     };
         }
-        PositionXmlParser::SubElementRoadPositionParser::SubElementRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementRoadPositionParser::SubElementRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _roadPositionXmlParser = std::make_shared<RoadPositionXmlParser>(messageLogger, filename);
+            _roadPositionXmlParser = std::make_shared<RoadPositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementRoadPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1647,9 +1647,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ROAD_POSITION
                     };
         }
-        PositionXmlParser::SubElementRelativeRoadPositionParser::SubElementRelativeRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementRelativeRoadPositionParser::SubElementRelativeRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeRoadPositionXmlParser = std::make_shared<RelativeRoadPositionXmlParser>(messageLogger, filename);
+            _relativeRoadPositionXmlParser = std::make_shared<RelativeRoadPositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementRelativeRoadPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1685,9 +1685,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_ROAD_POSITION
                     };
         }
-        PositionXmlParser::SubElementLanePositionParser::SubElementLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementLanePositionParser::SubElementLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _lanePositionXmlParser = std::make_shared<LanePositionXmlParser>(messageLogger, filename);
+            _lanePositionXmlParser = std::make_shared<LanePositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementLanePositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1723,9 +1723,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LANE_POSITION
                     };
         }
-        PositionXmlParser::SubElementRelativeLanePositionParser::SubElementRelativeLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementRelativeLanePositionParser::SubElementRelativeLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeLanePositionXmlParser = std::make_shared<RelativeLanePositionXmlParser>(messageLogger, filename);
+            _relativeLanePositionXmlParser = std::make_shared<RelativeLanePositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementRelativeLanePositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1761,9 +1761,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_LANE_POSITION
                     };
         }
-        PositionXmlParser::SubElementRoutePositionParser::SubElementRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementRoutePositionParser::SubElementRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _routePositionXmlParser = std::make_shared<RoutePositionXmlParser>(messageLogger, filename);
+            _routePositionXmlParser = std::make_shared<RoutePositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementRoutePositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1800,10 +1800,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PositionXmlParser::PositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PositionXmlParser::PositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1813,7 +1813,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PositionInLaneCoordinatesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PositionInLaneCoordinatesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PositionInLaneCoordinatesXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1822,7 +1822,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeLaneId: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLaneId(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLaneId(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1851,11 +1851,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LANE_ID, std::make_shared<AttributeLaneId>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LANE_ID, std::make_shared<AttributeLaneId>(_messageLogger, _filename, _parserOptions)));
             class AttributeLaneOffset: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLaneOffset(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLaneOffset(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1884,11 +1884,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LANE_OFFSET, std::make_shared<AttributeLaneOffset>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LANE_OFFSET, std::make_shared<AttributeLaneOffset>(_messageLogger, _filename, _parserOptions)));
             class AttributePathS: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePathS(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePathS(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1917,7 +1917,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PATH_S, std::make_shared<AttributePathS>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PATH_S, std::make_shared<AttributePathS>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -1928,10 +1928,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        PositionInLaneCoordinatesXmlParser::PositionInLaneCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PositionInLaneCoordinatesXmlParser::PositionInLaneCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1941,7 +1941,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PositionInRoadCoordinatesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PositionInRoadCoordinatesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PositionInRoadCoordinatesXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1950,7 +1950,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributePathS: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePathS(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePathS(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1979,11 +1979,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PATH_S, std::make_shared<AttributePathS>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PATH_S, std::make_shared<AttributePathS>(_messageLogger, _filename, _parserOptions)));
             class AttributeT: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeT(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeT(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2012,7 +2012,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__T, std::make_shared<AttributeT>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__T, std::make_shared<AttributeT>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -2023,10 +2023,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        PositionInRoadCoordinatesXmlParser::PositionInRoadCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PositionInRoadCoordinatesXmlParser::PositionInRoadCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2036,7 +2036,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PositionOfCurrentEntityXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PositionOfCurrentEntityXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PositionOfCurrentEntityXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2045,7 +2045,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2076,7 +2076,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -2087,10 +2087,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        PositionOfCurrentEntityXmlParser::PositionOfCurrentEntityXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PositionOfCurrentEntityXmlParser::PositionOfCurrentEntityXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2100,7 +2100,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PrecipitationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PrecipitationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PrecipitationXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2109,7 +2109,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeIntensity: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeIntensity(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeIntensity(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2138,11 +2138,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__INTENSITY, std::make_shared<AttributeIntensity>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__INTENSITY, std::make_shared<AttributeIntensity>(_messageLogger, _filename, _parserOptions)));
             class AttributePrecipitationType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePrecipitationType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePrecipitationType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2180,7 +2180,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PRECIPITATION_TYPE, std::make_shared<AttributePrecipitationType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PRECIPITATION_TYPE, std::make_shared<AttributePrecipitationType>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -2191,10 +2191,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        PrecipitationXmlParser::PrecipitationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PrecipitationXmlParser::PrecipitationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2204,7 +2204,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PrivateXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PrivateXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PrivateXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2213,7 +2213,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2244,20 +2244,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> PrivateXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPrivateActionsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPrivateActionsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PrivateXmlParser::SubElementPrivateActionsParser::SubElementPrivateActionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateXmlParser::SubElementPrivateActionsParser::SubElementPrivateActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _privateActionXmlParser = std::make_shared<PrivateActionXmlParser>(messageLogger, filename);
+            _privateActionXmlParser = std::make_shared<PrivateActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateXmlParser::SubElementPrivateActionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2295,10 +2295,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PrivateXmlParser::PrivateXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PrivateXmlParser::PrivateXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2308,7 +2308,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PrivateActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            PrivateActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PrivateActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -2321,20 +2321,20 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> PrivateActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementLongitudinalActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementLateralActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementVisibilityActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementSynchronizeActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementActivateControllerActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementControllerActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTeleportActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRoutingActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementLongitudinalActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementLateralActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementVisibilityActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementSynchronizeActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementActivateControllerActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementControllerActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTeleportActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRoutingActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PrivateActionXmlParser::SubElementLongitudinalActionParser::SubElementLongitudinalActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementLongitudinalActionParser::SubElementLongitudinalActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _longitudinalActionXmlParser = std::make_shared<LongitudinalActionXmlParser>(messageLogger, filename);
+            _longitudinalActionXmlParser = std::make_shared<LongitudinalActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementLongitudinalActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2370,9 +2370,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LONGITUDINAL_ACTION
                     };
         }
-        PrivateActionXmlParser::SubElementLateralActionParser::SubElementLateralActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementLateralActionParser::SubElementLateralActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _lateralActionXmlParser = std::make_shared<LateralActionXmlParser>(messageLogger, filename);
+            _lateralActionXmlParser = std::make_shared<LateralActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementLateralActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2408,9 +2408,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LATERAL_ACTION
                     };
         }
-        PrivateActionXmlParser::SubElementVisibilityActionParser::SubElementVisibilityActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementVisibilityActionParser::SubElementVisibilityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _visibilityActionXmlParser = std::make_shared<VisibilityActionXmlParser>(messageLogger, filename);
+            _visibilityActionXmlParser = std::make_shared<VisibilityActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementVisibilityActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2446,9 +2446,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__VISIBILITY_ACTION
                     };
         }
-        PrivateActionXmlParser::SubElementSynchronizeActionParser::SubElementSynchronizeActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementSynchronizeActionParser::SubElementSynchronizeActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _synchronizeActionXmlParser = std::make_shared<SynchronizeActionXmlParser>(messageLogger, filename);
+            _synchronizeActionXmlParser = std::make_shared<SynchronizeActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementSynchronizeActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2484,9 +2484,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SYNCHRONIZE_ACTION
                     };
         }
-        PrivateActionXmlParser::SubElementActivateControllerActionParser::SubElementActivateControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementActivateControllerActionParser::SubElementActivateControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _activateControllerActionXmlParser = std::make_shared<ActivateControllerActionXmlParser>(messageLogger, filename);
+            _activateControllerActionXmlParser = std::make_shared<ActivateControllerActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementActivateControllerActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2522,9 +2522,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ACTIVATE_CONTROLLER_ACTION
                     };
         }
-        PrivateActionXmlParser::SubElementControllerActionParser::SubElementControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementControllerActionParser::SubElementControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerActionXmlParser = std::make_shared<ControllerActionXmlParser>(messageLogger, filename);
+            _controllerActionXmlParser = std::make_shared<ControllerActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementControllerActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2560,9 +2560,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CONTROLLER_ACTION
                     };
         }
-        PrivateActionXmlParser::SubElementTeleportActionParser::SubElementTeleportActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementTeleportActionParser::SubElementTeleportActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _teleportActionXmlParser = std::make_shared<TeleportActionXmlParser>(messageLogger, filename);
+            _teleportActionXmlParser = std::make_shared<TeleportActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementTeleportActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2598,9 +2598,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TELEPORT_ACTION
                     };
         }
-        PrivateActionXmlParser::SubElementRoutingActionParser::SubElementRoutingActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementRoutingActionParser::SubElementRoutingActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _routingActionXmlParser = std::make_shared<RoutingActionXmlParser>(messageLogger, filename);
+            _routingActionXmlParser = std::make_shared<RoutingActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementRoutingActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2637,10 +2637,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PrivateActionXmlParser::PrivateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PrivateActionXmlParser::PrivateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2650,7 +2650,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PropertiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PropertiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PropertiesXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2662,14 +2662,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> PropertiesXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementFilesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementFilesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PropertiesXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PropertiesXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _propertyXmlParser = std::make_shared<PropertyXmlParser>(messageLogger, filename);
+            _propertyXmlParser = std::make_shared<PropertyXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PropertiesXmlParser::SubElementPropertiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2706,9 +2706,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PROPERTY
                     };
         }
-        PropertiesXmlParser::SubElementFilesParser::SubElementFilesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PropertiesXmlParser::SubElementFilesParser::SubElementFilesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _fileXmlParser = std::make_shared<FileXmlParser>(messageLogger, filename);
+            _fileXmlParser = std::make_shared<FileXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PropertiesXmlParser::SubElementFilesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2746,10 +2746,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PropertiesXmlParser::PropertiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PropertiesXmlParser::PropertiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2759,7 +2759,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PropertyXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PropertyXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PropertyXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2768,7 +2768,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2797,11 +2797,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2830,7 +2830,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -2841,10 +2841,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        PropertyXmlParser::PropertyXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PropertyXmlParser::PropertyXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2854,7 +2854,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ReachPositionConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ReachPositionConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ReachPositionConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -2864,7 +2864,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeTolerance: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTolerance(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTolerance(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2893,20 +2893,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TOLERANCE, std::make_shared<AttributeTolerance>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TOLERANCE, std::make_shared<AttributeTolerance>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ReachPositionConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ReachPositionConditionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ReachPositionConditionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ReachPositionConditionXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2943,10 +2943,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ReachPositionConditionXmlParser::ReachPositionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ReachPositionConditionXmlParser::ReachPositionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2956,7 +2956,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeDistanceConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RelativeDistanceConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeDistanceConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2965,7 +2965,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2996,11 +2996,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeFreespace: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3029,11 +3029,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename, _parserOptions)));
             class AttributeRelativeDistanceType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRelativeDistanceType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRelativeDistanceType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3071,11 +3071,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RELATIVE_DISTANCE_TYPE, std::make_shared<AttributeRelativeDistanceType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RELATIVE_DISTANCE_TYPE, std::make_shared<AttributeRelativeDistanceType>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3113,11 +3113,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3146,7 +3146,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -3157,10 +3157,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        RelativeDistanceConditionXmlParser::RelativeDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeDistanceConditionXmlParser::RelativeDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3170,7 +3170,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeLanePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            RelativeLanePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeLanePositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -3180,7 +3180,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDLane: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDLane(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDLane(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3209,11 +3209,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__D_LANE, std::make_shared<AttributeDLane>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__D_LANE, std::make_shared<AttributeDLane>(_messageLogger, _filename, _parserOptions)));
             class AttributeDs: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDs(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDs(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3242,11 +3242,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DS, std::make_shared<AttributeDs>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DS, std::make_shared<AttributeDs>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3277,11 +3277,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeOffset: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3310,20 +3310,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RelativeLanePositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RelativeLanePositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RelativeLanePositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RelativeLanePositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3360,10 +3360,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RelativeLanePositionXmlParser::RelativeLanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeLanePositionXmlParser::RelativeLanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3373,7 +3373,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeObjectPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            RelativeObjectPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeObjectPositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -3383,7 +3383,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDx: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDx(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDx(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3412,11 +3412,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DX, std::make_shared<AttributeDx>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DX, std::make_shared<AttributeDx>(_messageLogger, _filename, _parserOptions)));
             class AttributeDy: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDy(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDy(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3445,11 +3445,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DY, std::make_shared<AttributeDy>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DY, std::make_shared<AttributeDy>(_messageLogger, _filename, _parserOptions)));
             class AttributeDz: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDz(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDz(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3478,11 +3478,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DZ, std::make_shared<AttributeDz>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DZ, std::make_shared<AttributeDz>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3513,20 +3513,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RelativeObjectPositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RelativeObjectPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RelativeObjectPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RelativeObjectPositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3563,10 +3563,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RelativeObjectPositionXmlParser::RelativeObjectPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeObjectPositionXmlParser::RelativeObjectPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3576,7 +3576,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeRoadPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            RelativeRoadPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeRoadPositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -3586,7 +3586,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDs: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDs(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDs(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3615,11 +3615,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DS, std::make_shared<AttributeDs>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DS, std::make_shared<AttributeDs>(_messageLogger, _filename, _parserOptions)));
             class AttributeDt: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDt(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDt(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3648,11 +3648,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DT, std::make_shared<AttributeDt>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DT, std::make_shared<AttributeDt>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3683,20 +3683,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RelativeRoadPositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RelativeRoadPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RelativeRoadPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RelativeRoadPositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3733,10 +3733,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RelativeRoadPositionXmlParser::RelativeRoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeRoadPositionXmlParser::RelativeRoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3746,7 +3746,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeSpeedConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RelativeSpeedConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeSpeedConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3755,7 +3755,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3786,11 +3786,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3828,11 +3828,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3861,7 +3861,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -3872,10 +3872,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        RelativeSpeedConditionXmlParser::RelativeSpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeSpeedConditionXmlParser::RelativeSpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3885,7 +3885,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeSpeedToMasterXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RelativeSpeedToMasterXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeSpeedToMasterXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3894,7 +3894,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeSpeedTargetValueType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeSpeedTargetValueType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeSpeedTargetValueType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3932,11 +3932,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SPEED_TARGET_VALUE_TYPE, std::make_shared<AttributeSpeedTargetValueType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SPEED_TARGET_VALUE_TYPE, std::make_shared<AttributeSpeedTargetValueType>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3965,7 +3965,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -3976,10 +3976,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        RelativeSpeedToMasterXmlParser::RelativeSpeedToMasterXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeSpeedToMasterXmlParser::RelativeSpeedToMasterXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3989,7 +3989,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeTargetLaneXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RelativeTargetLaneXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeTargetLaneXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3998,7 +3998,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4029,11 +4029,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4062,7 +4062,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -4073,10 +4073,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        RelativeTargetLaneXmlParser::RelativeTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeTargetLaneXmlParser::RelativeTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4086,7 +4086,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeTargetLaneOffsetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RelativeTargetLaneOffsetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeTargetLaneOffsetXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4095,7 +4095,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4126,11 +4126,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4159,7 +4159,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -4170,10 +4170,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        RelativeTargetLaneOffsetXmlParser::RelativeTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeTargetLaneOffsetXmlParser::RelativeTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4183,7 +4183,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeTargetSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RelativeTargetSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeTargetSpeedXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4192,7 +4192,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeContinuous: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4221,11 +4221,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4256,11 +4256,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeSpeedTargetValueType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeSpeedTargetValueType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeSpeedTargetValueType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4298,11 +4298,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SPEED_TARGET_VALUE_TYPE, std::make_shared<AttributeSpeedTargetValueType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SPEED_TARGET_VALUE_TYPE, std::make_shared<AttributeSpeedTargetValueType>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4331,7 +4331,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -4342,10 +4342,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        RelativeTargetSpeedXmlParser::RelativeTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeTargetSpeedXmlParser::RelativeTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4355,7 +4355,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeWorldPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            RelativeWorldPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeWorldPositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -4365,7 +4365,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDx: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDx(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDx(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4394,11 +4394,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DX, std::make_shared<AttributeDx>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DX, std::make_shared<AttributeDx>(_messageLogger, _filename, _parserOptions)));
             class AttributeDy: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDy(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDy(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4427,11 +4427,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DY, std::make_shared<AttributeDy>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DY, std::make_shared<AttributeDy>(_messageLogger, _filename, _parserOptions)));
             class AttributeDz: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDz(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDz(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4460,11 +4460,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DZ, std::make_shared<AttributeDz>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DZ, std::make_shared<AttributeDz>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4495,20 +4495,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RelativeWorldPositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RelativeWorldPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RelativeWorldPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RelativeWorldPositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4545,10 +4545,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RelativeWorldPositionXmlParser::RelativeWorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeWorldPositionXmlParser::RelativeWorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4558,7 +4558,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RoadConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RoadConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RoadConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4567,7 +4567,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeFrictionScaleFactor: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFrictionScaleFactor(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFrictionScaleFactor(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4596,20 +4596,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FRICTION_SCALE_FACTOR, std::make_shared<AttributeFrictionScaleFactor>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FRICTION_SCALE_FACTOR, std::make_shared<AttributeFrictionScaleFactor>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RoadConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RoadConditionXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoadConditionXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename);
+            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoadConditionXmlParser::SubElementPropertiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4646,10 +4646,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RoadConditionXmlParser::RoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RoadConditionXmlParser::RoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4659,7 +4659,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RoadNetworkXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RoadNetworkXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RoadNetworkXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4671,15 +4671,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> RoadNetworkXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementLogicFileParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementSceneGraphFileParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementTrafficSignalsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__TRAFFIC_SIGNALS) );
+            result.push_back(std::make_shared<SubElementLogicFileParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementSceneGraphFileParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementTrafficSignalsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__TRAFFIC_SIGNALS, _parserOptions) );
             return result;
         }
 
-        RoadNetworkXmlParser::SubElementLogicFileParser::SubElementLogicFileParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoadNetworkXmlParser::SubElementLogicFileParser::SubElementLogicFileParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _fileXmlParser = std::make_shared<FileXmlParser>(messageLogger, filename);
+            _fileXmlParser = std::make_shared<FileXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoadNetworkXmlParser::SubElementLogicFileParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4715,9 +4715,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LOGIC_FILE
                     };
         }
-        RoadNetworkXmlParser::SubElementSceneGraphFileParser::SubElementSceneGraphFileParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoadNetworkXmlParser::SubElementSceneGraphFileParser::SubElementSceneGraphFileParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _fileXmlParser = std::make_shared<FileXmlParser>(messageLogger, filename);
+            _fileXmlParser = std::make_shared<FileXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoadNetworkXmlParser::SubElementSceneGraphFileParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4753,9 +4753,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SCENE_GRAPH_FILE
                     };
         }
-        RoadNetworkXmlParser::SubElementTrafficSignalsParser::SubElementTrafficSignalsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoadNetworkXmlParser::SubElementTrafficSignalsParser::SubElementTrafficSignalsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSignalControllerXmlParser = std::make_shared<TrafficSignalControllerXmlParser>(messageLogger, filename);
+            _trafficSignalControllerXmlParser = std::make_shared<TrafficSignalControllerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoadNetworkXmlParser::SubElementTrafficSignalsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4790,10 +4790,10 @@ namespace NET_ASAM_OPENSCENARIO
             return {OSC_CONSTANTS::ELEMENT__TRAFFIC_SIGNAL_CONTROLLER};
         }
   
-        RoadNetworkXmlParser::RoadNetworkXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RoadNetworkXmlParser::RoadNetworkXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4803,7 +4803,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RoadPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            RoadPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RoadPositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -4813,7 +4813,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRoadId: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRoadId(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRoadId(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4842,11 +4842,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ROAD_ID, std::make_shared<AttributeRoadId>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ROAD_ID, std::make_shared<AttributeRoadId>(_messageLogger, _filename, _parserOptions)));
             class AttributeS: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeS(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeS(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4875,11 +4875,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__S, std::make_shared<AttributeS>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__S, std::make_shared<AttributeS>(_messageLogger, _filename, _parserOptions)));
             class AttributeT: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeT(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeT(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4908,20 +4908,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__T, std::make_shared<AttributeT>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__T, std::make_shared<AttributeT>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RoadPositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RoadPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoadPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoadPositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4958,10 +4958,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RoadPositionXmlParser::RoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RoadPositionXmlParser::RoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4971,7 +4971,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RouteXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RouteXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RouteXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4980,7 +4980,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeClosed: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeClosed(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeClosed(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5009,11 +5009,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CLOSED, std::make_shared<AttributeClosed>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CLOSED, std::make_shared<AttributeClosed>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5042,21 +5042,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RouteXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementWaypointsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementWaypointsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RouteXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RouteXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RouteXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5090,9 +5090,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        RouteXmlParser::SubElementWaypointsParser::SubElementWaypointsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RouteXmlParser::SubElementWaypointsParser::SubElementWaypointsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _waypointXmlParser = std::make_shared<WaypointXmlParser>(messageLogger, filename);
+            _waypointXmlParser = std::make_shared<WaypointXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RouteXmlParser::SubElementWaypointsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5130,10 +5130,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RouteXmlParser::RouteXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RouteXmlParser::RouteXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5143,7 +5143,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RouteCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            RouteCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RouteCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -5156,13 +5156,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> RouteCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RouteCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RouteCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RouteCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5199,10 +5199,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RouteCatalogLocationXmlParser::RouteCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RouteCatalogLocationXmlParser::RouteCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5212,7 +5212,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RoutePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            RoutePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RoutePositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -5225,15 +5225,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> RoutePositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRouteRefParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementInRoutePositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRouteRefParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementInRoutePositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RoutePositionXmlParser::SubElementRouteRefParser::SubElementRouteRefParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoutePositionXmlParser::SubElementRouteRefParser::SubElementRouteRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _routeRefXmlParser = std::make_shared<RouteRefXmlParser>(messageLogger, filename);
+            _routeRefXmlParser = std::make_shared<RouteRefXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoutePositionXmlParser::SubElementRouteRefParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5269,9 +5269,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ROUTE_REF
                     };
         }
-        RoutePositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoutePositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoutePositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5307,9 +5307,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ORIENTATION
                     };
         }
-        RoutePositionXmlParser::SubElementInRoutePositionParser::SubElementInRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoutePositionXmlParser::SubElementInRoutePositionParser::SubElementInRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _inRoutePositionXmlParser = std::make_shared<InRoutePositionXmlParser>(messageLogger, filename);
+            _inRoutePositionXmlParser = std::make_shared<InRoutePositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoutePositionXmlParser::SubElementInRoutePositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5346,10 +5346,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RoutePositionXmlParser::RoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RoutePositionXmlParser::RoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5359,7 +5359,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RouteRefXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            RouteRefXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RouteRefXmlParser::GetAttributeNameToAttributeParserMap()
@@ -5372,14 +5372,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> RouteRefXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRouteParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRouteParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RouteRefXmlParser::SubElementRouteParser::SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RouteRefXmlParser::SubElementRouteParser::SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _routeXmlParser = std::make_shared<RouteXmlParser>(messageLogger, filename);
+            _routeXmlParser = std::make_shared<RouteXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RouteRefXmlParser::SubElementRouteParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5415,9 +5415,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ROUTE
                     };
         }
-        RouteRefXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RouteRefXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RouteRefXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5455,10 +5455,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RouteRefXmlParser::RouteRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RouteRefXmlParser::RouteRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5468,7 +5468,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RoutingActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            RoutingActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RoutingActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -5481,15 +5481,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> RoutingActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementAssignRouteActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementFollowTrajectoryActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementAcquirePositionActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementAssignRouteActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementFollowTrajectoryActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementAcquirePositionActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RoutingActionXmlParser::SubElementAssignRouteActionParser::SubElementAssignRouteActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoutingActionXmlParser::SubElementAssignRouteActionParser::SubElementAssignRouteActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _assignRouteActionXmlParser = std::make_shared<AssignRouteActionXmlParser>(messageLogger, filename);
+            _assignRouteActionXmlParser = std::make_shared<AssignRouteActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoutingActionXmlParser::SubElementAssignRouteActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5525,9 +5525,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ASSIGN_ROUTE_ACTION
                     };
         }
-        RoutingActionXmlParser::SubElementFollowTrajectoryActionParser::SubElementFollowTrajectoryActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoutingActionXmlParser::SubElementFollowTrajectoryActionParser::SubElementFollowTrajectoryActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _followTrajectoryActionXmlParser = std::make_shared<FollowTrajectoryActionXmlParser>(messageLogger, filename);
+            _followTrajectoryActionXmlParser = std::make_shared<FollowTrajectoryActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoutingActionXmlParser::SubElementFollowTrajectoryActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5563,9 +5563,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__FOLLOW_TRAJECTORY_ACTION
                     };
         }
-        RoutingActionXmlParser::SubElementAcquirePositionActionParser::SubElementAcquirePositionActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoutingActionXmlParser::SubElementAcquirePositionActionParser::SubElementAcquirePositionActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _acquirePositionActionXmlParser = std::make_shared<AcquirePositionActionXmlParser>(messageLogger, filename);
+            _acquirePositionActionXmlParser = std::make_shared<AcquirePositionActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoutingActionXmlParser::SubElementAcquirePositionActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5602,10 +5602,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RoutingActionXmlParser::RoutingActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RoutingActionXmlParser::RoutingActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5615,23 +5615,23 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ScenarioDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ScenarioDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
 
         std::vector<std::shared_ptr<IElementParser>> ScenarioDefinitionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementCatalogLocationsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRoadNetworkParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementEntitiesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStoryboardParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementCatalogLocationsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRoadNetworkParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementEntitiesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStoryboardParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ScenarioDefinitionXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ScenarioDefinitionXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ScenarioDefinitionXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5665,9 +5665,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        ScenarioDefinitionXmlParser::SubElementCatalogLocationsParser::SubElementCatalogLocationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ScenarioDefinitionXmlParser::SubElementCatalogLocationsParser::SubElementCatalogLocationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogLocationsXmlParser = std::make_shared<CatalogLocationsXmlParser>(messageLogger, filename);
+            _catalogLocationsXmlParser = std::make_shared<CatalogLocationsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ScenarioDefinitionXmlParser::SubElementCatalogLocationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5703,9 +5703,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CATALOG_LOCATIONS
                     };
         }
-        ScenarioDefinitionXmlParser::SubElementRoadNetworkParser::SubElementRoadNetworkParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ScenarioDefinitionXmlParser::SubElementRoadNetworkParser::SubElementRoadNetworkParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _roadNetworkXmlParser = std::make_shared<RoadNetworkXmlParser>(messageLogger, filename);
+            _roadNetworkXmlParser = std::make_shared<RoadNetworkXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ScenarioDefinitionXmlParser::SubElementRoadNetworkParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5741,9 +5741,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ROAD_NETWORK
                     };
         }
-        ScenarioDefinitionXmlParser::SubElementEntitiesParser::SubElementEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ScenarioDefinitionXmlParser::SubElementEntitiesParser::SubElementEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entitiesXmlParser = std::make_shared<EntitiesXmlParser>(messageLogger, filename);
+            _entitiesXmlParser = std::make_shared<EntitiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ScenarioDefinitionXmlParser::SubElementEntitiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5779,9 +5779,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENTITIES
                     };
         }
-        ScenarioDefinitionXmlParser::SubElementStoryboardParser::SubElementStoryboardParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ScenarioDefinitionXmlParser::SubElementStoryboardParser::SubElementStoryboardParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _storyboardXmlParser = std::make_shared<StoryboardXmlParser>(messageLogger, filename);
+            _storyboardXmlParser = std::make_shared<StoryboardXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ScenarioDefinitionXmlParser::SubElementStoryboardParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5818,10 +5818,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ScenarioDefinitionXmlParser::ScenarioDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        ScenarioDefinitionXmlParser::ScenarioDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5831,7 +5831,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ScenarioObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ScenarioObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ScenarioObjectXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -5840,7 +5840,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5869,21 +5869,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ScenarioObjectXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEntityObjectParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementObjectControllerParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEntityObjectParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementObjectControllerParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ScenarioObjectXmlParser::SubElementEntityObjectParser::SubElementEntityObjectParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ScenarioObjectXmlParser::SubElementEntityObjectParser::SubElementEntityObjectParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityObjectXmlParser = std::make_shared<EntityObjectXmlParser>(messageLogger, filename);
+            _entityObjectXmlParser = std::make_shared<EntityObjectXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ScenarioObjectXmlParser::SubElementEntityObjectParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5925,9 +5925,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__MISC_OBJECT
                     };
         }
-        ScenarioObjectXmlParser::SubElementObjectControllerParser::SubElementObjectControllerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ScenarioObjectXmlParser::SubElementObjectControllerParser::SubElementObjectControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _objectControllerXmlParser = std::make_shared<ObjectControllerXmlParser>(messageLogger, filename);
+            _objectControllerXmlParser = std::make_shared<ObjectControllerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ScenarioObjectXmlParser::SubElementObjectControllerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5964,10 +5964,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ScenarioObjectXmlParser::ScenarioObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ScenarioObjectXmlParser::ScenarioObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5977,7 +5977,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SelectedEntitiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            SelectedEntitiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> SelectedEntitiesXmlParser::GetAttributeNameToAttributeParserMap()
@@ -5990,14 +5990,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> SelectedEntitiesXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEntityRefParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementByTypeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEntityRefParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementByTypeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        SelectedEntitiesXmlParser::SubElementEntityRefParser::SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SelectedEntitiesXmlParser::SubElementEntityRefParser::SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename);
+            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SelectedEntitiesXmlParser::SubElementEntityRefParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6034,9 +6034,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENTITY_REF
                     };
         }
-        SelectedEntitiesXmlParser::SubElementByTypeParser::SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SelectedEntitiesXmlParser::SubElementByTypeParser::SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _byTypeXmlParser = std::make_shared<ByTypeXmlParser>(messageLogger, filename);
+            _byTypeXmlParser = std::make_shared<ByTypeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SelectedEntitiesXmlParser::SubElementByTypeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6074,10 +6074,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        SelectedEntitiesXmlParser::SelectedEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        SelectedEntitiesXmlParser::SelectedEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6087,7 +6087,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ShapeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ShapeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ShapeXmlParser::GetAttributeNameToAttributeParserMap()
@@ -6100,15 +6100,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ShapeXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPolylineParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementClothoidParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementNurbsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPolylineParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementClothoidParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementNurbsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ShapeXmlParser::SubElementPolylineParser::SubElementPolylineParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ShapeXmlParser::SubElementPolylineParser::SubElementPolylineParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _polylineXmlParser = std::make_shared<PolylineXmlParser>(messageLogger, filename);
+            _polylineXmlParser = std::make_shared<PolylineXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ShapeXmlParser::SubElementPolylineParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6144,9 +6144,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__POLYLINE
                     };
         }
-        ShapeXmlParser::SubElementClothoidParser::SubElementClothoidParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ShapeXmlParser::SubElementClothoidParser::SubElementClothoidParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _clothoidXmlParser = std::make_shared<ClothoidXmlParser>(messageLogger, filename);
+            _clothoidXmlParser = std::make_shared<ClothoidXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ShapeXmlParser::SubElementClothoidParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6182,9 +6182,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CLOTHOID
                     };
         }
-        ShapeXmlParser::SubElementNurbsParser::SubElementNurbsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ShapeXmlParser::SubElementNurbsParser::SubElementNurbsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _nurbsXmlParser = std::make_shared<NurbsXmlParser>(messageLogger, filename);
+            _nurbsXmlParser = std::make_shared<NurbsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ShapeXmlParser::SubElementNurbsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6221,10 +6221,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ShapeXmlParser::ShapeXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ShapeXmlParser::ShapeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6234,7 +6234,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SimulationTimeConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            SimulationTimeConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> SimulationTimeConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -6243,7 +6243,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6281,11 +6281,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6314,7 +6314,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -6325,10 +6325,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        SimulationTimeConditionXmlParser::SimulationTimeConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        SimulationTimeConditionXmlParser::SimulationTimeConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6338,7 +6338,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SpeedActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            SpeedActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> SpeedActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -6351,14 +6351,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> SpeedActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementSpeedActionDynamicsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementSpeedActionTargetParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementSpeedActionDynamicsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementSpeedActionTargetParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        SpeedActionXmlParser::SubElementSpeedActionDynamicsParser::SubElementSpeedActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SpeedActionXmlParser::SubElementSpeedActionDynamicsParser::SubElementSpeedActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _transitionDynamicsXmlParser = std::make_shared<TransitionDynamicsXmlParser>(messageLogger, filename);
+            _transitionDynamicsXmlParser = std::make_shared<TransitionDynamicsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SpeedActionXmlParser::SubElementSpeedActionDynamicsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6394,9 +6394,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SPEED_ACTION_DYNAMICS
                     };
         }
-        SpeedActionXmlParser::SubElementSpeedActionTargetParser::SubElementSpeedActionTargetParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SpeedActionXmlParser::SubElementSpeedActionTargetParser::SubElementSpeedActionTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _speedActionTargetXmlParser = std::make_shared<SpeedActionTargetXmlParser>(messageLogger, filename);
+            _speedActionTargetXmlParser = std::make_shared<SpeedActionTargetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SpeedActionXmlParser::SubElementSpeedActionTargetParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6433,10 +6433,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        SpeedActionXmlParser::SpeedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        SpeedActionXmlParser::SpeedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6446,7 +6446,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SpeedActionTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            SpeedActionTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> SpeedActionTargetXmlParser::GetAttributeNameToAttributeParserMap()
@@ -6459,14 +6459,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> SpeedActionTargetXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRelativeTargetSpeedParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementAbsoluteTargetSpeedParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRelativeTargetSpeedParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementAbsoluteTargetSpeedParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        SpeedActionTargetXmlParser::SubElementRelativeTargetSpeedParser::SubElementRelativeTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SpeedActionTargetXmlParser::SubElementRelativeTargetSpeedParser::SubElementRelativeTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeTargetSpeedXmlParser = std::make_shared<RelativeTargetSpeedXmlParser>(messageLogger, filename);
+            _relativeTargetSpeedXmlParser = std::make_shared<RelativeTargetSpeedXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SpeedActionTargetXmlParser::SubElementRelativeTargetSpeedParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6502,9 +6502,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_TARGET_SPEED
                     };
         }
-        SpeedActionTargetXmlParser::SubElementAbsoluteTargetSpeedParser::SubElementAbsoluteTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SpeedActionTargetXmlParser::SubElementAbsoluteTargetSpeedParser::SubElementAbsoluteTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _absoluteTargetSpeedXmlParser = std::make_shared<AbsoluteTargetSpeedXmlParser>(messageLogger, filename);
+            _absoluteTargetSpeedXmlParser = std::make_shared<AbsoluteTargetSpeedXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SpeedActionTargetXmlParser::SubElementAbsoluteTargetSpeedParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6541,10 +6541,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        SpeedActionTargetXmlParser::SpeedActionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        SpeedActionTargetXmlParser::SpeedActionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6554,7 +6554,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SpeedConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            SpeedConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> SpeedConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -6563,7 +6563,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6601,11 +6601,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6634,7 +6634,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -6645,10 +6645,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        SpeedConditionXmlParser::SpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        SpeedConditionXmlParser::SpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6658,7 +6658,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            StandStillConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            StandStillConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> StandStillConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -6667,7 +6667,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDuration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6696,7 +6696,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -6707,10 +6707,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        StandStillConditionXmlParser::StandStillConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        StandStillConditionXmlParser::StandStillConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6720,7 +6720,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            StoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            StoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> StoryXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -6729,7 +6729,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6758,21 +6758,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> StoryXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementActsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementActsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        StoryXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StoryXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StoryXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6806,9 +6806,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        StoryXmlParser::SubElementActsParser::SubElementActsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StoryXmlParser::SubElementActsParser::SubElementActsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _actXmlParser = std::make_shared<ActXmlParser>(messageLogger, filename);
+            _actXmlParser = std::make_shared<ActXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StoryXmlParser::SubElementActsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6846,10 +6846,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        StoryXmlParser::StoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        StoryXmlParser::StoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6859,7 +6859,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            StoryboardXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            StoryboardXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> StoryboardXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -6871,15 +6871,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> StoryboardXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementInitParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStoriesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStopTriggerParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementInitParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStoriesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStopTriggerParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        StoryboardXmlParser::SubElementInitParser::SubElementInitParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StoryboardXmlParser::SubElementInitParser::SubElementInitParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _initXmlParser = std::make_shared<InitXmlParser>(messageLogger, filename);
+            _initXmlParser = std::make_shared<InitXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StoryboardXmlParser::SubElementInitParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6915,9 +6915,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__INIT
                     };
         }
-        StoryboardXmlParser::SubElementStoriesParser::SubElementStoriesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StoryboardXmlParser::SubElementStoriesParser::SubElementStoriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _storyXmlParser = std::make_shared<StoryXmlParser>(messageLogger, filename);
+            _storyXmlParser = std::make_shared<StoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StoryboardXmlParser::SubElementStoriesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6954,9 +6954,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__STORY
                     };
         }
-        StoryboardXmlParser::SubElementStopTriggerParser::SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StoryboardXmlParser::SubElementStopTriggerParser::SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename);
+            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StoryboardXmlParser::SubElementStopTriggerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6993,10 +6993,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        StoryboardXmlParser::StoryboardXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        StoryboardXmlParser::StoryboardXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7006,7 +7006,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            StoryboardElementStateConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            StoryboardElementStateConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> StoryboardElementStateConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -7015,7 +7015,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeState: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeState(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeState(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7053,11 +7053,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename, _parserOptions)));
             class AttributeStoryboardElementRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeStoryboardElementRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeStoryboardElementRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7088,11 +7088,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STORYBOARD_ELEMENT_REF, std::make_shared<AttributeStoryboardElementRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STORYBOARD_ELEMENT_REF, std::make_shared<AttributeStoryboardElementRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeStoryboardElementType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeStoryboardElementType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeStoryboardElementType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7130,7 +7130,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STORYBOARD_ELEMENT_TYPE, std::make_shared<AttributeStoryboardElementType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STORYBOARD_ELEMENT_TYPE, std::make_shared<AttributeStoryboardElementType>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -7141,10 +7141,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        StoryboardElementStateConditionXmlParser::StoryboardElementStateConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        StoryboardElementStateConditionXmlParser::StoryboardElementStateConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7154,7 +7154,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SunXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            SunXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> SunXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -7163,7 +7163,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeAzimuth: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeAzimuth(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeAzimuth(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7192,11 +7192,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__AZIMUTH, std::make_shared<AttributeAzimuth>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__AZIMUTH, std::make_shared<AttributeAzimuth>(_messageLogger, _filename, _parserOptions)));
             class AttributeElevation: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeElevation(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeElevation(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7225,11 +7225,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ELEVATION, std::make_shared<AttributeElevation>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ELEVATION, std::make_shared<AttributeElevation>(_messageLogger, _filename, _parserOptions)));
             class AttributeIntensity: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeIntensity(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeIntensity(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7258,7 +7258,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__INTENSITY, std::make_shared<AttributeIntensity>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__INTENSITY, std::make_shared<AttributeIntensity>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -7269,10 +7269,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        SunXmlParser::SunXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        SunXmlParser::SunXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7282,7 +7282,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SynchronizeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            SynchronizeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> SynchronizeActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -7292,7 +7292,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMasterEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMasterEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMasterEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7323,22 +7323,22 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MASTER_ENTITY_REF, std::make_shared<AttributeMasterEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MASTER_ENTITY_REF, std::make_shared<AttributeMasterEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> SynchronizeActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTargetPositionMasterParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTargetPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementFinalSpeedParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTargetPositionMasterParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTargetPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementFinalSpeedParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        SynchronizeActionXmlParser::SubElementTargetPositionMasterParser::SubElementTargetPositionMasterParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SynchronizeActionXmlParser::SubElementTargetPositionMasterParser::SubElementTargetPositionMasterParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SynchronizeActionXmlParser::SubElementTargetPositionMasterParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7374,9 +7374,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TARGET_POSITION_MASTER
                     };
         }
-        SynchronizeActionXmlParser::SubElementTargetPositionParser::SubElementTargetPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SynchronizeActionXmlParser::SubElementTargetPositionParser::SubElementTargetPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SynchronizeActionXmlParser::SubElementTargetPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7412,9 +7412,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TARGET_POSITION
                     };
         }
-        SynchronizeActionXmlParser::SubElementFinalSpeedParser::SubElementFinalSpeedParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SynchronizeActionXmlParser::SubElementFinalSpeedParser::SubElementFinalSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _finalSpeedXmlParser = std::make_shared<FinalSpeedXmlParser>(messageLogger, filename);
+            _finalSpeedXmlParser = std::make_shared<FinalSpeedXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SynchronizeActionXmlParser::SubElementFinalSpeedParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7451,10 +7451,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        SynchronizeActionXmlParser::SynchronizeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        SynchronizeActionXmlParser::SynchronizeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7464,7 +7464,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TeleportActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TeleportActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TeleportActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -7476,13 +7476,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> TeleportActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TeleportActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TeleportActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TeleportActionXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7519,10 +7519,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TeleportActionXmlParser::TeleportActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TeleportActionXmlParser::TeleportActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7532,7 +7532,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TimeHeadwayConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TimeHeadwayConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TimeHeadwayConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -7541,7 +7541,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeAlongRoute: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeAlongRoute(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeAlongRoute(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7570,11 +7570,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<AttributeAlongRoute>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<AttributeAlongRoute>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7605,11 +7605,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeFreespace: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7638,11 +7638,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7680,11 +7680,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7713,7 +7713,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -7724,10 +7724,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TimeHeadwayConditionXmlParser::TimeHeadwayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TimeHeadwayConditionXmlParser::TimeHeadwayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7737,7 +7737,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TimeOfDayXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TimeOfDayXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TimeOfDayXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -7746,7 +7746,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeAnimation: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeAnimation(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeAnimation(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7775,11 +7775,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ANIMATION, std::make_shared<AttributeAnimation>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ANIMATION, std::make_shared<AttributeAnimation>(_messageLogger, _filename, _parserOptions)));
             class AttributeDateTime: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDateTime(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDateTime(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7808,7 +7808,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DATE_TIME, std::make_shared<AttributeDateTime>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DATE_TIME, std::make_shared<AttributeDateTime>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -7819,10 +7819,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TimeOfDayXmlParser::TimeOfDayXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TimeOfDayXmlParser::TimeOfDayXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7832,7 +7832,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TimeOfDayConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TimeOfDayConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TimeOfDayConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -7841,7 +7841,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDateTime: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDateTime(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDateTime(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7870,11 +7870,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DATE_TIME, std::make_shared<AttributeDateTime>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DATE_TIME, std::make_shared<AttributeDateTime>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7912,7 +7912,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -7923,10 +7923,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TimeOfDayConditionXmlParser::TimeOfDayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TimeOfDayConditionXmlParser::TimeOfDayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7936,7 +7936,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TimeReferenceXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            TimeReferenceXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TimeReferenceXmlParser::GetAttributeNameToAttributeParserMap()
@@ -7949,14 +7949,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> TimeReferenceXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementNoneParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTimingParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementNoneParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTimingParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TimeReferenceXmlParser::SubElementNoneParser::SubElementNoneParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TimeReferenceXmlParser::SubElementNoneParser::SubElementNoneParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _noneXmlParser = std::make_shared<NoneXmlParser>(messageLogger, filename);
+            _noneXmlParser = std::make_shared<NoneXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TimeReferenceXmlParser::SubElementNoneParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7992,9 +7992,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__NONE
                     };
         }
-        TimeReferenceXmlParser::SubElementTimingParser::SubElementTimingParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TimeReferenceXmlParser::SubElementTimingParser::SubElementTimingParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _timingXmlParser = std::make_shared<TimingXmlParser>(messageLogger, filename);
+            _timingXmlParser = std::make_shared<TimingXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TimeReferenceXmlParser::SubElementTimingParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8031,10 +8031,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TimeReferenceXmlParser::TimeReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TimeReferenceXmlParser::TimeReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8044,7 +8044,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TimeToCollisionConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            TimeToCollisionConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TimeToCollisionConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -8054,7 +8054,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeAlongRoute: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeAlongRoute(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeAlongRoute(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8083,11 +8083,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<AttributeAlongRoute>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<AttributeAlongRoute>(_messageLogger, _filename, _parserOptions)));
             class AttributeFreespace: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8116,11 +8116,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8158,11 +8158,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8191,20 +8191,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TimeToCollisionConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTimeToCollisionConditionTargetParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTimeToCollisionConditionTargetParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TimeToCollisionConditionXmlParser::SubElementTimeToCollisionConditionTargetParser::SubElementTimeToCollisionConditionTargetParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TimeToCollisionConditionXmlParser::SubElementTimeToCollisionConditionTargetParser::SubElementTimeToCollisionConditionTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _timeToCollisionConditionTargetXmlParser = std::make_shared<TimeToCollisionConditionTargetXmlParser>(messageLogger, filename);
+            _timeToCollisionConditionTargetXmlParser = std::make_shared<TimeToCollisionConditionTargetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TimeToCollisionConditionXmlParser::SubElementTimeToCollisionConditionTargetParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8241,10 +8241,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TimeToCollisionConditionXmlParser::TimeToCollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TimeToCollisionConditionXmlParser::TimeToCollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8254,7 +8254,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TimeToCollisionConditionTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            TimeToCollisionConditionTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TimeToCollisionConditionTargetXmlParser::GetAttributeNameToAttributeParserMap()
@@ -8267,14 +8267,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> TimeToCollisionConditionTargetXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementEntityRefParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementEntityRefParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TimeToCollisionConditionTargetXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TimeToCollisionConditionTargetXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TimeToCollisionConditionTargetXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8310,9 +8310,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__POSITION
                     };
         }
-        TimeToCollisionConditionTargetXmlParser::SubElementEntityRefParser::SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TimeToCollisionConditionTargetXmlParser::SubElementEntityRefParser::SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename);
+            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TimeToCollisionConditionTargetXmlParser::SubElementEntityRefParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8349,10 +8349,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TimeToCollisionConditionTargetXmlParser::TimeToCollisionConditionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TimeToCollisionConditionTargetXmlParser::TimeToCollisionConditionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8362,7 +8362,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TimingXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TimingXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TimingXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8371,7 +8371,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDomainAbsoluteRelative: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDomainAbsoluteRelative(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDomainAbsoluteRelative(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8409,11 +8409,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DOMAIN_ABSOLUTE_RELATIVE, std::make_shared<AttributeDomainAbsoluteRelative>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DOMAIN_ABSOLUTE_RELATIVE, std::make_shared<AttributeDomainAbsoluteRelative>(_messageLogger, _filename, _parserOptions)));
             class AttributeOffset: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8442,11 +8442,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename, _parserOptions)));
             class AttributeScale: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeScale(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeScale(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8475,7 +8475,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SCALE, std::make_shared<AttributeScale>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SCALE, std::make_shared<AttributeScale>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -8486,10 +8486,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TimingXmlParser::TimingXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TimingXmlParser::TimingXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8499,7 +8499,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            TrafficActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -8512,15 +8512,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> TrafficActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTrafficSourceActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficSinkActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficSwarmActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTrafficSourceActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficSinkActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficSwarmActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrafficActionXmlParser::SubElementTrafficSourceActionParser::SubElementTrafficSourceActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficActionXmlParser::SubElementTrafficSourceActionParser::SubElementTrafficSourceActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSourceActionXmlParser = std::make_shared<TrafficSourceActionXmlParser>(messageLogger, filename);
+            _trafficSourceActionXmlParser = std::make_shared<TrafficSourceActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficActionXmlParser::SubElementTrafficSourceActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8556,9 +8556,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAFFIC_SOURCE_ACTION
                     };
         }
-        TrafficActionXmlParser::SubElementTrafficSinkActionParser::SubElementTrafficSinkActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficActionXmlParser::SubElementTrafficSinkActionParser::SubElementTrafficSinkActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSinkActionXmlParser = std::make_shared<TrafficSinkActionXmlParser>(messageLogger, filename);
+            _trafficSinkActionXmlParser = std::make_shared<TrafficSinkActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficActionXmlParser::SubElementTrafficSinkActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8594,9 +8594,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAFFIC_SINK_ACTION
                     };
         }
-        TrafficActionXmlParser::SubElementTrafficSwarmActionParser::SubElementTrafficSwarmActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficActionXmlParser::SubElementTrafficSwarmActionParser::SubElementTrafficSwarmActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSwarmActionXmlParser = std::make_shared<TrafficSwarmActionXmlParser>(messageLogger, filename);
+            _trafficSwarmActionXmlParser = std::make_shared<TrafficSwarmActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficActionXmlParser::SubElementTrafficSwarmActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8633,10 +8633,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrafficActionXmlParser::TrafficActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficActionXmlParser::TrafficActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8646,7 +8646,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            TrafficDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficDefinitionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -8656,7 +8656,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8685,21 +8685,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TrafficDefinitionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementVehicleCategoryDistributionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementControllerDistributionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementVehicleCategoryDistributionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementControllerDistributionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrafficDefinitionXmlParser::SubElementVehicleCategoryDistributionParser::SubElementVehicleCategoryDistributionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficDefinitionXmlParser::SubElementVehicleCategoryDistributionParser::SubElementVehicleCategoryDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _vehicleCategoryDistributionXmlParser = std::make_shared<VehicleCategoryDistributionXmlParser>(messageLogger, filename);
+            _vehicleCategoryDistributionXmlParser = std::make_shared<VehicleCategoryDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficDefinitionXmlParser::SubElementVehicleCategoryDistributionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8735,9 +8735,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__VEHICLE_CATEGORY_DISTRIBUTION
                     };
         }
-        TrafficDefinitionXmlParser::SubElementControllerDistributionParser::SubElementControllerDistributionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficDefinitionXmlParser::SubElementControllerDistributionParser::SubElementControllerDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerDistributionXmlParser = std::make_shared<ControllerDistributionXmlParser>(messageLogger, filename);
+            _controllerDistributionXmlParser = std::make_shared<ControllerDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficDefinitionXmlParser::SubElementControllerDistributionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8774,10 +8774,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrafficDefinitionXmlParser::TrafficDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficDefinitionXmlParser::TrafficDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8787,7 +8787,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSignalActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            TrafficSignalActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSignalActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -8800,14 +8800,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> TrafficSignalActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTrafficSignalControllerActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficSignalStateActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTrafficSignalControllerActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficSignalStateActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrafficSignalActionXmlParser::SubElementTrafficSignalControllerActionParser::SubElementTrafficSignalControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSignalActionXmlParser::SubElementTrafficSignalControllerActionParser::SubElementTrafficSignalControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSignalControllerActionXmlParser = std::make_shared<TrafficSignalControllerActionXmlParser>(messageLogger, filename);
+            _trafficSignalControllerActionXmlParser = std::make_shared<TrafficSignalControllerActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSignalActionXmlParser::SubElementTrafficSignalControllerActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8843,9 +8843,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAFFIC_SIGNAL_CONTROLLER_ACTION
                     };
         }
-        TrafficSignalActionXmlParser::SubElementTrafficSignalStateActionParser::SubElementTrafficSignalStateActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSignalActionXmlParser::SubElementTrafficSignalStateActionParser::SubElementTrafficSignalStateActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSignalStateActionXmlParser = std::make_shared<TrafficSignalStateActionXmlParser>(messageLogger, filename);
+            _trafficSignalStateActionXmlParser = std::make_shared<TrafficSignalStateActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSignalActionXmlParser::SubElementTrafficSignalStateActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8882,10 +8882,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrafficSignalActionXmlParser::TrafficSignalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSignalActionXmlParser::TrafficSignalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8895,7 +8895,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSignalConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrafficSignalConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSignalConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8904,7 +8904,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8933,11 +8933,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeState: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeState(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeState(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8966,7 +8966,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -8977,10 +8977,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TrafficSignalConditionXmlParser::TrafficSignalConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSignalConditionXmlParser::TrafficSignalConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8990,7 +8990,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSignalControllerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrafficSignalControllerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSignalControllerXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8999,7 +8999,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDelay: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDelay(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDelay(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9028,11 +9028,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DELAY, std::make_shared<AttributeDelay>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DELAY, std::make_shared<AttributeDelay>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9061,11 +9061,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeReference: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeReference(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeReference(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9094,20 +9094,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__REFERENCE, std::make_shared<AttributeReference>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__REFERENCE, std::make_shared<AttributeReference>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TrafficSignalControllerXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPhasesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPhasesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrafficSignalControllerXmlParser::SubElementPhasesParser::SubElementPhasesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSignalControllerXmlParser::SubElementPhasesParser::SubElementPhasesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _phaseXmlParser = std::make_shared<PhaseXmlParser>(messageLogger, filename);
+            _phaseXmlParser = std::make_shared<PhaseXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSignalControllerXmlParser::SubElementPhasesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9145,10 +9145,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrafficSignalControllerXmlParser::TrafficSignalControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSignalControllerXmlParser::TrafficSignalControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9158,7 +9158,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSignalControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrafficSignalControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSignalControllerActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -9167,7 +9167,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributePhase: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePhase(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePhase(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9196,11 +9196,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PHASE, std::make_shared<AttributePhase>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PHASE, std::make_shared<AttributePhase>(_messageLogger, _filename, _parserOptions)));
             class AttributeTrafficSignalControllerRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTrafficSignalControllerRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTrafficSignalControllerRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9231,7 +9231,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC_SIGNAL_CONTROLLER_REF, std::make_shared<AttributeTrafficSignalControllerRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC_SIGNAL_CONTROLLER_REF, std::make_shared<AttributeTrafficSignalControllerRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -9242,10 +9242,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TrafficSignalControllerActionXmlParser::TrafficSignalControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSignalControllerActionXmlParser::TrafficSignalControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9255,7 +9255,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSignalControllerConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrafficSignalControllerConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSignalControllerConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -9264,7 +9264,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributePhase: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePhase(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePhase(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9293,11 +9293,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PHASE, std::make_shared<AttributePhase>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PHASE, std::make_shared<AttributePhase>(_messageLogger, _filename, _parserOptions)));
             class AttributeTrafficSignalControllerRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTrafficSignalControllerRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTrafficSignalControllerRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9328,7 +9328,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC_SIGNAL_CONTROLLER_REF, std::make_shared<AttributeTrafficSignalControllerRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC_SIGNAL_CONTROLLER_REF, std::make_shared<AttributeTrafficSignalControllerRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -9339,10 +9339,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TrafficSignalControllerConditionXmlParser::TrafficSignalControllerConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSignalControllerConditionXmlParser::TrafficSignalControllerConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9352,7 +9352,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSignalStateXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrafficSignalStateXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSignalStateXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -9361,7 +9361,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeState: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeState(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeState(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9390,11 +9390,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename, _parserOptions)));
             class AttributeTrafficSignalId: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTrafficSignalId(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTrafficSignalId(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9423,7 +9423,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC_SIGNAL_ID, std::make_shared<AttributeTrafficSignalId>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC_SIGNAL_ID, std::make_shared<AttributeTrafficSignalId>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -9434,10 +9434,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TrafficSignalStateXmlParser::TrafficSignalStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSignalStateXmlParser::TrafficSignalStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9447,7 +9447,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSignalStateActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrafficSignalStateActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSignalStateActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -9456,7 +9456,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9485,11 +9485,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeState: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeState(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeState(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9518,7 +9518,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -9529,10 +9529,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TrafficSignalStateActionXmlParser::TrafficSignalStateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSignalStateActionXmlParser::TrafficSignalStateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9542,7 +9542,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSinkActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            TrafficSinkActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSinkActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9552,7 +9552,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRadius: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRadius(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRadius(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9581,11 +9581,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RADIUS, std::make_shared<AttributeRadius>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RADIUS, std::make_shared<AttributeRadius>(_messageLogger, _filename, _parserOptions)));
             class AttributeRate: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRate(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRate(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9614,21 +9614,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RATE, std::make_shared<AttributeRate>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RATE, std::make_shared<AttributeRate>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TrafficSinkActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficDefinitionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficDefinitionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrafficSinkActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSinkActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSinkActionXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9664,9 +9664,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__POSITION
                     };
         }
-        TrafficSinkActionXmlParser::SubElementTrafficDefinitionParser::SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSinkActionXmlParser::SubElementTrafficDefinitionParser::SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficDefinitionXmlParser = std::make_shared<TrafficDefinitionXmlParser>(messageLogger, filename);
+            _trafficDefinitionXmlParser = std::make_shared<TrafficDefinitionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSinkActionXmlParser::SubElementTrafficDefinitionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9703,10 +9703,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrafficSinkActionXmlParser::TrafficSinkActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSinkActionXmlParser::TrafficSinkActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9716,7 +9716,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSourceActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            TrafficSourceActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSourceActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9726,7 +9726,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRadius: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRadius(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRadius(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9755,11 +9755,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RADIUS, std::make_shared<AttributeRadius>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RADIUS, std::make_shared<AttributeRadius>(_messageLogger, _filename, _parserOptions)));
             class AttributeRate: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRate(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRate(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9788,11 +9788,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RATE, std::make_shared<AttributeRate>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RATE, std::make_shared<AttributeRate>(_messageLogger, _filename, _parserOptions)));
             class AttributeVelocity: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeVelocity(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeVelocity(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9821,21 +9821,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VELOCITY, std::make_shared<AttributeVelocity>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VELOCITY, std::make_shared<AttributeVelocity>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TrafficSourceActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficDefinitionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficDefinitionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrafficSourceActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSourceActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSourceActionXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9871,9 +9871,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__POSITION
                     };
         }
-        TrafficSourceActionXmlParser::SubElementTrafficDefinitionParser::SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSourceActionXmlParser::SubElementTrafficDefinitionParser::SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficDefinitionXmlParser = std::make_shared<TrafficDefinitionXmlParser>(messageLogger, filename);
+            _trafficDefinitionXmlParser = std::make_shared<TrafficDefinitionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSourceActionXmlParser::SubElementTrafficDefinitionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9910,10 +9910,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrafficSourceActionXmlParser::TrafficSourceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSourceActionXmlParser::TrafficSourceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9923,7 +9923,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSwarmActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            TrafficSwarmActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSwarmActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9933,7 +9933,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeInnerRadius: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeInnerRadius(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeInnerRadius(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9962,11 +9962,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__INNER_RADIUS, std::make_shared<AttributeInnerRadius>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__INNER_RADIUS, std::make_shared<AttributeInnerRadius>(_messageLogger, _filename, _parserOptions)));
             class AttributeNumberOfVehicles: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeNumberOfVehicles(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeNumberOfVehicles(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9995,11 +9995,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NUMBER_OF_VEHICLES, std::make_shared<AttributeNumberOfVehicles>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NUMBER_OF_VEHICLES, std::make_shared<AttributeNumberOfVehicles>(_messageLogger, _filename, _parserOptions)));
             class AttributeOffset: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10028,11 +10028,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename, _parserOptions)));
             class AttributeSemiMajorAxis: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeSemiMajorAxis(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeSemiMajorAxis(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10061,11 +10061,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SEMI_MAJOR_AXIS, std::make_shared<AttributeSemiMajorAxis>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SEMI_MAJOR_AXIS, std::make_shared<AttributeSemiMajorAxis>(_messageLogger, _filename, _parserOptions)));
             class AttributeSemiMinorAxis: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeSemiMinorAxis(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeSemiMinorAxis(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10094,11 +10094,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SEMI_MINOR_AXIS, std::make_shared<AttributeSemiMinorAxis>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SEMI_MINOR_AXIS, std::make_shared<AttributeSemiMinorAxis>(_messageLogger, _filename, _parserOptions)));
             class AttributeVelocity: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeVelocity(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeVelocity(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10127,21 +10127,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VELOCITY, std::make_shared<AttributeVelocity>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VELOCITY, std::make_shared<AttributeVelocity>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TrafficSwarmActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementCentralObjectParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficDefinitionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementCentralObjectParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficDefinitionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrafficSwarmActionXmlParser::SubElementCentralObjectParser::SubElementCentralObjectParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSwarmActionXmlParser::SubElementCentralObjectParser::SubElementCentralObjectParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _centralSwarmObjectXmlParser = std::make_shared<CentralSwarmObjectXmlParser>(messageLogger, filename);
+            _centralSwarmObjectXmlParser = std::make_shared<CentralSwarmObjectXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSwarmActionXmlParser::SubElementCentralObjectParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10177,9 +10177,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CENTRAL_OBJECT
                     };
         }
-        TrafficSwarmActionXmlParser::SubElementTrafficDefinitionParser::SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSwarmActionXmlParser::SubElementTrafficDefinitionParser::SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficDefinitionXmlParser = std::make_shared<TrafficDefinitionXmlParser>(messageLogger, filename);
+            _trafficDefinitionXmlParser = std::make_shared<TrafficDefinitionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSwarmActionXmlParser::SubElementTrafficDefinitionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10216,10 +10216,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrafficSwarmActionXmlParser::TrafficSwarmActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSwarmActionXmlParser::TrafficSwarmActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10229,7 +10229,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrajectoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrajectoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrajectoryXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10238,7 +10238,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeClosed: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeClosed(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeClosed(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10267,11 +10267,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CLOSED, std::make_shared<AttributeClosed>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CLOSED, std::make_shared<AttributeClosed>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10300,21 +10300,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TrajectoryXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementShapeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementShapeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrajectoryXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrajectoryXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrajectoryXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10348,9 +10348,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        TrajectoryXmlParser::SubElementShapeParser::SubElementShapeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrajectoryXmlParser::SubElementShapeParser::SubElementShapeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _shapeXmlParser = std::make_shared<ShapeXmlParser>(messageLogger, filename);
+            _shapeXmlParser = std::make_shared<ShapeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrajectoryXmlParser::SubElementShapeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10387,10 +10387,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrajectoryXmlParser::TrajectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrajectoryXmlParser::TrajectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10400,7 +10400,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrajectoryCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            TrajectoryCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrajectoryCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -10413,13 +10413,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> TrajectoryCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrajectoryCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrajectoryCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrajectoryCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10456,10 +10456,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrajectoryCatalogLocationXmlParser::TrajectoryCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrajectoryCatalogLocationXmlParser::TrajectoryCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10469,7 +10469,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrajectoryFollowingModeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrajectoryFollowingModeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrajectoryFollowingModeXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10478,7 +10478,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeFollowingMode: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFollowingMode(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFollowingMode(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10516,7 +10516,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FOLLOWING_MODE, std::make_shared<AttributeFollowingMode>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FOLLOWING_MODE, std::make_shared<AttributeFollowingMode>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -10527,10 +10527,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TrajectoryFollowingModeXmlParser::TrajectoryFollowingModeXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrajectoryFollowingModeXmlParser::TrajectoryFollowingModeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10540,7 +10540,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TransitionDynamicsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TransitionDynamicsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TransitionDynamicsXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10549,7 +10549,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDynamicsDimension: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDynamicsDimension(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDynamicsDimension(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10587,11 +10587,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DYNAMICS_DIMENSION, std::make_shared<AttributeDynamicsDimension>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DYNAMICS_DIMENSION, std::make_shared<AttributeDynamicsDimension>(_messageLogger, _filename, _parserOptions)));
             class AttributeDynamicsShape: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDynamicsShape(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDynamicsShape(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10629,11 +10629,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DYNAMICS_SHAPE, std::make_shared<AttributeDynamicsShape>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DYNAMICS_SHAPE, std::make_shared<AttributeDynamicsShape>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10662,7 +10662,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -10673,10 +10673,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TransitionDynamicsXmlParser::TransitionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TransitionDynamicsXmlParser::TransitionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10686,7 +10686,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TraveledDistanceConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TraveledDistanceConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TraveledDistanceConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10695,7 +10695,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10724,7 +10724,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -10735,10 +10735,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TraveledDistanceConditionXmlParser::TraveledDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TraveledDistanceConditionXmlParser::TraveledDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10748,7 +10748,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TriggerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TriggerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TriggerXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10760,13 +10760,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> TriggerXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementConditionGroupsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementConditionGroupsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TriggerXmlParser::SubElementConditionGroupsParser::SubElementConditionGroupsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TriggerXmlParser::SubElementConditionGroupsParser::SubElementConditionGroupsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _conditionGroupXmlParser = std::make_shared<ConditionGroupXmlParser>(messageLogger, filename);
+            _conditionGroupXmlParser = std::make_shared<ConditionGroupXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TriggerXmlParser::SubElementConditionGroupsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10804,10 +10804,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TriggerXmlParser::TriggerXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TriggerXmlParser::TriggerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10817,7 +10817,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TriggeringEntitiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TriggeringEntitiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TriggeringEntitiesXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10826,7 +10826,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeTriggeringEntitiesRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTriggeringEntitiesRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTriggeringEntitiesRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10864,20 +10864,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRIGGERING_ENTITIES_RULE, std::make_shared<AttributeTriggeringEntitiesRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRIGGERING_ENTITIES_RULE, std::make_shared<AttributeTriggeringEntitiesRule>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TriggeringEntitiesXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEntityRefsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEntityRefsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TriggeringEntitiesXmlParser::SubElementEntityRefsParser::SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TriggeringEntitiesXmlParser::SubElementEntityRefsParser::SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename);
+            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TriggeringEntitiesXmlParser::SubElementEntityRefsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10915,10 +10915,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TriggeringEntitiesXmlParser::TriggeringEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TriggeringEntitiesXmlParser::TriggeringEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10928,7 +10928,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            UserDefinedActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            UserDefinedActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> UserDefinedActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10940,13 +10940,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> UserDefinedActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementCustomCommandActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementCustomCommandActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        UserDefinedActionXmlParser::SubElementCustomCommandActionParser::SubElementCustomCommandActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        UserDefinedActionXmlParser::SubElementCustomCommandActionParser::SubElementCustomCommandActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _customCommandActionXmlParser = std::make_shared<CustomCommandActionXmlParser>(messageLogger, filename);
+            _customCommandActionXmlParser = std::make_shared<CustomCommandActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void UserDefinedActionXmlParser::SubElementCustomCommandActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10983,10 +10983,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        UserDefinedActionXmlParser::UserDefinedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        UserDefinedActionXmlParser::UserDefinedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10996,7 +10996,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            UserDefinedValueConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            UserDefinedValueConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> UserDefinedValueConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11005,7 +11005,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11034,11 +11034,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11076,11 +11076,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11109,7 +11109,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -11120,10 +11120,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        UserDefinedValueConditionXmlParser::UserDefinedValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        UserDefinedValueConditionXmlParser::UserDefinedValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11133,7 +11133,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            VehicleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            VehicleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> VehicleXmlParser::GetAttributeNameToAttributeParserMap()
@@ -11143,7 +11143,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11172,11 +11172,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeVehicleCategory: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeVehicleCategory(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeVehicleCategory(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11214,24 +11214,24 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VEHICLE_CATEGORY, std::make_shared<AttributeVehicleCategory>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VEHICLE_CATEGORY, std::make_shared<AttributeVehicleCategory>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> VehicleXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPerformanceParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementAxlesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPerformanceParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementAxlesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        VehicleXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VehicleXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VehicleXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11265,9 +11265,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        VehicleXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VehicleXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename);
+            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VehicleXmlParser::SubElementBoundingBoxParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11303,9 +11303,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__BOUNDING_BOX
                     };
         }
-        VehicleXmlParser::SubElementPerformanceParser::SubElementPerformanceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VehicleXmlParser::SubElementPerformanceParser::SubElementPerformanceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _performanceXmlParser = std::make_shared<PerformanceXmlParser>(messageLogger, filename);
+            _performanceXmlParser = std::make_shared<PerformanceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VehicleXmlParser::SubElementPerformanceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11341,9 +11341,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PERFORMANCE
                     };
         }
-        VehicleXmlParser::SubElementAxlesParser::SubElementAxlesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VehicleXmlParser::SubElementAxlesParser::SubElementAxlesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _axlesXmlParser = std::make_shared<AxlesXmlParser>(messageLogger, filename);
+            _axlesXmlParser = std::make_shared<AxlesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VehicleXmlParser::SubElementAxlesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11379,9 +11379,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__AXLES
                     };
         }
-        VehicleXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VehicleXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename);
+            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VehicleXmlParser::SubElementPropertiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11418,10 +11418,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        VehicleXmlParser::VehicleXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        VehicleXmlParser::VehicleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11431,7 +11431,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            VehicleCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            VehicleCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> VehicleCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -11444,13 +11444,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> VehicleCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        VehicleCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VehicleCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VehicleCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11487,10 +11487,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        VehicleCatalogLocationXmlParser::VehicleCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        VehicleCatalogLocationXmlParser::VehicleCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11500,7 +11500,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            VehicleCategoryDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            VehicleCategoryDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> VehicleCategoryDistributionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11512,13 +11512,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> VehicleCategoryDistributionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementVehicleCategoryDistributionEntriesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementVehicleCategoryDistributionEntriesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        VehicleCategoryDistributionXmlParser::SubElementVehicleCategoryDistributionEntriesParser::SubElementVehicleCategoryDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VehicleCategoryDistributionXmlParser::SubElementVehicleCategoryDistributionEntriesParser::SubElementVehicleCategoryDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _vehicleCategoryDistributionEntryXmlParser = std::make_shared<VehicleCategoryDistributionEntryXmlParser>(messageLogger, filename);
+            _vehicleCategoryDistributionEntryXmlParser = std::make_shared<VehicleCategoryDistributionEntryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VehicleCategoryDistributionXmlParser::SubElementVehicleCategoryDistributionEntriesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11556,10 +11556,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        VehicleCategoryDistributionXmlParser::VehicleCategoryDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        VehicleCategoryDistributionXmlParser::VehicleCategoryDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11569,7 +11569,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            VehicleCategoryDistributionEntryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            VehicleCategoryDistributionEntryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> VehicleCategoryDistributionEntryXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11578,7 +11578,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeCategory: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCategory(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCategory(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11616,11 +11616,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CATEGORY, std::make_shared<AttributeCategory>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CATEGORY, std::make_shared<AttributeCategory>(_messageLogger, _filename, _parserOptions)));
             class AttributeWeight: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11649,7 +11649,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -11660,10 +11660,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        VehicleCategoryDistributionEntryXmlParser::VehicleCategoryDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        VehicleCategoryDistributionEntryXmlParser::VehicleCategoryDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11673,7 +11673,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            VertexXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            VertexXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> VertexXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11682,7 +11682,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeTime: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTime(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTime(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11711,20 +11711,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TIME, std::make_shared<AttributeTime>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TIME, std::make_shared<AttributeTime>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> VertexXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        VertexXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VertexXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VertexXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11761,10 +11761,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        VertexXmlParser::VertexXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        VertexXmlParser::VertexXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11774,7 +11774,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            VisibilityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            VisibilityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> VisibilityActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11783,7 +11783,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeGraphics: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeGraphics(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeGraphics(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11812,11 +11812,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__GRAPHICS, std::make_shared<AttributeGraphics>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__GRAPHICS, std::make_shared<AttributeGraphics>(_messageLogger, _filename, _parserOptions)));
             class AttributeSensors: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeSensors(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeSensors(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11845,11 +11845,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SENSORS, std::make_shared<AttributeSensors>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SENSORS, std::make_shared<AttributeSensors>(_messageLogger, _filename, _parserOptions)));
             class AttributeTraffic: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTraffic(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTraffic(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11878,7 +11878,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC, std::make_shared<AttributeTraffic>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC, std::make_shared<AttributeTraffic>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -11889,10 +11889,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        VisibilityActionXmlParser::VisibilityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        VisibilityActionXmlParser::VisibilityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11902,7 +11902,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            WaypointXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            WaypointXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> WaypointXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11911,7 +11911,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRouteStrategy: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRouteStrategy(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRouteStrategy(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11949,20 +11949,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ROUTE_STRATEGY, std::make_shared<AttributeRouteStrategy>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ROUTE_STRATEGY, std::make_shared<AttributeRouteStrategy>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> WaypointXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        WaypointXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        WaypointXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void WaypointXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11999,10 +11999,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        WaypointXmlParser::WaypointXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        WaypointXmlParser::WaypointXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12012,7 +12012,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            WeatherXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            WeatherXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> WeatherXmlParser::GetAttributeNameToAttributeParserMap()
@@ -12022,7 +12022,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeCloudState: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCloudState(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCloudState(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12060,22 +12060,22 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CLOUD_STATE, std::make_shared<AttributeCloudState>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CLOUD_STATE, std::make_shared<AttributeCloudState>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> WeatherXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementSunParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementFogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPrecipitationParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementSunParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementFogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPrecipitationParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        WeatherXmlParser::SubElementSunParser::SubElementSunParser(IParserMessageLogger& messageLogger, std::string& filename)
+        WeatherXmlParser::SubElementSunParser::SubElementSunParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _sunXmlParser = std::make_shared<SunXmlParser>(messageLogger, filename);
+            _sunXmlParser = std::make_shared<SunXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void WeatherXmlParser::SubElementSunParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12111,9 +12111,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SUN
                     };
         }
-        WeatherXmlParser::SubElementFogParser::SubElementFogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        WeatherXmlParser::SubElementFogParser::SubElementFogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _fogXmlParser = std::make_shared<FogXmlParser>(messageLogger, filename);
+            _fogXmlParser = std::make_shared<FogXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void WeatherXmlParser::SubElementFogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12149,9 +12149,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__FOG
                     };
         }
-        WeatherXmlParser::SubElementPrecipitationParser::SubElementPrecipitationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        WeatherXmlParser::SubElementPrecipitationParser::SubElementPrecipitationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _precipitationXmlParser = std::make_shared<PrecipitationXmlParser>(messageLogger, filename);
+            _precipitationXmlParser = std::make_shared<PrecipitationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void WeatherXmlParser::SubElementPrecipitationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12188,10 +12188,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        WeatherXmlParser::WeatherXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        WeatherXmlParser::WeatherXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12201,7 +12201,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            WorldPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            WorldPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> WorldPositionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -12210,7 +12210,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeH: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeH(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeH(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12239,11 +12239,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__H, std::make_shared<AttributeH>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__H, std::make_shared<AttributeH>(_messageLogger, _filename, _parserOptions)));
             class AttributeP: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeP(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeP(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12272,11 +12272,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__P, std::make_shared<AttributeP>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__P, std::make_shared<AttributeP>(_messageLogger, _filename, _parserOptions)));
             class AttributeR: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeR(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeR(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12305,11 +12305,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__R, std::make_shared<AttributeR>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__R, std::make_shared<AttributeR>(_messageLogger, _filename, _parserOptions)));
             class AttributeX: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeX(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeX(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12338,11 +12338,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__X, std::make_shared<AttributeX>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__X, std::make_shared<AttributeX>(_messageLogger, _filename, _parserOptions)));
             class AttributeY: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeY(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeY(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12371,11 +12371,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Y, std::make_shared<AttributeY>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Y, std::make_shared<AttributeY>(_messageLogger, _filename, _parserOptions)));
             class AttributeZ: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeZ(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeZ(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12404,7 +12404,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Z, std::make_shared<AttributeZ>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Z, std::make_shared<AttributeZ>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -12415,10 +12415,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        WorldPositionXmlParser::WorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        WorldPositionXmlParser::WorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 

--- a/cpp/openScenarioLib/generated/v1_0/xmlParser/XmlParsersV1_0.h
+++ b/cpp/openScenarioLib/generated/v1_0/xmlParser/XmlParsersV1_0.h
@@ -248,8 +248,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -263,8 +264,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AbsoluteSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            AbsoluteSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -290,8 +292,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -305,8 +308,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AbsoluteTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            AbsoluteTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -332,8 +336,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -347,8 +352,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AbsoluteTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            AbsoluteTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -374,8 +380,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -389,8 +396,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AbsoluteTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            AbsoluteTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -416,8 +424,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -431,8 +440,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AccelerationConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            AccelerationConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -458,8 +468,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -480,7 +491,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -499,8 +510,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AcquirePositionActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            AcquirePositionActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -526,8 +538,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -547,7 +560,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementManeuverGroupsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementManeuverGroupsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -572,7 +585,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -597,7 +610,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -616,8 +629,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ActXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ActXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -643,8 +657,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -665,7 +680,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementGlobalActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementGlobalActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -690,7 +705,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementUserDefinedActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementUserDefinedActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -715,7 +730,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPrivateActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPrivateActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -734,8 +749,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -761,8 +777,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -776,8 +793,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ActivateControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ActivateControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -803,8 +821,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -824,7 +843,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -843,8 +862,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ActorsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ActorsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -870,8 +890,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -892,7 +913,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -911,8 +932,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AddEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            AddEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -938,8 +960,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -960,7 +983,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -985,7 +1008,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1004,8 +1027,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AssignControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            AssignControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1031,8 +1055,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -1053,7 +1078,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1078,7 +1103,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1097,8 +1122,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AssignRouteActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            AssignRouteActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1124,8 +1150,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -1139,8 +1166,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AxleXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            AxleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1166,8 +1194,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -1187,7 +1216,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFrontAxleParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFrontAxleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1212,7 +1241,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRearAxleParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRearAxleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1237,7 +1266,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAdditionalAxlesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAdditionalAxlesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1256,8 +1285,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AxlesXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            AxlesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1283,8 +1313,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -1305,7 +1336,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCenterParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCenterParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1330,7 +1361,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDimensionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDimensionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1349,8 +1380,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            BoundingBoxXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            BoundingBoxXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1376,8 +1408,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -1398,7 +1431,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTriggeringEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTriggeringEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1423,7 +1456,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1442,8 +1475,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ByEntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ByEntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1469,8 +1503,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -1484,8 +1519,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ByObjectTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ByObjectTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1511,8 +1547,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -1526,8 +1563,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ByTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ByTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1553,8 +1591,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -1575,7 +1614,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1600,7 +1639,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTimeOfDayConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTimeOfDayConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1625,7 +1664,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSimulationTimeConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSimulationTimeConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1650,7 +1689,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStoryboardElementStateConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStoryboardElementStateConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1675,7 +1714,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementUserDefinedValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementUserDefinedValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1700,7 +1739,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSignalConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSignalConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1725,7 +1764,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSignalControllerConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSignalControllerConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1744,8 +1783,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ByValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ByValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1771,8 +1811,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -1792,7 +1833,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementVehiclesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementVehiclesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1817,7 +1858,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllersParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllersParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1842,7 +1883,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPedestriansParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPedestriansParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1867,7 +1908,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementMiscObjectsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementMiscObjectsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1892,7 +1933,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEnvironmentsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEnvironmentsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1917,7 +1958,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1942,7 +1983,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrajectoriesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrajectoriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1967,7 +2008,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRoutesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRoutesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1986,8 +2027,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CatalogXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            CatalogXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2012,8 +2054,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -2033,7 +2076,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2052,8 +2095,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CatalogDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            CatalogDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2079,8 +2123,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -2101,7 +2146,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementVehicleCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementVehicleCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2126,7 +2171,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllerCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllerCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2151,7 +2196,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPedestrianCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPedestrianCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2176,7 +2221,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementMiscObjectCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementMiscObjectCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2201,7 +2246,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEnvironmentCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEnvironmentCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2226,7 +2271,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementManeuverCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementManeuverCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2251,7 +2296,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrajectoryCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrajectoryCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2276,7 +2321,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRouteCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRouteCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2295,8 +2340,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CatalogLocationsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            CatalogLocationsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2322,8 +2368,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -2343,7 +2390,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterAssignmentsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterAssignmentsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2362,8 +2409,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CatalogReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            CatalogReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2389,8 +2437,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -2404,8 +2453,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CenterXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            CenterXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2431,8 +2481,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -2446,8 +2497,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CentralSwarmObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            CentralSwarmObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2473,8 +2525,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -2494,7 +2547,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2513,8 +2566,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ClothoidXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ClothoidXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2540,8 +2594,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -2562,7 +2617,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2587,7 +2642,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2606,8 +2661,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            CollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2633,8 +2689,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -2655,7 +2712,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementByEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementByEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2680,7 +2737,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementByValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementByValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2699,8 +2756,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2726,8 +2784,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -2747,7 +2806,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementConditionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementConditionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2766,8 +2825,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ConditionGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ConditionGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2793,8 +2853,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -2814,7 +2875,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2833,8 +2894,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ControlPointXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ControlPointXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2860,8 +2922,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -2882,7 +2945,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2907,7 +2970,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2926,8 +2989,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2953,8 +3017,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -2975,7 +3040,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAssignControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAssignControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3000,7 +3065,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOverrideControllerValueActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOverrideControllerValueActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3019,8 +3084,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3046,8 +3112,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -3068,7 +3135,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3087,8 +3154,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ControllerCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ControllerCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3114,8 +3182,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3135,7 +3204,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllerDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllerDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3154,8 +3223,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ControllerDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ControllerDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3181,8 +3251,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -3203,7 +3274,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3228,7 +3299,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3247,8 +3318,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ControllerDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ControllerDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3274,8 +3346,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CustomCommandActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            CustomCommandActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3301,8 +3374,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3316,8 +3390,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DeleteEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            DeleteEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3343,8 +3418,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3358,8 +3434,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DimensionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            DimensionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3385,8 +3462,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3400,8 +3478,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DirectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            DirectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3427,8 +3506,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -3449,7 +3529,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3468,8 +3548,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            DistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3495,8 +3576,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3510,8 +3592,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DynamicConstraintsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            DynamicConstraintsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3537,8 +3620,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3552,8 +3636,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EndOfRoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            EndOfRoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3579,8 +3664,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3600,7 +3686,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementScenarioObjectsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementScenarioObjectsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3625,7 +3711,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntitySelectionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntitySelectionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3644,8 +3730,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            EntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3671,8 +3758,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -3693,7 +3781,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAddEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAddEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3718,7 +3806,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDeleteEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDeleteEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3737,8 +3825,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            EntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3764,8 +3853,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -3786,7 +3876,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEndOfRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEndOfRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3811,7 +3901,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3836,7 +3926,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOffroadConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOffroadConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3861,7 +3951,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTimeHeadwayConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTimeHeadwayConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3886,7 +3976,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTimeToCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTimeToCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3911,7 +4001,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAccelerationConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAccelerationConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3936,7 +4026,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStandStillConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStandStillConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3961,7 +4051,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3986,7 +4076,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4011,7 +4101,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTraveledDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTraveledDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4036,7 +4126,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementReachPositionConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementReachPositionConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4061,7 +4151,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4086,7 +4176,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4105,8 +4195,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            EntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4131,8 +4222,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -4153,7 +4245,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4178,7 +4270,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementVehicleParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementVehicleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4203,7 +4295,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPedestrianParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPedestrianParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4228,7 +4320,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementMiscObjectParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementMiscObjectParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4247,8 +4339,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EntityObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            EntityObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4274,8 +4367,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -4289,8 +4383,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EntityRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            EntityRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4316,8 +4411,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -4337,7 +4433,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementMembersParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementMembersParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4356,8 +4452,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EntitySelectionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            EntitySelectionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4383,8 +4480,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -4405,7 +4503,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4430,7 +4528,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTimeOfDayParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTimeOfDayParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4455,7 +4553,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementWeatherParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementWeatherParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4480,7 +4578,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4499,8 +4597,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EnvironmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            EnvironmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4526,8 +4625,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -4548,7 +4648,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEnvironmentParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEnvironmentParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4573,7 +4673,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4592,8 +4692,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EnvironmentActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            EnvironmentActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4619,8 +4720,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -4641,7 +4743,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4660,8 +4762,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EnvironmentCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            EnvironmentCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4687,8 +4790,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -4708,7 +4812,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4733,7 +4837,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4752,8 +4856,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EventXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            EventXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4779,8 +4884,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -4794,8 +4900,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            FileXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            FileXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4821,8 +4928,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -4836,8 +4944,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            FileHeaderXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            FileHeaderXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4863,8 +4972,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -4885,7 +4995,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAbsoluteSpeedParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAbsoluteSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4910,7 +5020,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeSpeedToMasterParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeSpeedToMasterParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4929,8 +5039,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            FinalSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            FinalSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4956,8 +5067,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -4978,7 +5090,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4997,8 +5109,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            FogXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            FogXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5024,8 +5137,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -5046,7 +5160,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrajectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrajectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5071,7 +5185,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5096,7 +5210,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTimeReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTimeReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5121,7 +5235,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrajectoryFollowingModeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrajectoryFollowingModeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5140,8 +5254,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            FollowTrajectoryActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            FollowTrajectoryActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5167,8 +5282,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -5189,7 +5305,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEnvironmentActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEnvironmentActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5214,7 +5330,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5239,7 +5355,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5264,7 +5380,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementInfrastructureActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementInfrastructureActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5289,7 +5405,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5308,8 +5424,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            GlobalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            GlobalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5335,8 +5452,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -5357,7 +5475,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFromCurrentEntityParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFromCurrentEntityParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5382,7 +5500,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFromRoadCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFromRoadCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5407,7 +5525,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFromLaneCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFromLaneCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5426,8 +5544,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            InRoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            InRoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5453,8 +5572,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -5475,7 +5595,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSignalActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSignalActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5494,8 +5614,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            InfrastructureActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            InfrastructureActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5521,8 +5642,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -5542,7 +5664,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5561,8 +5683,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            InitXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            InitXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5588,8 +5711,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -5609,7 +5733,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementGlobalActionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementGlobalActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5634,7 +5758,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementUserDefinedActionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementUserDefinedActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5659,7 +5783,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPrivatesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPrivatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5678,8 +5802,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            InitActionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            InitActionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5705,8 +5830,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -5720,8 +5846,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            KnotXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            KnotXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5747,8 +5874,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -5769,7 +5897,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLaneChangeActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLaneChangeActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5794,7 +5922,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLaneChangeTargetParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLaneChangeTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5813,8 +5941,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LaneChangeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            LaneChangeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5840,8 +5969,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -5862,7 +5992,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5887,7 +6017,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAbsoluteTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAbsoluteTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5906,8 +6036,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LaneChangeTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            LaneChangeTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5933,8 +6064,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -5955,7 +6087,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLaneOffsetActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLaneOffsetActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5980,7 +6112,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLaneOffsetTargetParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLaneOffsetTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5999,8 +6131,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LaneOffsetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            LaneOffsetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6026,8 +6159,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -6041,8 +6175,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LaneOffsetActionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            LaneOffsetActionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6068,8 +6203,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -6090,7 +6226,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6115,7 +6251,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAbsoluteTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAbsoluteTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6134,8 +6270,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LaneOffsetTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            LaneOffsetTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6161,8 +6298,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -6183,7 +6321,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6202,8 +6340,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            LanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6229,8 +6368,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -6251,7 +6391,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLaneChangeActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLaneChangeActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6276,7 +6416,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLaneOffsetActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLaneOffsetActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6301,7 +6441,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLateralDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLateralDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6320,8 +6460,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LateralActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            LateralActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6347,8 +6488,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -6369,7 +6511,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6388,8 +6530,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LateralDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            LateralDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6415,8 +6558,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -6437,7 +6581,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSpeedActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSpeedActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6462,7 +6606,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLongitudinalDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLongitudinalDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6481,8 +6625,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LongitudinalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            LongitudinalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6508,8 +6653,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -6530,7 +6676,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6549,8 +6695,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LongitudinalDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            LongitudinalDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6576,8 +6723,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -6597,7 +6745,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6622,7 +6770,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEventsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEventsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6641,8 +6789,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ManeuverXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ManeuverXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6668,8 +6817,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -6690,7 +6840,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6709,8 +6859,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ManeuverCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ManeuverCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6736,8 +6887,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -6757,7 +6909,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementActorsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementActorsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6782,7 +6934,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferencesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferencesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6807,7 +6959,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6826,8 +6978,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ManeuverGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ManeuverGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6853,8 +7006,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -6875,7 +7029,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6900,7 +7054,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6925,7 +7079,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6944,8 +7098,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            MiscObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            MiscObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6971,8 +7126,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -6993,7 +7149,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7012,8 +7168,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            MiscObjectCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            MiscObjectCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7039,8 +7196,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -7061,7 +7219,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAddValueParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAddValueParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7086,7 +7244,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementMultiplyByValueParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementMultiplyByValueParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7105,8 +7263,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ModifyRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ModifyRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7132,8 +7291,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -7147,8 +7307,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            NoneXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            NoneXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7174,8 +7335,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -7195,7 +7357,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControlPointsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControlPointsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7220,7 +7382,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementKnotsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementKnotsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7239,8 +7401,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            NurbsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            NurbsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7266,8 +7429,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -7288,7 +7452,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7313,7 +7477,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7332,8 +7496,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ObjectControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ObjectControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7359,8 +7524,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -7374,8 +7540,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OffroadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            OffroadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7401,8 +7568,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -7422,7 +7590,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFileHeaderParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFileHeaderParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7447,7 +7615,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOpenScenarioCategoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOpenScenarioCategoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7466,8 +7634,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OpenScenarioXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            OpenScenarioXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7492,8 +7661,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -7514,7 +7684,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementScenarioDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementScenarioDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7539,7 +7709,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7558,8 +7728,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OpenScenarioCategoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            OpenScenarioCategoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7585,8 +7756,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -7600,8 +7772,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OrientationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            OrientationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7627,8 +7800,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -7642,8 +7816,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OverrideBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            OverrideBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7669,8 +7844,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -7684,8 +7860,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OverrideClutchActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            OverrideClutchActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7711,8 +7888,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -7733,7 +7911,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementThrottleParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementThrottleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7758,7 +7936,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementBrakeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementBrakeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7783,7 +7961,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementClutchParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementClutchParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7808,7 +7986,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParkingBrakeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParkingBrakeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7833,7 +8011,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSteeringWheelParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSteeringWheelParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7858,7 +8036,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementGearParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementGearParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7877,8 +8055,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OverrideControllerValueActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            OverrideControllerValueActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7904,8 +8083,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -7919,8 +8099,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OverrideGearActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            OverrideGearActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7946,8 +8127,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -7961,8 +8143,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OverrideParkingBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            OverrideParkingBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7988,8 +8171,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8003,8 +8187,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OverrideSteeringWheelActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            OverrideSteeringWheelActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8030,8 +8215,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8045,8 +8231,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OverrideThrottleActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            OverrideThrottleActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8072,8 +8259,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -8094,7 +8282,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSetActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSetActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8119,7 +8307,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementModifyActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementModifyActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8138,8 +8326,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ParameterActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8165,8 +8354,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8180,8 +8370,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterAddValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ParameterAddValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8207,8 +8398,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8222,8 +8414,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterAssignmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ParameterAssignmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8249,8 +8442,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8264,8 +8458,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ParameterConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8291,8 +8486,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8306,8 +8502,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterDeclarationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ParameterDeclarationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8333,8 +8530,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -8355,7 +8553,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRuleParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRuleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8374,8 +8572,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterModifyActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ParameterModifyActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8401,8 +8600,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8416,8 +8616,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterMultiplyByValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ParameterMultiplyByValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8443,8 +8644,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8458,8 +8660,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterSetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ParameterSetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8485,8 +8688,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -8507,7 +8711,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8532,7 +8736,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8557,7 +8761,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8576,8 +8780,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PedestrianXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            PedestrianXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8603,8 +8808,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -8625,7 +8831,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8644,8 +8850,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PedestrianCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            PedestrianCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8671,8 +8878,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8686,8 +8894,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PerformanceXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            PerformanceXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8713,8 +8922,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8734,7 +8944,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSignalStatesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSignalStatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8753,8 +8963,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PhaseXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            PhaseXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8780,8 +8991,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8801,7 +9013,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementVerticesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementVerticesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8820,8 +9032,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PolylineXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            PolylineXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8847,8 +9060,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -8869,7 +9083,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8894,7 +9108,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8919,7 +9133,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeObjectPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeObjectPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8944,7 +9158,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8969,7 +9183,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8994,7 +9208,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9019,7 +9233,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9044,7 +9258,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9063,8 +9277,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            PositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9090,8 +9305,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9105,8 +9321,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PositionInLaneCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            PositionInLaneCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9132,8 +9349,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9147,8 +9365,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PositionInRoadCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            PositionInRoadCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9174,8 +9393,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9189,8 +9409,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PositionOfCurrentEntityXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            PositionOfCurrentEntityXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9216,8 +9437,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9231,8 +9453,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PrecipitationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            PrecipitationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9258,8 +9481,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9279,7 +9503,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPrivateActionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPrivateActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9298,8 +9522,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PrivateXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            PrivateXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9325,8 +9550,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -9347,7 +9573,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLongitudinalActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLongitudinalActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9372,7 +9598,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLateralActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLateralActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9397,7 +9623,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementVisibilityActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementVisibilityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9422,7 +9648,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSynchronizeActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSynchronizeActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9447,7 +9673,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementActivateControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementActivateControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9472,7 +9698,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9497,7 +9723,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTeleportActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTeleportActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9522,7 +9748,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRoutingActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRoutingActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9541,8 +9767,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PrivateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            PrivateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9568,8 +9795,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9589,7 +9817,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9614,7 +9842,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFilesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFilesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9633,8 +9861,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PropertiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            PropertiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9660,8 +9889,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9675,8 +9905,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PropertyXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            PropertyXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9702,8 +9933,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -9724,7 +9956,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9743,8 +9975,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ReachPositionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ReachPositionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9770,8 +10003,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9785,8 +10019,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RelativeDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9812,8 +10047,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -9834,7 +10070,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9853,8 +10089,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeLanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RelativeLanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9880,8 +10117,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -9902,7 +10140,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9921,8 +10159,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeObjectPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RelativeObjectPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9948,8 +10187,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -9970,7 +10210,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9989,8 +10229,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeRoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RelativeRoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10016,8 +10257,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10031,8 +10273,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeSpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RelativeSpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10058,8 +10301,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10073,8 +10317,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeSpeedToMasterXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RelativeSpeedToMasterXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10100,8 +10345,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10115,8 +10361,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RelativeTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10142,8 +10389,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10157,8 +10405,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RelativeTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10184,8 +10433,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10199,8 +10449,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RelativeTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10226,8 +10477,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -10248,7 +10500,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10267,8 +10519,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeWorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RelativeWorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10294,8 +10547,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10315,7 +10569,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10334,8 +10588,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10361,8 +10616,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10382,7 +10638,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLogicFileParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLogicFileParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10407,7 +10663,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSceneGraphFileParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSceneGraphFileParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10432,7 +10688,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSignalsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSignalsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10451,8 +10707,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RoadNetworkXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RoadNetworkXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10478,8 +10735,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -10500,7 +10758,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10519,8 +10777,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10546,8 +10805,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10567,7 +10827,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10592,7 +10852,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementWaypointsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementWaypointsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10611,8 +10871,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RouteXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RouteXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10638,8 +10899,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -10660,7 +10922,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10679,8 +10941,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RouteCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RouteCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10706,8 +10969,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -10728,7 +10992,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRouteRefParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRouteRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10753,7 +11017,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10778,7 +11042,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementInRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementInRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10797,8 +11061,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10824,8 +11089,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -10846,7 +11112,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10871,7 +11137,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10890,8 +11156,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RouteRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RouteRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10917,8 +11184,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -10939,7 +11207,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAssignRouteActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAssignRouteActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10964,7 +11232,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFollowTrajectoryActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFollowTrajectoryActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10989,7 +11257,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAcquirePositionActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAcquirePositionActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11008,8 +11276,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RoutingActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            RoutingActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11034,8 +11303,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11055,7 +11325,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11080,7 +11350,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogLocationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogLocationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11105,7 +11375,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRoadNetworkParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRoadNetworkParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11130,7 +11400,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11155,7 +11425,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStoryboardParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStoryboardParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11174,8 +11444,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ScenarioDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ScenarioDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11201,8 +11472,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11222,7 +11494,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityObjectParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityObjectParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11247,7 +11519,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementObjectControllerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementObjectControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11266,8 +11538,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ScenarioObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ScenarioObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11293,8 +11566,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -11315,7 +11589,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11340,7 +11614,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11359,8 +11633,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SelectedEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            SelectedEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11386,8 +11661,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -11408,7 +11684,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPolylineParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPolylineParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11433,7 +11709,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementClothoidParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementClothoidParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11458,7 +11734,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementNurbsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementNurbsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11477,8 +11753,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ShapeXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            ShapeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11504,8 +11781,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11519,8 +11797,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SimulationTimeConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            SimulationTimeConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11546,8 +11825,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -11568,7 +11848,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSpeedActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSpeedActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11593,7 +11873,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSpeedActionTargetParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSpeedActionTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11612,8 +11892,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SpeedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            SpeedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11639,8 +11920,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -11661,7 +11943,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11686,7 +11968,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAbsoluteTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAbsoluteTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11705,8 +11987,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SpeedActionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            SpeedActionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11732,8 +12015,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11747,8 +12031,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            SpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11774,8 +12059,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11789,8 +12075,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            StandStillConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            StandStillConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11816,8 +12103,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11837,7 +12125,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11862,7 +12150,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementActsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementActsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11881,8 +12169,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            StoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            StoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11908,8 +12197,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11929,7 +12219,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementInitParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementInitParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11954,7 +12244,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStoriesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStoriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11979,7 +12269,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11998,8 +12288,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            StoryboardXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            StoryboardXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12025,8 +12316,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -12040,8 +12332,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            StoryboardElementStateConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            StoryboardElementStateConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12067,8 +12360,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -12082,8 +12376,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SunXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            SunXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12109,8 +12404,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -12131,7 +12427,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTargetPositionMasterParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTargetPositionMasterParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12156,7 +12452,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTargetPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTargetPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12181,7 +12477,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFinalSpeedParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFinalSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12200,8 +12496,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SynchronizeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            SynchronizeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12227,8 +12524,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -12248,7 +12546,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12267,8 +12565,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TeleportActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TeleportActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12294,8 +12593,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -12309,8 +12609,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TimeHeadwayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TimeHeadwayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12336,8 +12637,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -12351,8 +12653,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TimeOfDayXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TimeOfDayXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12378,8 +12681,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -12393,8 +12697,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TimeOfDayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TimeOfDayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12420,8 +12725,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -12442,7 +12748,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementNoneParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementNoneParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12467,7 +12773,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTimingParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTimingParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12486,8 +12792,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TimeReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TimeReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12513,8 +12820,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -12535,7 +12843,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTimeToCollisionConditionTargetParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTimeToCollisionConditionTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12554,8 +12862,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TimeToCollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TimeToCollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12581,8 +12890,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -12603,7 +12913,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12628,7 +12938,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12647,8 +12957,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TimeToCollisionConditionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TimeToCollisionConditionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12674,8 +12985,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -12689,8 +13001,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TimingXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TimingXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12716,8 +13029,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -12738,7 +13052,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSourceActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSourceActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12763,7 +13077,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSinkActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSinkActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12788,7 +13102,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSwarmActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSwarmActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12807,8 +13121,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrafficActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12834,8 +13149,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -12856,7 +13172,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementVehicleCategoryDistributionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementVehicleCategoryDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12881,7 +13197,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllerDistributionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllerDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12900,8 +13216,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrafficDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12927,8 +13244,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -12949,7 +13267,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSignalControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSignalControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12974,7 +13292,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSignalStateActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSignalStateActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12993,8 +13311,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSignalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrafficSignalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13020,8 +13339,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13035,8 +13355,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSignalConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrafficSignalConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13062,8 +13383,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13083,7 +13405,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPhasesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPhasesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13102,8 +13424,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSignalControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrafficSignalControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13129,8 +13452,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13144,8 +13468,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSignalControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrafficSignalControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13171,8 +13496,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13186,8 +13512,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSignalControllerConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrafficSignalControllerConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13213,8 +13540,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13228,8 +13556,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSignalStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrafficSignalStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13255,8 +13584,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13270,8 +13600,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSignalStateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrafficSignalStateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13297,8 +13628,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -13319,7 +13651,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13344,7 +13676,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13363,8 +13695,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSinkActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrafficSinkActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13390,8 +13723,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -13412,7 +13746,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13437,7 +13771,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13456,8 +13790,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSourceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrafficSourceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13483,8 +13818,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -13505,7 +13841,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCentralObjectParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCentralObjectParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13530,7 +13866,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13549,8 +13885,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSwarmActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrafficSwarmActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13576,8 +13913,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13597,7 +13935,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13622,7 +13960,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementShapeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementShapeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13641,8 +13979,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrajectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrajectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13668,8 +14007,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -13690,7 +14030,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13709,8 +14049,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrajectoryCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrajectoryCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13736,8 +14077,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13751,8 +14093,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrajectoryFollowingModeXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TrajectoryFollowingModeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13778,8 +14121,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13793,8 +14137,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TransitionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TransitionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13820,8 +14165,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13835,8 +14181,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TraveledDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TraveledDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13862,8 +14209,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13883,7 +14231,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementConditionGroupsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementConditionGroupsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13902,8 +14250,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TriggerXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TriggerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13929,8 +14278,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13950,7 +14300,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13969,8 +14319,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TriggeringEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            TriggeringEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13996,8 +14347,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14017,7 +14369,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCustomCommandActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCustomCommandActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14036,8 +14388,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            UserDefinedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            UserDefinedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14063,8 +14416,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14078,8 +14432,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            UserDefinedValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            UserDefinedValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14105,8 +14460,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -14127,7 +14483,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14152,7 +14508,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14177,7 +14533,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPerformanceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPerformanceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14202,7 +14558,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAxlesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAxlesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14227,7 +14583,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14246,8 +14602,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            VehicleXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            VehicleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14273,8 +14630,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -14295,7 +14653,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14314,8 +14672,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            VehicleCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            VehicleCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14341,8 +14700,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14362,7 +14722,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementVehicleCategoryDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementVehicleCategoryDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14381,8 +14741,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            VehicleCategoryDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            VehicleCategoryDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14408,8 +14769,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14423,8 +14785,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            VehicleCategoryDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            VehicleCategoryDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14450,8 +14813,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14471,7 +14835,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14490,8 +14854,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            VertexXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            VertexXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14517,8 +14882,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14532,8 +14898,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            VisibilityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            VisibilityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14559,8 +14926,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14580,7 +14948,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14599,8 +14967,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            WaypointXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            WaypointXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14626,8 +14995,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -14648,7 +15018,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSunParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSunParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14673,7 +15043,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14698,7 +15068,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPrecipitationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPrecipitationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14717,8 +15087,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            WeatherXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            WeatherXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14744,8 +15115,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14759,8 +15131,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            WorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            WorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
     }

--- a/cpp/openScenarioLib/generated/v1_1/impl/ApiClassImplV1_1.h
+++ b/cpp/openScenarioLib/generated/v1_1/impl/ApiClassImplV1_1.h
@@ -65,7 +65,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetValue() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ISteadyState> GetSteadyState() const override;
 
-    bool isSetSteadyState = false;          
+            bool isSetSteadyState = false;          
 
 
             OPENSCENARIOLIB_EXP void SetValue(const double value) override;
@@ -625,7 +625,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrigger> GetStartTrigger() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrigger> GetStopTrigger() const override;
 
-    bool isSetStopTrigger = false;          
+            bool isSetStopTrigger = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -732,9 +732,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IUserDefinedAction> GetUserDefinedAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPrivateAction> GetPrivateAction() const override;
 
-    bool isSetGlobalAction = false;          
-    bool isSetUserDefinedAction = false;          
-    bool isSetPrivateAction = false;          
+            bool isSetGlobalAction = false;          
+            bool isSetUserDefinedAction = false;          
+            bool isSetPrivateAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -842,8 +842,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool GetLateral() const override;
             OPENSCENARIOLIB_EXP bool GetLongitudinal() const override;
 
-    bool isSetLateral = false;          
-    bool isSetLongitudinal = false;          
+            bool isSetLateral = false;          
+            bool isSetLongitudinal = false;          
 
 
             OPENSCENARIOLIB_EXP void SetLateral(const bool lateral) override;
@@ -952,7 +952,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetEntityRefsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntityRef> GetEntityRefsAtIndex(unsigned int index) const override;
 
-    bool isSetEntityRefs = false;          
+            bool isSetEntityRefs = false;          
 
 
             OPENSCENARIOLIB_EXP void SetSelectTriggeringEntities(const bool selectTriggeringEntities) override;
@@ -1137,10 +1137,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IController> GetController() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReference> GetCatalogReference() const override;
 
-    bool isSetActivateLateral = false;          
-    bool isSetActivateLongitudinal = false;          
-    bool isSetController = false;          
-    bool isSetCatalogReference = false;          
+            bool isSetActivateLateral = false;          
+            bool isSetActivateLongitudinal = false;          
+            bool isSetController = false;          
+            bool isSetCatalogReference = false;          
 
 
             OPENSCENARIOLIB_EXP void SetActivateLateral(const bool activateLateral) override;
@@ -1254,8 +1254,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IRoute> GetRoute() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReference> GetCatalogReference() const override;
 
-    bool isSetRoute = false;          
-    bool isSetCatalogReference = false;          
+            bool isSetRoute = false;          
+            bool isSetCatalogReference = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRoute(std::shared_ptr<IRouteWriter> route) override;
@@ -1485,7 +1485,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetAdditionalAxlesSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAxle> GetAdditionalAxlesAtIndex(unsigned int index) const override;
 
-    bool isSetAdditionalAxles = false;          
+            bool isSetAdditionalAxles = false;          
 
 
             OPENSCENARIOLIB_EXP void SetFrontAxle(std::shared_ptr<IAxleWriter> frontAxle) override;
@@ -1945,13 +1945,13 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalCondition> GetTrafficSignalCondition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalControllerCondition> GetTrafficSignalControllerCondition() const override;
 
-    bool isSetParameterCondition = false;          
-    bool isSetTimeOfDayCondition = false;          
-    bool isSetSimulationTimeCondition = false;          
-    bool isSetStoryboardElementStateCondition = false;          
-    bool isSetUserDefinedValueCondition = false;          
-    bool isSetTrafficSignalCondition = false;          
-    bool isSetTrafficSignalControllerCondition = false;          
+            bool isSetParameterCondition = false;          
+            bool isSetTimeOfDayCondition = false;          
+            bool isSetSimulationTimeCondition = false;          
+            bool isSetStoryboardElementStateCondition = false;          
+            bool isSetUserDefinedValueCondition = false;          
+            bool isSetTrafficSignalCondition = false;          
+            bool isSetTrafficSignalControllerCondition = false;          
 
 
             OPENSCENARIOLIB_EXP void SetParameterCondition(std::shared_ptr<IParameterConditionWriter> parameterCondition) override;
@@ -2117,15 +2117,15 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetRoutesSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRoute> GetRoutesAtIndex(unsigned int index) const override;
 
-    bool isSetName = false;          
-    bool isSetVehicles = false;          
-    bool isSetControllers = false;          
-    bool isSetPedestrians = false;          
-    bool isSetMiscObjects = false;          
-    bool isSetEnvironments = false;          
-    bool isSetManeuvers = false;          
-    bool isSetTrajectories = false;          
-    bool isSetRoutes = false;          
+            bool isSetName = false;          
+            bool isSetVehicles = false;          
+            bool isSetControllers = false;          
+            bool isSetPedestrians = false;          
+            bool isSetMiscObjects = false;          
+            bool isSetEnvironments = false;          
+            bool isSetManeuvers = false;          
+            bool isSetTrajectories = false;          
+            bool isSetRoutes = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -2347,14 +2347,14 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryCatalogLocation> GetTrajectoryCatalog() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRouteCatalogLocation> GetRouteCatalog() const override;
 
-    bool isSetVehicleCatalog = false;          
-    bool isSetControllerCatalog = false;          
-    bool isSetPedestrianCatalog = false;          
-    bool isSetMiscObjectCatalog = false;          
-    bool isSetEnvironmentCatalog = false;          
-    bool isSetManeuverCatalog = false;          
-    bool isSetTrajectoryCatalog = false;          
-    bool isSetRouteCatalog = false;          
+            bool isSetVehicleCatalog = false;          
+            bool isSetControllerCatalog = false;          
+            bool isSetPedestrianCatalog = false;          
+            bool isSetMiscObjectCatalog = false;          
+            bool isSetEnvironmentCatalog = false;          
+            bool isSetManeuverCatalog = false;          
+            bool isSetTrajectoryCatalog = false;          
+            bool isSetRouteCatalog = false;          
 
 
             OPENSCENARIOLIB_EXP void SetVehicleCatalog(std::shared_ptr<IVehicleCatalogLocationWriter> vehicleCatalog) override;
@@ -2487,7 +2487,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterAssignment> GetParameterAssignmentsAtIndex(unsigned int index) const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogElement> GetRef() const override;
 
-    bool isSetParameterAssignments = false;          
+            bool isSetParameterAssignments = false;          
 
 
             OPENSCENARIOLIB_EXP void SetCatalogName(const std::string catalogName) override;
@@ -2803,10 +2803,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetStopTime() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetPosition() const override;
 
-    bool isSetCurvatureDot = false;          
-    bool isSetCurvaturePrime = false;          
-    bool isSetStartTime = false;          
-    bool isSetStopTime = false;          
+            bool isSetCurvatureDot = false;          
+            bool isSetCurvaturePrime = false;          
+            bool isSetStartTime = false;          
+            bool isSetStopTime = false;          
 
 
             OPENSCENARIOLIB_EXP void SetCurvature(const double curvature) override;
@@ -2949,8 +2949,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntityRef> GetEntityRef() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IByObjectType> GetByType() const override;
 
-    bool isSetEntityRef = false;          
-    bool isSetByType = false;          
+            bool isSetEntityRef = false;          
+            bool isSetByType = false;          
 
 
             OPENSCENARIOLIB_EXP void SetEntityRef(std::shared_ptr<IEntityRefWriter> entityRef) override;
@@ -3052,8 +3052,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IByEntityCondition> GetByEntityCondition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IByValueCondition> GetByValueCondition() const override;
 
-    bool isSetByEntityCondition = false;          
-    bool isSetByValueCondition = false;          
+            bool isSetByEntityCondition = false;          
+            bool isSetByValueCondition = false;          
 
 
             OPENSCENARIOLIB_EXP void SetConditionEdge(const ConditionEdge conditionEdge) override;
@@ -3261,8 +3261,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetWeight() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetPosition() const override;
 
-    bool isSetTime = false;          
-    bool isSetWeight = false;          
+            bool isSetTime = false;          
+            bool isSetWeight = false;          
 
 
             OPENSCENARIOLIB_EXP void SetTime(const double time) override;
@@ -3376,7 +3376,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterDeclaration> GetParameterDeclarationsAtIndex(unsigned int index) const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IProperties> GetProperties() const override;
 
-    bool isSetParameterDeclarations = false;          
+            bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -3479,9 +3479,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IOverrideControllerValueAction> GetOverrideControllerValueAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IActivateControllerAction> GetActivateControllerAction() const override;
 
-    bool isSetAssignControllerAction = false;          
-    bool isSetOverrideControllerValueAction = false;          
-    bool isSetActivateControllerAction = false;          
+            bool isSetAssignControllerAction = false;          
+            bool isSetOverrideControllerValueAction = false;          
+            bool isSetActivateControllerAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAssignControllerAction(std::shared_ptr<IAssignControllerActionWriter> assignControllerAction) override;
@@ -3754,8 +3754,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IController> GetController() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReference> GetCatalogReference() const override;
 
-    bool isSetController = false;          
-    bool isSetCatalogReference = false;          
+            bool isSetController = false;          
+            bool isSetCatalogReference = false;          
 
 
             OPENSCENARIOLIB_EXP void SetWeight(const double weight) override;
@@ -4038,7 +4038,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetDeterministicParameterDistributionsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IDeterministicParameterDistribution> GetDeterministicParameterDistributionsAtIndex(unsigned int index) const override;
 
-    bool isSetDeterministicParameterDistributions = false;          
+            bool isSetDeterministicParameterDistributions = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDeterministicParameterDistributions(std::vector<std::shared_ptr<IDeterministicParameterDistributionWriter>>& deterministicParameterDistributions) override;
@@ -4784,9 +4784,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetValue() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetPosition() const override;
 
-    bool isSetAlongRoute = false;          
-    bool isSetCoordinateSystem = false;          
-    bool isSetRelativeDistanceType = false;          
+            bool isSetAlongRoute = false;          
+            bool isSetCoordinateSystem = false;          
+            bool isSetRelativeDistanceType = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAlongRoute(const bool alongRoute) override;
@@ -5291,9 +5291,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetMaxDeceleration() const override;
             OPENSCENARIOLIB_EXP double GetMaxSpeed() const override;
 
-    bool isSetMaxAcceleration = false;          
-    bool isSetMaxDeceleration = false;          
-    bool isSetMaxSpeed = false;          
+            bool isSetMaxAcceleration = false;          
+            bool isSetMaxDeceleration = false;          
+            bool isSetMaxSpeed = false;          
 
 
             OPENSCENARIOLIB_EXP void SetMaxAcceleration(const double maxAcceleration) override;
@@ -5505,8 +5505,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetEntitySelectionsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntitySelection> GetEntitySelectionsAtIndex(unsigned int index) const override;
 
-    bool isSetScenarioObjects = false;          
-    bool isSetEntitySelections = false;          
+            bool isSetScenarioObjects = false;          
+            bool isSetEntitySelections = false;          
 
 
             OPENSCENARIOLIB_EXP void SetScenarioObjects(std::vector<std::shared_ptr<IScenarioObjectWriter>>& scenarioObjects) override;
@@ -5600,8 +5600,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IAddEntityAction> GetAddEntityAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IDeleteEntityAction> GetDeleteEntityAction() const override;
 
-    bool isSetAddEntityAction = false;          
-    bool isSetDeleteEntityAction = false;          
+            bool isSetAddEntityAction = false;          
+            bool isSetDeleteEntityAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetEntityRef(std::shared_ptr<INamedReference<IEntity>> entityRef) override;
@@ -5725,19 +5725,19 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IDistanceCondition> GetDistanceCondition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeDistanceCondition> GetRelativeDistanceCondition() const override;
 
-    bool isSetEndOfRoadCondition = false;          
-    bool isSetCollisionCondition = false;          
-    bool isSetOffroadCondition = false;          
-    bool isSetTimeHeadwayCondition = false;          
-    bool isSetTimeToCollisionCondition = false;          
-    bool isSetAccelerationCondition = false;          
-    bool isSetStandStillCondition = false;          
-    bool isSetSpeedCondition = false;          
-    bool isSetRelativeSpeedCondition = false;          
-    bool isSetTraveledDistanceCondition = false;          
-    bool isSetReachPositionCondition = false;          
-    bool isSetDistanceCondition = false;          
-    bool isSetRelativeDistanceCondition = false;          
+            bool isSetEndOfRoadCondition = false;          
+            bool isSetCollisionCondition = false;          
+            bool isSetOffroadCondition = false;          
+            bool isSetTimeHeadwayCondition = false;          
+            bool isSetTimeToCollisionCondition = false;          
+            bool isSetAccelerationCondition = false;          
+            bool isSetStandStillCondition = false;          
+            bool isSetSpeedCondition = false;          
+            bool isSetRelativeSpeedCondition = false;          
+            bool isSetTraveledDistanceCondition = false;          
+            bool isSetReachPositionCondition = false;          
+            bool isSetDistanceCondition = false;          
+            bool isSetRelativeDistanceCondition = false;          
 
 
             OPENSCENARIOLIB_EXP void SetEndOfRoadCondition(std::shared_ptr<IEndOfRoadConditionWriter> endOfRoadCondition) override;
@@ -5892,11 +5892,11 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IMiscObject> GetMiscObject() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IExternalObjectReference> GetExternalObjectReference() const override;
 
-    bool isSetCatalogReference = false;          
-    bool isSetVehicle = false;          
-    bool isSetPedestrian = false;          
-    bool isSetMiscObject = false;          
-    bool isSetExternalObjectReference = false;          
+            bool isSetCatalogReference = false;          
+            bool isSetVehicle = false;          
+            bool isSetPedestrian = false;          
+            bool isSetMiscObject = false;          
+            bool isSetExternalObjectReference = false;          
 
 
             OPENSCENARIOLIB_EXP void SetCatalogReference(std::shared_ptr<ICatalogReferenceWriter> catalogReference) override;
@@ -6200,10 +6200,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IWeather> GetWeather() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRoadCondition> GetRoadCondition() const override;
 
-    bool isSetParameterDeclarations = false;          
-    bool isSetTimeOfDay = false;          
-    bool isSetWeather = false;          
-    bool isSetRoadCondition = false;          
+            bool isSetParameterDeclarations = false;          
+            bool isSetTimeOfDay = false;          
+            bool isSetWeather = false;          
+            bool isSetRoadCondition = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -6316,8 +6316,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IEnvironment> GetEnvironment() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReference> GetCatalogReference() const override;
 
-    bool isSetEnvironment = false;          
-    bool isSetCatalogReference = false;          
+            bool isSetEnvironment = false;          
+            bool isSetCatalogReference = false;          
 
 
             OPENSCENARIOLIB_EXP void SetEnvironment(std::shared_ptr<IEnvironmentWriter> environment) override;
@@ -6507,8 +6507,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IAction> GetActionsAtIndex(unsigned int index) const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrigger> GetStartTrigger() const override;
 
-    bool isSetMaximumExecutionCount = false;          
-    bool isSetStartTrigger = false;          
+            bool isSetMaximumExecutionCount = false;          
+            bool isSetStartTrigger = false;          
 
 
             OPENSCENARIOLIB_EXP void SetMaximumExecutionCount(const uint32_t maximumExecutionCount) override;
@@ -6816,7 +6816,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP uint16_t GetRevMinor() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ILicense> GetLicense() const override;
 
-    bool isSetLicense = false;          
+            bool isSetLicense = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAuthor(const std::string author) override;
@@ -6945,8 +6945,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IAbsoluteSpeed> GetAbsoluteSpeed() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeSpeedToMaster> GetRelativeSpeedToMaster() const override;
 
-    bool isSetAbsoluteSpeed = false;          
-    bool isSetRelativeSpeedToMaster = false;          
+            bool isSetAbsoluteSpeed = false;          
+            bool isSetRelativeSpeedToMaster = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAbsoluteSpeed(std::shared_ptr<IAbsoluteSpeedWriter> absoluteSpeed) override;
@@ -7041,7 +7041,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetVisualRange() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IBoundingBox> GetBoundingBox() const override;
 
-    bool isSetBoundingBox = false;          
+            bool isSetBoundingBox = false;          
 
 
             OPENSCENARIOLIB_EXP void SetVisualRange(const double visualRange) override;
@@ -7147,10 +7147,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryFollowingMode> GetTrajectoryFollowingMode() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryRef> GetTrajectoryRef() const override;
 
-    bool isSetInitialDistanceOffset = false;          
-    bool isSetTrajectory = false;          
-    bool isSetCatalogReference = false;          
-    bool isSetTrajectoryRef = false;          
+            bool isSetInitialDistanceOffset = false;          
+            bool isSetTrajectory = false;          
+            bool isSetCatalogReference = false;          
+            bool isSetTrajectoryRef = false;          
 
 
             OPENSCENARIOLIB_EXP void SetInitialDistanceOffset(const double initialDistanceOffset) override;
@@ -7270,8 +7270,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetLongitude() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
 
-    bool isSetHeight = false;          
-    bool isSetOrientation = false;          
+            bool isSetHeight = false;          
+            bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetHeight(const double height) override;
@@ -7392,11 +7392,11 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IInfrastructureAction> GetInfrastructureAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficAction> GetTrafficAction() const override;
 
-    bool isSetEnvironmentAction = false;          
-    bool isSetEntityAction = false;          
-    bool isSetParameterAction = false;          
-    bool isSetInfrastructureAction = false;          
-    bool isSetTrafficAction = false;          
+            bool isSetEnvironmentAction = false;          
+            bool isSetEntityAction = false;          
+            bool isSetParameterAction = false;          
+            bool isSetInfrastructureAction = false;          
+            bool isSetTrafficAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetEnvironmentAction(std::shared_ptr<IEnvironmentActionWriter> environmentAction) override;
@@ -7689,9 +7689,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPositionInRoadCoordinates> GetFromRoadCoordinates() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPositionInLaneCoordinates> GetFromLaneCoordinates() const override;
 
-    bool isSetFromCurrentEntity = false;          
-    bool isSetFromRoadCoordinates = false;          
-    bool isSetFromLaneCoordinates = false;          
+            bool isSetFromCurrentEntity = false;          
+            bool isSetFromRoadCoordinates = false;          
+            bool isSetFromLaneCoordinates = false;          
 
 
             OPENSCENARIOLIB_EXP void SetFromCurrentEntity(std::shared_ptr<IPositionOfCurrentEntityWriter> fromCurrentEntity) override;
@@ -7972,9 +7972,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetPrivatesSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPrivate> GetPrivatesAtIndex(unsigned int index) const override;
 
-    bool isSetGlobalActions = false;          
-    bool isSetUserDefinedActions = false;          
-    bool isSetPrivates = false;          
+            bool isSetGlobalActions = false;          
+            bool isSetUserDefinedActions = false;          
+            bool isSetPrivates = false;          
 
 
             OPENSCENARIOLIB_EXP void SetGlobalActions(std::vector<std::shared_ptr<IGlobalActionWriter>>& globalActions) override;
@@ -8163,7 +8163,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITransitionDynamics> GetLaneChangeActionDynamics() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ILaneChangeTarget> GetLaneChangeTarget() const override;
 
-    bool isSetTargetLaneOffset = false;          
+            bool isSetTargetLaneOffset = false;          
 
 
             OPENSCENARIOLIB_EXP void SetTargetLaneOffset(const double targetLaneOffset) override;
@@ -8263,8 +8263,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeTargetLane> GetRelativeTargetLane() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAbsoluteTargetLane> GetAbsoluteTargetLane() const override;
 
-    bool isSetRelativeTargetLane = false;          
-    bool isSetAbsoluteTargetLane = false;          
+            bool isSetRelativeTargetLane = false;          
+            bool isSetAbsoluteTargetLane = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRelativeTargetLane(std::shared_ptr<IRelativeTargetLaneWriter> relativeTargetLane) override;
@@ -8459,7 +8459,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP DynamicsShape GetDynamicsShape() const override;
             OPENSCENARIOLIB_EXP double GetMaxLateralAcc() const override;
 
-    bool isSetMaxLateralAcc = false;          
+            bool isSetMaxLateralAcc = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDynamicsShape(const DynamicsShape dynamicsShape) override;
@@ -8561,8 +8561,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeTargetLaneOffset> GetRelativeTargetLaneOffset() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAbsoluteTargetLaneOffset> GetAbsoluteTargetLaneOffset() const override;
 
-    bool isSetRelativeTargetLaneOffset = false;          
-    bool isSetAbsoluteTargetLaneOffset = false;          
+            bool isSetRelativeTargetLaneOffset = false;          
+            bool isSetAbsoluteTargetLaneOffset = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRelativeTargetLaneOffset(std::shared_ptr<IRelativeTargetLaneOffsetWriter> relativeTargetLaneOffset) override;
@@ -8664,8 +8664,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetS() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
 
-    bool isSetOffset = false;          
-    bool isSetOrientation = false;          
+            bool isSetOffset = false;          
+            bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetLaneId(const std::string laneId) override;
@@ -8790,9 +8790,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ILaneOffsetAction> GetLaneOffsetAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ILateralDistanceAction> GetLateralDistanceAction() const override;
 
-    bool isSetLaneChangeAction = false;          
-    bool isSetLaneOffsetAction = false;          
-    bool isSetLateralDistanceAction = false;          
+            bool isSetLaneChangeAction = false;          
+            bool isSetLaneOffsetAction = false;          
+            bool isSetLateralDistanceAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetLaneChangeAction(std::shared_ptr<ILaneChangeActionWriter> laneChangeAction) override;
@@ -8903,10 +8903,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP bool GetFreespace() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IDynamicConstraints> GetDynamicConstraints() const override;
 
-    bool isSetCoordinateSystem = false;          
-    bool isSetDisplacement = false;          
-    bool isSetDistance = false;          
-    bool isSetDynamicConstraints = false;          
+            bool isSetCoordinateSystem = false;          
+            bool isSetDisplacement = false;          
+            bool isSetDistance = false;          
+            bool isSetDynamicConstraints = false;          
 
 
             OPENSCENARIOLIB_EXP void SetContinuous(const bool continuous) override;
@@ -9054,9 +9054,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::string GetResource() const override;
             OPENSCENARIOLIB_EXP std::string GetSpdxId() const override;
 
-    bool isSetText = false;          
-    bool isSetResource = false;          
-    bool isSetSpdxId = false;          
+            bool isSetText = false;          
+            bool isSetResource = false;          
+            bool isSetSpdxId = false;          
 
 
             OPENSCENARIOLIB_EXP void SetText(const std::string text) override;
@@ -9178,8 +9178,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ISpeedAction> GetSpeedAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ILongitudinalDistanceAction> GetLongitudinalDistanceAction() const override;
 
-    bool isSetSpeedAction = false;          
-    bool isSetLongitudinalDistanceAction = false;          
+            bool isSetSpeedAction = false;          
+            bool isSetLongitudinalDistanceAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetSpeedAction(std::shared_ptr<ISpeedActionWriter> speedAction) override;
@@ -9287,11 +9287,11 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetTimeGap() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IDynamicConstraints> GetDynamicConstraints() const override;
 
-    bool isSetCoordinateSystem = false;          
-    bool isSetDisplacement = false;          
-    bool isSetDistance = false;          
-    bool isSetTimeGap = false;          
-    bool isSetDynamicConstraints = false;          
+            bool isSetCoordinateSystem = false;          
+            bool isSetDisplacement = false;          
+            bool isSetDistance = false;          
+            bool isSetTimeGap = false;          
+            bool isSetDynamicConstraints = false;          
 
 
             OPENSCENARIOLIB_EXP void SetContinuous(const bool continuous) override;
@@ -9455,7 +9455,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetEventsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IEvent> GetEventsAtIndex(unsigned int index) const override;
 
-    bool isSetParameterDeclarations = false;          
+            bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -9655,8 +9655,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetManeuversSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IManeuver> GetManeuversAtIndex(unsigned int index) const override;
 
-    bool isSetCatalogReferences = false;          
-    bool isSetManeuvers = false;          
+            bool isSetCatalogReferences = false;          
+            bool isSetManeuvers = false;          
 
 
             OPENSCENARIOLIB_EXP void SetMaximumExecutionCount(const uint32_t maximumExecutionCount) override;
@@ -9783,8 +9783,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IBoundingBox> GetBoundingBox() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IProperties> GetProperties() const override;
 
-    bool isSetModel3d = false;          
-    bool isSetParameterDeclarations = false;          
+            bool isSetModel3d = false;          
+            bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetMass(const double mass) override;
@@ -9998,8 +9998,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterAddValueRule> GetAddValue() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterMultiplyByValueRule> GetMultiplyByValue() const override;
 
-    bool isSetAddValue = false;          
-    bool isSetMultiplyByValue = false;          
+            bool isSetAddValue = false;          
+            bool isSetMultiplyByValue = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAddValue(std::shared_ptr<IParameterAddValueRuleWriter> addValue) override;
@@ -10175,7 +10175,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetVariance() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRange> GetRange() const override;
 
-    bool isSetRange = false;          
+            bool isSetRange = false;          
 
 
             OPENSCENARIOLIB_EXP void SetExpectedValue(const double expectedValue) override;
@@ -10386,8 +10386,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReference> GetCatalogReference() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IController> GetController() const override;
 
-    bool isSetCatalogReference = false;          
-    bool isSetController = false;          
+            bool isSetCatalogReference = false;          
+            bool isSetController = false;          
 
 
             OPENSCENARIOLIB_EXP void SetCatalogReference(std::shared_ptr<ICatalogReferenceWriter> catalogReference) override;
@@ -10759,10 +10759,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetR() const override;
             OPENSCENARIOLIB_EXP ReferenceContext GetType() const override;
 
-    bool isSetH = false;          
-    bool isSetP = false;          
-    bool isSetR = false;          
-    bool isSetType = false;          
+            bool isSetH = false;          
+            bool isSetP = false;          
+            bool isSetR = false;          
+            bool isSetType = false;          
 
 
             OPENSCENARIOLIB_EXP void SetH(const double h) override;
@@ -11096,12 +11096,12 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IOverrideSteeringWheelAction> GetSteeringWheel() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOverrideGearAction> GetGear() const override;
 
-    bool isSetThrottle = false;          
-    bool isSetBrake = false;          
-    bool isSetClutch = false;          
-    bool isSetParkingBrake = false;          
-    bool isSetSteeringWheel = false;          
-    bool isSetGear = false;          
+            bool isSetThrottle = false;          
+            bool isSetBrake = false;          
+            bool isSetClutch = false;          
+            bool isSetParkingBrake = false;          
+            bool isSetSteeringWheel = false;          
+            bool isSetGear = false;          
 
 
             OPENSCENARIOLIB_EXP void SetThrottle(std::shared_ptr<IOverrideThrottleActionWriter> throttle) override;
@@ -11621,8 +11621,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterSetAction> GetSetAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterModifyAction> GetModifyAction() const override;
 
-    bool isSetSetAction = false;          
-    bool isSetModifyAction = false;          
+            bool isSetSetAction = false;          
+            bool isSetModifyAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetParameterRef(std::shared_ptr<INamedReference<IParameterDeclaration>> parameterRef) override;
@@ -12031,7 +12031,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetConstraintGroupsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IValueConstraintGroup> GetConstraintGroupsAtIndex(unsigned int index) const override;
 
-    bool isSetConstraintGroups = false;          
+            bool isSetConstraintGroups = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -12679,9 +12679,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IBoundingBox> GetBoundingBox() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IProperties> GetProperties() const override;
 
-    bool isSetModel = false;          
-    bool isSetModel3d = false;          
-    bool isSetParameterDeclarations = false;          
+            bool isSetModel = false;          
+            bool isSetModel3d = false;          
+            bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetMass(const double mass) override;
@@ -13023,7 +13023,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetTrafficSignalStatesSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalState> GetTrafficSignalStatesAtIndex(unsigned int index) const override;
 
-    bool isSetTrafficSignalStates = false;          
+            bool isSetTrafficSignalStates = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDuration(const double duration) override;
@@ -13128,7 +13128,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetExpectedValue() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRange> GetRange() const override;
 
-    bool isSetRange = false;          
+            bool isSetRange = false;          
 
 
             OPENSCENARIOLIB_EXP void SetExpectedValue(const double expectedValue) override;
@@ -13328,16 +13328,16 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IGeoPosition> GetGeoPosition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryPosition> GetTrajectoryPosition() const override;
 
-    bool isSetWorldPosition = false;          
-    bool isSetRelativeWorldPosition = false;          
-    bool isSetRelativeObjectPosition = false;          
-    bool isSetRoadPosition = false;          
-    bool isSetRelativeRoadPosition = false;          
-    bool isSetLanePosition = false;          
-    bool isSetRelativeLanePosition = false;          
-    bool isSetRoutePosition = false;          
-    bool isSetGeoPosition = false;          
-    bool isSetTrajectoryPosition = false;          
+            bool isSetWorldPosition = false;          
+            bool isSetRelativeWorldPosition = false;          
+            bool isSetRelativeObjectPosition = false;          
+            bool isSetRoadPosition = false;          
+            bool isSetRelativeRoadPosition = false;          
+            bool isSetLanePosition = false;          
+            bool isSetRelativeLanePosition = false;          
+            bool isSetRoutePosition = false;          
+            bool isSetGeoPosition = false;          
+            bool isSetTrajectoryPosition = false;          
 
 
             OPENSCENARIOLIB_EXP void SetWorldPosition(std::shared_ptr<IWorldPositionWriter> worldPosition) override;
@@ -13475,7 +13475,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetLaneOffset() const override;
             OPENSCENARIOLIB_EXP double GetPathS() const override;
 
-    bool isSetLaneOffset = false;          
+            bool isSetLaneOffset = false;          
 
 
             OPENSCENARIOLIB_EXP void SetLaneId(const std::string laneId) override;
@@ -13777,8 +13777,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetPrecipitationIntensity() const override;
             OPENSCENARIOLIB_EXP PrecipitationType GetPrecipitationType() const override;
 
-    bool isSetIntensity = false;          
-    bool isSetPrecipitationIntensity = false;          
+            bool isSetIntensity = false;          
+            bool isSetPrecipitationIntensity = false;          
 
 
             OPENSCENARIOLIB_EXP void SetIntensity(const double intensity) override;
@@ -13999,14 +13999,14 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITeleportAction> GetTeleportAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IRoutingAction> GetRoutingAction() const override;
 
-    bool isSetLongitudinalAction = false;          
-    bool isSetLateralAction = false;          
-    bool isSetVisibilityAction = false;          
-    bool isSetSynchronizeAction = false;          
-    bool isSetActivateControllerAction = false;          
-    bool isSetControllerAction = false;          
-    bool isSetTeleportAction = false;          
-    bool isSetRoutingAction = false;          
+            bool isSetLongitudinalAction = false;          
+            bool isSetLateralAction = false;          
+            bool isSetVisibilityAction = false;          
+            bool isSetSynchronizeAction = false;          
+            bool isSetActivateControllerAction = false;          
+            bool isSetControllerAction = false;          
+            bool isSetTeleportAction = false;          
+            bool isSetRoutingAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetLongitudinalAction(std::shared_ptr<ILongitudinalActionWriter> longitudinalAction) override;
@@ -14326,8 +14326,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetFilesSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IFile> GetFilesAtIndex(unsigned int index) const override;
 
-    bool isSetProperties = false;          
-    bool isSetFiles = false;          
+            bool isSetProperties = false;          
+            bool isSetFiles = false;          
 
 
             OPENSCENARIOLIB_EXP void SetProperties(std::vector<std::shared_ptr<IPropertyWriter>>& properties) override;
@@ -14724,7 +14724,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP Rule GetRule() const override;
             OPENSCENARIOLIB_EXP double GetValue() const override;
 
-    bool isSetCoordinateSystem = false;          
+            bool isSetCoordinateSystem = false;          
 
 
             OPENSCENARIOLIB_EXP void SetCoordinateSystem(const CoordinateSystem coordinateSystem) override;
@@ -14868,10 +14868,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetOffset() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
 
-    bool isSetDs = false;          
-    bool isSetDsLane = false;          
-    bool isSetOffset = false;          
-    bool isSetOrientation = false;          
+            bool isSetDs = false;          
+            bool isSetDsLane = false;          
+            bool isSetOffset = false;          
+            bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDLane(const int dLane) override;
@@ -15013,8 +15013,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<INamedReference<IEntity>> GetEntityRef() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
 
-    bool isSetDz = false;          
-    bool isSetOrientation = false;          
+            bool isSetDz = false;          
+            bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDx(const double dx) override;
@@ -15142,7 +15142,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<INamedReference<IEntity>> GetEntityRef() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
 
-    bool isSetOrientation = false;          
+            bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDs(const double ds) override;
@@ -15368,7 +15368,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetValue() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ISteadyState> GetSteadyState() const override;
 
-    bool isSetSteadyState = false;          
+            bool isSetSteadyState = false;          
 
 
             OPENSCENARIOLIB_EXP void SetSpeedTargetValueType(const SpeedTargetValueType speedTargetValueType) override;
@@ -15801,8 +15801,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<INamedReference<IEntity>> GetEntityRef() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
 
-    bool isSetDz = false;          
-    bool isSetOrientation = false;          
+            bool isSetDz = false;          
+            bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDx(const double dx) override;
@@ -15926,7 +15926,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetFrictionScaleFactor() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IProperties> GetProperties() const override;
 
-    bool isSetProperties = false;          
+            bool isSetProperties = false;          
 
 
             OPENSCENARIOLIB_EXP void SetFrictionScaleFactor(const double frictionScaleFactor) override;
@@ -16031,10 +16031,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalController> GetTrafficSignalsAtIndex(unsigned int index) const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IUsedArea> GetUsedArea() const override;
 
-    bool isSetLogicFile = false;          
-    bool isSetSceneGraphFile = false;          
-    bool isSetTrafficSignals = false;          
-    bool isSetUsedArea = false;          
+            bool isSetLogicFile = false;          
+            bool isSetSceneGraphFile = false;          
+            bool isSetTrafficSignals = false;          
+            bool isSetUsedArea = false;          
 
 
             OPENSCENARIOLIB_EXP void SetLogicFile(std::shared_ptr<IFileWriter> logicFile) override;
@@ -16143,7 +16143,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetT() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
 
-    bool isSetOrientation = false;          
+            bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRoadId(const std::string roadId) override;
@@ -16270,7 +16270,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetWaypointsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IWaypoint> GetWaypointsAtIndex(unsigned int index) const override;
 
-    bool isSetParameterDeclarations = false;          
+            bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetClosed(const bool closed) override;
@@ -16464,7 +16464,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IInRoutePosition> GetInRoutePosition() const override;
 
-    bool isSetOrientation = false;          
+            bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRouteRef(std::shared_ptr<IRouteRefWriter> routeRef) override;
@@ -16559,8 +16559,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IRoute> GetRoute() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ICatalogReference> GetCatalogReference() const override;
 
-    bool isSetRoute = false;          
-    bool isSetCatalogReference = false;          
+            bool isSetRoute = false;          
+            bool isSetCatalogReference = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRoute(std::shared_ptr<IRouteWriter> route) override;
@@ -16656,9 +16656,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IFollowTrajectoryAction> GetFollowTrajectoryAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAcquirePositionAction> GetAcquirePositionAction() const override;
 
-    bool isSetAssignRouteAction = false;          
-    bool isSetFollowTrajectoryAction = false;          
-    bool isSetAcquirePositionAction = false;          
+            bool isSetAssignRouteAction = false;          
+            bool isSetFollowTrajectoryAction = false;          
+            bool isSetAcquirePositionAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAssignRouteAction(std::shared_ptr<IAssignRouteActionWriter> assignRouteAction) override;
@@ -16767,7 +16767,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntities> GetEntities() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IStoryboard> GetStoryboard() const override;
 
-    bool isSetParameterDeclarations = false;          
+            bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetParameterDeclarations(std::vector<std::shared_ptr<IParameterDeclarationWriter>>& parameterDeclarations) override;
@@ -16872,7 +16872,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntityObject> GetEntityObject() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IObjectController> GetObjectController() const override;
 
-    bool isSetObjectController = false;          
+            bool isSetObjectController = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -16980,8 +16980,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetByTypeSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IByType> GetByTypeAtIndex(unsigned int index) const override;
 
-    bool isSetEntityRef = false;          
-    bool isSetByType = false;          
+            bool isSetEntityRef = false;          
+            bool isSetByType = false;          
 
 
             OPENSCENARIOLIB_EXP void SetEntityRef(std::vector<std::shared_ptr<IEntityRefWriter>>& entityRef) override;
@@ -17075,9 +17075,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IClothoid> GetClothoid() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<INurbs> GetNurbs() const override;
 
-    bool isSetPolyline = false;          
-    bool isSetClothoid = false;          
-    bool isSetNurbs = false;          
+            bool isSetPolyline = false;          
+            bool isSetClothoid = false;          
+            bool isSetNurbs = false;          
 
 
             OPENSCENARIOLIB_EXP void SetPolyline(std::shared_ptr<IPolylineWriter> polyline) override;
@@ -17365,8 +17365,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IRelativeTargetSpeed> GetRelativeTargetSpeed() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAbsoluteTargetSpeed> GetAbsoluteTargetSpeed() const override;
 
-    bool isSetRelativeTargetSpeed = false;          
-    bool isSetAbsoluteTargetSpeed = false;          
+            bool isSetRelativeTargetSpeed = false;          
+            bool isSetAbsoluteTargetSpeed = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRelativeTargetSpeed(std::shared_ptr<IRelativeTargetSpeedWriter> relativeTargetSpeed) override;
@@ -17747,7 +17747,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetStochasticDistributionsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IStochasticDistribution> GetStochasticDistributionsAtIndex(unsigned int index) const override;
 
-    bool isSetRandomSeed = false;          
+            bool isSetRandomSeed = false;          
 
 
             OPENSCENARIOLIB_EXP void SetNumberOfTestRuns(const uint32_t numberOfTestRuns) override;
@@ -18066,7 +18066,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetActsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IAct> GetActsAtIndex(unsigned int index) const override;
 
-    bool isSetParameterDeclarations = false;          
+            bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetName(const std::string name) override;
@@ -18491,9 +18491,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetTargetPosition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IFinalSpeed> GetFinalSpeed() const override;
 
-    bool isSetTargetTolerance = false;          
-    bool isSetTargetToleranceMaster = false;          
-    bool isSetFinalSpeed = false;          
+            bool isSetTargetTolerance = false;          
+            bool isSetTargetToleranceMaster = false;          
+            bool isSetFinalSpeed = false;          
 
 
             OPENSCENARIOLIB_EXP void SetMasterEntityRef(std::shared_ptr<INamedReference<IEntity>> masterEntityRef) override;
@@ -18892,9 +18892,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP Rule GetRule() const override;
             OPENSCENARIOLIB_EXP double GetValue() const override;
 
-    bool isSetAlongRoute = false;          
-    bool isSetCoordinateSystem = false;          
-    bool isSetRelativeDistanceType = false;          
+            bool isSetAlongRoute = false;          
+            bool isSetCoordinateSystem = false;          
+            bool isSetRelativeDistanceType = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAlongRoute(const bool alongRoute) override;
@@ -19241,8 +19241,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<INone> GetNone() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITiming> GetTiming() const override;
 
-    bool isSetNone = false;          
-    bool isSetTiming = false;          
+            bool isSetNone = false;          
+            bool isSetTiming = false;          
 
 
             OPENSCENARIOLIB_EXP void SetNone(std::shared_ptr<INoneWriter> none) override;
@@ -19348,9 +19348,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetValue() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITimeToCollisionConditionTarget> GetTimeToCollisionConditionTarget() const override;
 
-    bool isSetAlongRoute = false;          
-    bool isSetCoordinateSystem = false;          
-    bool isSetRelativeDistanceType = false;          
+            bool isSetAlongRoute = false;          
+            bool isSetCoordinateSystem = false;          
+            bool isSetRelativeDistanceType = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAlongRoute(const bool alongRoute) override;
@@ -19491,8 +19491,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetPosition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IEntityRef> GetEntityRef() const override;
 
-    bool isSetPosition = false;          
-    bool isSetEntityRef = false;          
+            bool isSetPosition = false;          
+            bool isSetEntityRef = false;          
 
 
             OPENSCENARIOLIB_EXP void SetPosition(std::shared_ptr<IPositionWriter> position) override;
@@ -19703,11 +19703,11 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSwarmAction> GetTrafficSwarmAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficStopAction> GetTrafficStopAction() const override;
 
-    bool isSetTrafficName = false;          
-    bool isSetTrafficSourceAction = false;          
-    bool isSetTrafficSinkAction = false;          
-    bool isSetTrafficSwarmAction = false;          
-    bool isSetTrafficStopAction = false;          
+            bool isSetTrafficName = false;          
+            bool isSetTrafficSourceAction = false;          
+            bool isSetTrafficSinkAction = false;          
+            bool isSetTrafficSwarmAction = false;          
+            bool isSetTrafficStopAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetTrafficName(const std::string trafficName) override;
@@ -19921,8 +19921,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalControllerAction> GetTrafficSignalControllerAction() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficSignalStateAction> GetTrafficSignalStateAction() const override;
 
-    bool isSetTrafficSignalControllerAction = false;          
-    bool isSetTrafficSignalStateAction = false;          
+            bool isSetTrafficSignalControllerAction = false;          
+            bool isSetTrafficSignalStateAction = false;          
 
 
             OPENSCENARIOLIB_EXP void SetTrafficSignalControllerAction(std::shared_ptr<ITrafficSignalControllerActionWriter> trafficSignalControllerAction) override;
@@ -20126,9 +20126,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetPhasesSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPhase> GetPhasesAtIndex(unsigned int index) const override;
 
-    bool isSetDelay = false;          
-    bool isSetReference = false;          
-    bool isSetPhases = false;          
+            bool isSetDelay = false;          
+            bool isSetReference = false;          
+            bool isSetPhases = false;          
 
 
             OPENSCENARIOLIB_EXP void SetDelay(const double delay) override;
@@ -20250,7 +20250,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetPhaseRefSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPhase> GetPhaseRefAtIndex(unsigned int index) const override;
 
-    bool isSetPhaseRef = false;          
+            bool isSetPhaseRef = false;          
 
 
             OPENSCENARIOLIB_EXP void SetPhase(const std::string phase) override;
@@ -20360,7 +20360,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetPhaseRefSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPhase> GetPhaseRefAtIndex(unsigned int index) const override;
 
-    bool isSetPhaseRef = false;          
+            bool isSetPhaseRef = false;          
 
 
             OPENSCENARIOLIB_EXP void SetPhase(const std::string phase) override;
@@ -20669,8 +20669,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetPosition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficDefinition> GetTrafficDefinition() const override;
 
-    bool isSetRate = false;          
-    bool isSetTrafficDefinition = false;          
+            bool isSetRate = false;          
+            bool isSetTrafficDefinition = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRadius(const double radius) override;
@@ -20787,7 +20787,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetPosition() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficDefinition> GetTrafficDefinition() const override;
 
-    bool isSetVelocity = false;          
+            bool isSetVelocity = false;          
 
 
             OPENSCENARIOLIB_EXP void SetRadius(const double radius) override;
@@ -20996,7 +20996,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<ICentralSwarmObject> GetCentralObject() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrafficDefinition> GetTrafficDefinition() const override;
 
-    bool isSetVelocity = false;          
+            bool isSetVelocity = false;          
 
 
             OPENSCENARIOLIB_EXP void SetInnerRadius(const double innerRadius) override;
@@ -21146,7 +21146,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IParameterDeclaration> GetParameterDeclarationsAtIndex(unsigned int index) const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IShape> GetShape() const override;
 
-    bool isSetParameterDeclarations = false;          
+            bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetClosed(const bool closed) override;
@@ -21433,8 +21433,8 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IOrientation> GetOrientation() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<ITrajectoryRef> GetTrajectoryRef() const override;
 
-    bool isSetT = false;          
-    bool isSetOrientation = false;          
+            bool isSetT = false;          
+            bool isSetOrientation = false;          
 
 
             OPENSCENARIOLIB_EXP void SetS(const double s) override;
@@ -21835,7 +21835,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP int GetConditionGroupsSize() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IConditionGroup> GetConditionGroupsAtIndex(unsigned int index) const override;
 
-    bool isSetConditionGroups = false;          
+            bool isSetConditionGroups = false;          
 
 
             OPENSCENARIOLIB_EXP void SetConditionGroups(std::vector<std::shared_ptr<IConditionGroupWriter>>& conditionGroups) override;
@@ -22781,9 +22781,9 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IAxles> GetAxles() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IProperties> GetProperties() const override;
 
-    bool isSetMass = false;          
-    bool isSetModel3d = false;          
-    bool isSetParameterDeclarations = false;          
+            bool isSetMass = false;          
+            bool isSetModel3d = false;          
+            bool isSetParameterDeclarations = false;          
 
 
             OPENSCENARIOLIB_EXP void SetMass(const double mass) override;
@@ -23193,7 +23193,7 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetTime() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IPosition> GetPosition() const override;
 
-    bool isSetTime = false;          
+            bool isSetTime = false;          
 
 
             OPENSCENARIOLIB_EXP void SetTime(const double time) override;
@@ -23505,13 +23505,13 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP std::shared_ptr<IPrecipitation> GetPrecipitation() const override;
             OPENSCENARIOLIB_EXP std::shared_ptr<IWind> GetWind() const override;
 
-    bool isSetAtmosphericPressure = false;          
-    bool isSetCloudState = false;          
-    bool isSetTemperature = false;          
-    bool isSetSun = false;          
-    bool isSetFog = false;          
-    bool isSetPrecipitation = false;          
-    bool isSetWind = false;          
+            bool isSetAtmosphericPressure = false;          
+            bool isSetCloudState = false;          
+            bool isSetTemperature = false;          
+            bool isSetSun = false;          
+            bool isSetFog = false;          
+            bool isSetPrecipitation = false;          
+            bool isSetWind = false;          
 
 
             OPENSCENARIOLIB_EXP void SetAtmosphericPressure(const double atmosphericPressure) override;
@@ -23754,10 +23754,10 @@ namespace NET_ASAM_OPENSCENARIO
             OPENSCENARIOLIB_EXP double GetY() const override;
             OPENSCENARIOLIB_EXP double GetZ() const override;
 
-    bool isSetH = false;          
-    bool isSetP = false;          
-    bool isSetR = false;          
-    bool isSetZ = false;          
+            bool isSetH = false;          
+            bool isSetP = false;          
+            bool isSetR = false;          
+            bool isSetZ = false;          
 
 
             OPENSCENARIOLIB_EXP void SetH(const double h) override;

--- a/cpp/openScenarioLib/generated/v1_1/xmlParser/XmlParsers1V1_1.cpp
+++ b/cpp/openScenarioLib/generated/v1_1/xmlParser/XmlParsers1V1_1.cpp
@@ -35,7 +35,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AbsoluteSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            AbsoluteSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AbsoluteSpeedXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -44,7 +44,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -79,20 +79,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> AbsoluteSpeedXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementSteadyStateParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementSteadyStateParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        AbsoluteSpeedXmlParser::SubElementSteadyStateParser::SubElementSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AbsoluteSpeedXmlParser::SubElementSteadyStateParser::SubElementSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _steadyStateXmlParser = std::make_shared<SteadyStateXmlParser>(messageLogger, filename);
+            _steadyStateXmlParser = std::make_shared<SteadyStateXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AbsoluteSpeedXmlParser::SubElementSteadyStateParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -133,10 +133,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        AbsoluteSpeedXmlParser::AbsoluteSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AbsoluteSpeedXmlParser::AbsoluteSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -146,7 +146,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AbsoluteTargetLaneXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            AbsoluteTargetLaneXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AbsoluteTargetLaneXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -155,7 +155,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -190,7 +190,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -201,10 +201,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        AbsoluteTargetLaneXmlParser::AbsoluteTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AbsoluteTargetLaneXmlParser::AbsoluteTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -214,7 +214,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AbsoluteTargetLaneOffsetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            AbsoluteTargetLaneOffsetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AbsoluteTargetLaneOffsetXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -223,7 +223,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -258,7 +258,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -269,10 +269,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        AbsoluteTargetLaneOffsetXmlParser::AbsoluteTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AbsoluteTargetLaneOffsetXmlParser::AbsoluteTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -282,7 +282,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AbsoluteTargetSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            AbsoluteTargetSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AbsoluteTargetSpeedXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -291,7 +291,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -326,7 +326,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -337,10 +337,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        AbsoluteTargetSpeedXmlParser::AbsoluteTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AbsoluteTargetSpeedXmlParser::AbsoluteTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -350,7 +350,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AccelerationConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            AccelerationConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AccelerationConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -359,7 +359,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -386,7 +386,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (Rule::IsDeprecated(kResult))
+                        if (Rule::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  Rule::GetDeprecatedVersion(kResult) +"'. " + Rule::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -403,11 +403,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -442,7 +442,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -453,10 +453,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        AccelerationConditionXmlParser::AccelerationConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AccelerationConditionXmlParser::AccelerationConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -466,7 +466,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AcquirePositionActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            AcquirePositionActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AcquirePositionActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -479,13 +479,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> AcquirePositionActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        AcquirePositionActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AcquirePositionActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AcquirePositionActionXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -524,10 +524,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        AcquirePositionActionXmlParser::AcquirePositionActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AcquirePositionActionXmlParser::AcquirePositionActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -537,7 +537,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ActXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ActXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ActXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -546,7 +546,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -581,22 +581,22 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ActXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementManeuverGroupsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStartTriggerParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStopTriggerParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementManeuverGroupsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStartTriggerParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStopTriggerParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ActXmlParser::SubElementManeuverGroupsParser::SubElementManeuverGroupsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ActXmlParser::SubElementManeuverGroupsParser::SubElementManeuverGroupsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _maneuverGroupXmlParser = std::make_shared<ManeuverGroupXmlParser>(messageLogger, filename);
+            _maneuverGroupXmlParser = std::make_shared<ManeuverGroupXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ActXmlParser::SubElementManeuverGroupsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -635,9 +635,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__MANEUVER_GROUP
                     };
         }
-        ActXmlParser::SubElementStartTriggerParser::SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ActXmlParser::SubElementStartTriggerParser::SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename);
+            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ActXmlParser::SubElementStartTriggerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -675,9 +675,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__START_TRIGGER
                     };
         }
-        ActXmlParser::SubElementStopTriggerParser::SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ActXmlParser::SubElementStopTriggerParser::SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename);
+            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ActXmlParser::SubElementStopTriggerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -716,10 +716,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ActXmlParser::ActXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ActXmlParser::ActXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -729,7 +729,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -739,7 +739,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -774,22 +774,22 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementGlobalActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementUserDefinedActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPrivateActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementGlobalActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementUserDefinedActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPrivateActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ActionXmlParser::SubElementGlobalActionParser::SubElementGlobalActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ActionXmlParser::SubElementGlobalActionParser::SubElementGlobalActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _globalActionXmlParser = std::make_shared<GlobalActionXmlParser>(messageLogger, filename);
+            _globalActionXmlParser = std::make_shared<GlobalActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ActionXmlParser::SubElementGlobalActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -827,9 +827,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__GLOBAL_ACTION
                     };
         }
-        ActionXmlParser::SubElementUserDefinedActionParser::SubElementUserDefinedActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ActionXmlParser::SubElementUserDefinedActionParser::SubElementUserDefinedActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _userDefinedActionXmlParser = std::make_shared<UserDefinedActionXmlParser>(messageLogger, filename);
+            _userDefinedActionXmlParser = std::make_shared<UserDefinedActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ActionXmlParser::SubElementUserDefinedActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -867,9 +867,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__USER_DEFINED_ACTION
                     };
         }
-        ActionXmlParser::SubElementPrivateActionParser::SubElementPrivateActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ActionXmlParser::SubElementPrivateActionParser::SubElementPrivateActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _privateActionXmlParser = std::make_shared<PrivateActionXmlParser>(messageLogger, filename);
+            _privateActionXmlParser = std::make_shared<PrivateActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ActionXmlParser::SubElementPrivateActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -908,10 +908,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ActionXmlParser::ActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ActionXmlParser::ActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -921,7 +921,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ActivateControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ActivateControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ActivateControllerActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -930,7 +930,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeLateral: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLateral(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLateral(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -960,11 +960,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LATERAL, std::make_shared<AttributeLateral>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LATERAL, std::make_shared<AttributeLateral>(_messageLogger, _filename, _parserOptions)));
             class AttributeLongitudinal: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLongitudinal(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLongitudinal(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -994,7 +994,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LONGITUDINAL, std::make_shared<AttributeLongitudinal>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LONGITUDINAL, std::make_shared<AttributeLongitudinal>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -1005,10 +1005,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ActivateControllerActionXmlParser::ActivateControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ActivateControllerActionXmlParser::ActivateControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1018,7 +1018,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ActorsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ActorsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ActorsXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1027,7 +1027,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeSelectTriggeringEntities: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeSelectTriggeringEntities(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeSelectTriggeringEntities(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1057,20 +1057,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SELECT_TRIGGERING_ENTITIES, std::make_shared<AttributeSelectTriggeringEntities>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SELECT_TRIGGERING_ENTITIES, std::make_shared<AttributeSelectTriggeringEntities>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ActorsXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEntityRefsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEntityRefsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ActorsXmlParser::SubElementEntityRefsParser::SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ActorsXmlParser::SubElementEntityRefsParser::SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename);
+            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ActorsXmlParser::SubElementEntityRefsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1110,10 +1110,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ActorsXmlParser::ActorsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ActorsXmlParser::ActorsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1123,7 +1123,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AddEntityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            AddEntityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AddEntityActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -1136,13 +1136,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> AddEntityActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        AddEntityActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AddEntityActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AddEntityActionXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1181,10 +1181,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        AddEntityActionXmlParser::AddEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AddEntityActionXmlParser::AddEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1194,7 +1194,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AssignControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            AssignControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AssignControllerActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -1204,7 +1204,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeActivateLateral: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeActivateLateral(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeActivateLateral(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1234,11 +1234,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVATE_LATERAL, std::make_shared<AttributeActivateLateral>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVATE_LATERAL, std::make_shared<AttributeActivateLateral>(_messageLogger, _filename, _parserOptions)));
             class AttributeActivateLongitudinal: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeActivateLongitudinal(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeActivateLongitudinal(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1268,21 +1268,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVATE_LONGITUDINAL, std::make_shared<AttributeActivateLongitudinal>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVATE_LONGITUDINAL, std::make_shared<AttributeActivateLongitudinal>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> AssignControllerActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementControllerParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementControllerParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        AssignControllerActionXmlParser::SubElementControllerParser::SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AssignControllerActionXmlParser::SubElementControllerParser::SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename);
+            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AssignControllerActionXmlParser::SubElementControllerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1320,9 +1320,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CONTROLLER
                     };
         }
-        AssignControllerActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AssignControllerActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AssignControllerActionXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1362,10 +1362,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        AssignControllerActionXmlParser::AssignControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AssignControllerActionXmlParser::AssignControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1375,7 +1375,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AssignRouteActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            AssignRouteActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AssignRouteActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -1388,14 +1388,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> AssignRouteActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRouteParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRouteParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        AssignRouteActionXmlParser::SubElementRouteParser::SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AssignRouteActionXmlParser::SubElementRouteParser::SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _routeXmlParser = std::make_shared<RouteXmlParser>(messageLogger, filename);
+            _routeXmlParser = std::make_shared<RouteXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AssignRouteActionXmlParser::SubElementRouteParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1433,9 +1433,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ROUTE
                     };
         }
-        AssignRouteActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AssignRouteActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AssignRouteActionXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1475,10 +1475,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        AssignRouteActionXmlParser::AssignRouteActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AssignRouteActionXmlParser::AssignRouteActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1488,7 +1488,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AxleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            AxleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AxleXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1497,7 +1497,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMaxSteering: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxSteering(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxSteering(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1532,11 +1532,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_STEERING, std::make_shared<AttributeMaxSteering>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_STEERING, std::make_shared<AttributeMaxSteering>(_messageLogger, _filename, _parserOptions)));
             class AttributePositionX: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePositionX(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePositionX(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1571,11 +1571,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__POSITION_X, std::make_shared<AttributePositionX>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__POSITION_X, std::make_shared<AttributePositionX>(_messageLogger, _filename, _parserOptions)));
             class AttributePositionZ: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePositionZ(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePositionZ(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1610,11 +1610,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__POSITION_Z, std::make_shared<AttributePositionZ>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__POSITION_Z, std::make_shared<AttributePositionZ>(_messageLogger, _filename, _parserOptions)));
             class AttributeTrackWidth: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTrackWidth(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTrackWidth(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1649,11 +1649,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRACK_WIDTH, std::make_shared<AttributeTrackWidth>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRACK_WIDTH, std::make_shared<AttributeTrackWidth>(_messageLogger, _filename, _parserOptions)));
             class AttributeWheelDiameter: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeWheelDiameter(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeWheelDiameter(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1688,7 +1688,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WHEEL_DIAMETER, std::make_shared<AttributeWheelDiameter>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WHEEL_DIAMETER, std::make_shared<AttributeWheelDiameter>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -1699,10 +1699,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        AxleXmlParser::AxleXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AxleXmlParser::AxleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1712,7 +1712,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            AxlesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            AxlesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> AxlesXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1724,15 +1724,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> AxlesXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementFrontAxleParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRearAxleParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementAdditionalAxlesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementFrontAxleParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRearAxleParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementAdditionalAxlesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        AxlesXmlParser::SubElementFrontAxleParser::SubElementFrontAxleParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AxlesXmlParser::SubElementFrontAxleParser::SubElementFrontAxleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _axleXmlParser = std::make_shared<AxleXmlParser>(messageLogger, filename);
+            _axleXmlParser = std::make_shared<AxleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AxlesXmlParser::SubElementFrontAxleParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1770,9 +1770,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__FRONT_AXLE
                     };
         }
-        AxlesXmlParser::SubElementRearAxleParser::SubElementRearAxleParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AxlesXmlParser::SubElementRearAxleParser::SubElementRearAxleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _axleXmlParser = std::make_shared<AxleXmlParser>(messageLogger, filename);
+            _axleXmlParser = std::make_shared<AxleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AxlesXmlParser::SubElementRearAxleParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1810,9 +1810,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__REAR_AXLE
                     };
         }
-        AxlesXmlParser::SubElementAdditionalAxlesParser::SubElementAdditionalAxlesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        AxlesXmlParser::SubElementAdditionalAxlesParser::SubElementAdditionalAxlesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _axleXmlParser = std::make_shared<AxleXmlParser>(messageLogger, filename);
+            _axleXmlParser = std::make_shared<AxleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void AxlesXmlParser::SubElementAdditionalAxlesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1852,10 +1852,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        AxlesXmlParser::AxlesXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        AxlesXmlParser::AxlesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1865,7 +1865,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            BoundingBoxXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            BoundingBoxXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> BoundingBoxXmlParser::GetAttributeNameToAttributeParserMap()
@@ -1878,14 +1878,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> BoundingBoxXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementCenterParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementDimensionsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementCenterParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementDimensionsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        BoundingBoxXmlParser::SubElementCenterParser::SubElementCenterParser(IParserMessageLogger& messageLogger, std::string& filename)
+        BoundingBoxXmlParser::SubElementCenterParser::SubElementCenterParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _centerXmlParser = std::make_shared<CenterXmlParser>(messageLogger, filename);
+            _centerXmlParser = std::make_shared<CenterXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void BoundingBoxXmlParser::SubElementCenterParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1923,9 +1923,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CENTER
                     };
         }
-        BoundingBoxXmlParser::SubElementDimensionsParser::SubElementDimensionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        BoundingBoxXmlParser::SubElementDimensionsParser::SubElementDimensionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _dimensionsXmlParser = std::make_shared<DimensionsXmlParser>(messageLogger, filename);
+            _dimensionsXmlParser = std::make_shared<DimensionsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void BoundingBoxXmlParser::SubElementDimensionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1964,10 +1964,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        BoundingBoxXmlParser::BoundingBoxXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        BoundingBoxXmlParser::BoundingBoxXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1977,7 +1977,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ByEntityConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ByEntityConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ByEntityConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -1990,14 +1990,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ByEntityConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTriggeringEntitiesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementEntityConditionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTriggeringEntitiesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementEntityConditionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ByEntityConditionXmlParser::SubElementTriggeringEntitiesParser::SubElementTriggeringEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByEntityConditionXmlParser::SubElementTriggeringEntitiesParser::SubElementTriggeringEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _triggeringEntitiesXmlParser = std::make_shared<TriggeringEntitiesXmlParser>(messageLogger, filename);
+            _triggeringEntitiesXmlParser = std::make_shared<TriggeringEntitiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByEntityConditionXmlParser::SubElementTriggeringEntitiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2035,9 +2035,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRIGGERING_ENTITIES
                     };
         }
-        ByEntityConditionXmlParser::SubElementEntityConditionParser::SubElementEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByEntityConditionXmlParser::SubElementEntityConditionParser::SubElementEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityConditionXmlParser = std::make_shared<EntityConditionXmlParser>(messageLogger, filename);
+            _entityConditionXmlParser = std::make_shared<EntityConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByEntityConditionXmlParser::SubElementEntityConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2076,10 +2076,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ByEntityConditionXmlParser::ByEntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ByEntityConditionXmlParser::ByEntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2089,7 +2089,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ByObjectTypeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ByObjectTypeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ByObjectTypeXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2098,7 +2098,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2125,7 +2125,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (ObjectType::IsDeprecated(kResult))
+                        if (ObjectType::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  ObjectType::GetDeprecatedVersion(kResult) +"'. " + ObjectType::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -2142,7 +2142,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TYPE, std::make_shared<AttributeType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TYPE, std::make_shared<AttributeType>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -2153,10 +2153,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ByObjectTypeXmlParser::ByObjectTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ByObjectTypeXmlParser::ByObjectTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2166,7 +2166,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ByTypeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ByTypeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ByTypeXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2175,7 +2175,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeObjectType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeObjectType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeObjectType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2202,7 +2202,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (ObjectType::IsDeprecated(kResult))
+                        if (ObjectType::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  ObjectType::GetDeprecatedVersion(kResult) +"'. " + ObjectType::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -2219,7 +2219,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OBJECT_TYPE, std::make_shared<AttributeObjectType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OBJECT_TYPE, std::make_shared<AttributeObjectType>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -2230,10 +2230,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ByTypeXmlParser::ByTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ByTypeXmlParser::ByTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2243,7 +2243,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ByValueConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ByValueConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ByValueConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -2256,19 +2256,19 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ByValueConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementParameterConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTimeOfDayConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementSimulationTimeConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStoryboardElementStateConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementUserDefinedValueConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficSignalConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficSignalControllerConditionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementParameterConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTimeOfDayConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementSimulationTimeConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStoryboardElementStateConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementUserDefinedValueConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficSignalConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficSignalControllerConditionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ByValueConditionXmlParser::SubElementParameterConditionParser::SubElementParameterConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByValueConditionXmlParser::SubElementParameterConditionParser::SubElementParameterConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterConditionXmlParser = std::make_shared<ParameterConditionXmlParser>(messageLogger, filename);
+            _parameterConditionXmlParser = std::make_shared<ParameterConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByValueConditionXmlParser::SubElementParameterConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2306,9 +2306,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PARAMETER_CONDITION
                     };
         }
-        ByValueConditionXmlParser::SubElementTimeOfDayConditionParser::SubElementTimeOfDayConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByValueConditionXmlParser::SubElementTimeOfDayConditionParser::SubElementTimeOfDayConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _timeOfDayConditionXmlParser = std::make_shared<TimeOfDayConditionXmlParser>(messageLogger, filename);
+            _timeOfDayConditionXmlParser = std::make_shared<TimeOfDayConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByValueConditionXmlParser::SubElementTimeOfDayConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2346,9 +2346,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TIME_OF_DAY_CONDITION
                     };
         }
-        ByValueConditionXmlParser::SubElementSimulationTimeConditionParser::SubElementSimulationTimeConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByValueConditionXmlParser::SubElementSimulationTimeConditionParser::SubElementSimulationTimeConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _simulationTimeConditionXmlParser = std::make_shared<SimulationTimeConditionXmlParser>(messageLogger, filename);
+            _simulationTimeConditionXmlParser = std::make_shared<SimulationTimeConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByValueConditionXmlParser::SubElementSimulationTimeConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2386,9 +2386,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SIMULATION_TIME_CONDITION
                     };
         }
-        ByValueConditionXmlParser::SubElementStoryboardElementStateConditionParser::SubElementStoryboardElementStateConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByValueConditionXmlParser::SubElementStoryboardElementStateConditionParser::SubElementStoryboardElementStateConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _storyboardElementStateConditionXmlParser = std::make_shared<StoryboardElementStateConditionXmlParser>(messageLogger, filename);
+            _storyboardElementStateConditionXmlParser = std::make_shared<StoryboardElementStateConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByValueConditionXmlParser::SubElementStoryboardElementStateConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2426,9 +2426,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__STORYBOARD_ELEMENT_STATE_CONDITION
                     };
         }
-        ByValueConditionXmlParser::SubElementUserDefinedValueConditionParser::SubElementUserDefinedValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByValueConditionXmlParser::SubElementUserDefinedValueConditionParser::SubElementUserDefinedValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _userDefinedValueConditionXmlParser = std::make_shared<UserDefinedValueConditionXmlParser>(messageLogger, filename);
+            _userDefinedValueConditionXmlParser = std::make_shared<UserDefinedValueConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByValueConditionXmlParser::SubElementUserDefinedValueConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2466,9 +2466,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__USER_DEFINED_VALUE_CONDITION
                     };
         }
-        ByValueConditionXmlParser::SubElementTrafficSignalConditionParser::SubElementTrafficSignalConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByValueConditionXmlParser::SubElementTrafficSignalConditionParser::SubElementTrafficSignalConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSignalConditionXmlParser = std::make_shared<TrafficSignalConditionXmlParser>(messageLogger, filename);
+            _trafficSignalConditionXmlParser = std::make_shared<TrafficSignalConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByValueConditionXmlParser::SubElementTrafficSignalConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2506,9 +2506,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAFFIC_SIGNAL_CONDITION
                     };
         }
-        ByValueConditionXmlParser::SubElementTrafficSignalControllerConditionParser::SubElementTrafficSignalControllerConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ByValueConditionXmlParser::SubElementTrafficSignalControllerConditionParser::SubElementTrafficSignalControllerConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSignalControllerConditionXmlParser = std::make_shared<TrafficSignalControllerConditionXmlParser>(messageLogger, filename);
+            _trafficSignalControllerConditionXmlParser = std::make_shared<TrafficSignalControllerConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ByValueConditionXmlParser::SubElementTrafficSignalControllerConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2547,10 +2547,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ByValueConditionXmlParser::ByValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ByValueConditionXmlParser::ByValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2560,7 +2560,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            CatalogXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            CatalogXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> CatalogXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2569,7 +2569,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2604,27 +2604,27 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> CatalogXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementVehiclesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementControllersParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPedestriansParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementMiscObjectsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementEnvironmentsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementManeuversParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrajectoriesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRoutesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementVehiclesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementControllersParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPedestriansParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementMiscObjectsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementEnvironmentsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementManeuversParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrajectoriesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRoutesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        CatalogXmlParser::SubElementVehiclesParser::SubElementVehiclesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementVehiclesParser::SubElementVehiclesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _vehicleXmlParser = std::make_shared<VehicleXmlParser>(messageLogger, filename);
+            _vehicleXmlParser = std::make_shared<VehicleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementVehiclesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2663,9 +2663,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__VEHICLE
                     };
         }
-        CatalogXmlParser::SubElementControllersParser::SubElementControllersParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementControllersParser::SubElementControllersParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename);
+            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementControllersParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2704,9 +2704,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CONTROLLER
                     };
         }
-        CatalogXmlParser::SubElementPedestriansParser::SubElementPedestriansParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementPedestriansParser::SubElementPedestriansParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _pedestrianXmlParser = std::make_shared<PedestrianXmlParser>(messageLogger, filename);
+            _pedestrianXmlParser = std::make_shared<PedestrianXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementPedestriansParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2745,9 +2745,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PEDESTRIAN
                     };
         }
-        CatalogXmlParser::SubElementMiscObjectsParser::SubElementMiscObjectsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementMiscObjectsParser::SubElementMiscObjectsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _miscObjectXmlParser = std::make_shared<MiscObjectXmlParser>(messageLogger, filename);
+            _miscObjectXmlParser = std::make_shared<MiscObjectXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementMiscObjectsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2786,9 +2786,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__MISC_OBJECT
                     };
         }
-        CatalogXmlParser::SubElementEnvironmentsParser::SubElementEnvironmentsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementEnvironmentsParser::SubElementEnvironmentsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _environmentXmlParser = std::make_shared<EnvironmentXmlParser>(messageLogger, filename);
+            _environmentXmlParser = std::make_shared<EnvironmentXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementEnvironmentsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2827,9 +2827,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENVIRONMENT
                     };
         }
-        CatalogXmlParser::SubElementManeuversParser::SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementManeuversParser::SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _maneuverXmlParser = std::make_shared<ManeuverXmlParser>(messageLogger, filename);
+            _maneuverXmlParser = std::make_shared<ManeuverXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementManeuversParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2868,9 +2868,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__MANEUVER
                     };
         }
-        CatalogXmlParser::SubElementTrajectoriesParser::SubElementTrajectoriesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementTrajectoriesParser::SubElementTrajectoriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trajectoryXmlParser = std::make_shared<TrajectoryXmlParser>(messageLogger, filename);
+            _trajectoryXmlParser = std::make_shared<TrajectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementTrajectoriesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2909,9 +2909,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAJECTORY
                     };
         }
-        CatalogXmlParser::SubElementRoutesParser::SubElementRoutesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogXmlParser::SubElementRoutesParser::SubElementRoutesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _routeXmlParser = std::make_shared<RouteXmlParser>(messageLogger, filename);
+            _routeXmlParser = std::make_shared<RouteXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogXmlParser::SubElementRoutesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2951,10 +2951,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        CatalogXmlParser::CatalogXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        CatalogXmlParser::CatalogXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2964,19 +2964,19 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            CatalogDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            CatalogDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
 
         std::vector<std::shared_ptr<IElementParser>> CatalogDefinitionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementCatalogParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementCatalogParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        CatalogDefinitionXmlParser::SubElementCatalogParser::SubElementCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogDefinitionXmlParser::SubElementCatalogParser::SubElementCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogXmlParser = std::make_shared<CatalogXmlParser>(messageLogger, filename);
+            _catalogXmlParser = std::make_shared<CatalogXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogDefinitionXmlParser::SubElementCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3015,10 +3015,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        CatalogDefinitionXmlParser::CatalogDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        CatalogDefinitionXmlParser::CatalogDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3028,7 +3028,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            CatalogLocationsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            CatalogLocationsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> CatalogLocationsXmlParser::GetAttributeNameToAttributeParserMap()
@@ -3041,20 +3041,20 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> CatalogLocationsXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementVehicleCatalogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementControllerCatalogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPedestrianCatalogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementMiscObjectCatalogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementEnvironmentCatalogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementManeuverCatalogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrajectoryCatalogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRouteCatalogParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementVehicleCatalogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementControllerCatalogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPedestrianCatalogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementMiscObjectCatalogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementEnvironmentCatalogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementManeuverCatalogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrajectoryCatalogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRouteCatalogParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        CatalogLocationsXmlParser::SubElementVehicleCatalogParser::SubElementVehicleCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementVehicleCatalogParser::SubElementVehicleCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _vehicleCatalogLocationXmlParser = std::make_shared<VehicleCatalogLocationXmlParser>(messageLogger, filename);
+            _vehicleCatalogLocationXmlParser = std::make_shared<VehicleCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementVehicleCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3092,9 +3092,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__VEHICLE_CATALOG
                     };
         }
-        CatalogLocationsXmlParser::SubElementControllerCatalogParser::SubElementControllerCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementControllerCatalogParser::SubElementControllerCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerCatalogLocationXmlParser = std::make_shared<ControllerCatalogLocationXmlParser>(messageLogger, filename);
+            _controllerCatalogLocationXmlParser = std::make_shared<ControllerCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementControllerCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3132,9 +3132,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CONTROLLER_CATALOG
                     };
         }
-        CatalogLocationsXmlParser::SubElementPedestrianCatalogParser::SubElementPedestrianCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementPedestrianCatalogParser::SubElementPedestrianCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _pedestrianCatalogLocationXmlParser = std::make_shared<PedestrianCatalogLocationXmlParser>(messageLogger, filename);
+            _pedestrianCatalogLocationXmlParser = std::make_shared<PedestrianCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementPedestrianCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3172,9 +3172,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PEDESTRIAN_CATALOG
                     };
         }
-        CatalogLocationsXmlParser::SubElementMiscObjectCatalogParser::SubElementMiscObjectCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementMiscObjectCatalogParser::SubElementMiscObjectCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _miscObjectCatalogLocationXmlParser = std::make_shared<MiscObjectCatalogLocationXmlParser>(messageLogger, filename);
+            _miscObjectCatalogLocationXmlParser = std::make_shared<MiscObjectCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementMiscObjectCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3212,9 +3212,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__MISC_OBJECT_CATALOG
                     };
         }
-        CatalogLocationsXmlParser::SubElementEnvironmentCatalogParser::SubElementEnvironmentCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementEnvironmentCatalogParser::SubElementEnvironmentCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _environmentCatalogLocationXmlParser = std::make_shared<EnvironmentCatalogLocationXmlParser>(messageLogger, filename);
+            _environmentCatalogLocationXmlParser = std::make_shared<EnvironmentCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementEnvironmentCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3252,9 +3252,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENVIRONMENT_CATALOG
                     };
         }
-        CatalogLocationsXmlParser::SubElementManeuverCatalogParser::SubElementManeuverCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementManeuverCatalogParser::SubElementManeuverCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _maneuverCatalogLocationXmlParser = std::make_shared<ManeuverCatalogLocationXmlParser>(messageLogger, filename);
+            _maneuverCatalogLocationXmlParser = std::make_shared<ManeuverCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementManeuverCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3292,9 +3292,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__MANEUVER_CATALOG
                     };
         }
-        CatalogLocationsXmlParser::SubElementTrajectoryCatalogParser::SubElementTrajectoryCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementTrajectoryCatalogParser::SubElementTrajectoryCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trajectoryCatalogLocationXmlParser = std::make_shared<TrajectoryCatalogLocationXmlParser>(messageLogger, filename);
+            _trajectoryCatalogLocationXmlParser = std::make_shared<TrajectoryCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementTrajectoryCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3332,9 +3332,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAJECTORY_CATALOG
                     };
         }
-        CatalogLocationsXmlParser::SubElementRouteCatalogParser::SubElementRouteCatalogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogLocationsXmlParser::SubElementRouteCatalogParser::SubElementRouteCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _routeCatalogLocationXmlParser = std::make_shared<RouteCatalogLocationXmlParser>(messageLogger, filename);
+            _routeCatalogLocationXmlParser = std::make_shared<RouteCatalogLocationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogLocationsXmlParser::SubElementRouteCatalogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3373,10 +3373,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        CatalogLocationsXmlParser::CatalogLocationsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        CatalogLocationsXmlParser::CatalogLocationsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3386,7 +3386,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            CatalogReferenceXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            CatalogReferenceXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> CatalogReferenceXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3395,7 +3395,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeCatalogName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCatalogName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCatalogName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3430,11 +3430,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CATALOG_NAME, std::make_shared<AttributeCatalogName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CATALOG_NAME, std::make_shared<AttributeCatalogName>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntryName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntryName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntryName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3469,20 +3469,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTRY_NAME, std::make_shared<AttributeEntryName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTRY_NAME, std::make_shared<AttributeEntryName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> CatalogReferenceXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterAssignmentsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_ASSIGNMENTS) );
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterAssignmentsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_ASSIGNMENTS, _parserOptions) );
             return result;
         }
 
-        CatalogReferenceXmlParser::SubElementParameterAssignmentsParser::SubElementParameterAssignmentsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CatalogReferenceXmlParser::SubElementParameterAssignmentsParser::SubElementParameterAssignmentsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterAssignmentXmlParser = std::make_shared<ParameterAssignmentXmlParser>(messageLogger, filename);
+            _parameterAssignmentXmlParser = std::make_shared<ParameterAssignmentXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CatalogReferenceXmlParser::SubElementParameterAssignmentsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3519,10 +3519,10 @@ namespace NET_ASAM_OPENSCENARIO
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_ASSIGNMENT};
         }
   
-        CatalogReferenceXmlParser::CatalogReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        CatalogReferenceXmlParser::CatalogReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3532,7 +3532,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            CenterXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            CenterXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> CenterXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3541,7 +3541,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeX: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeX(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeX(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3576,11 +3576,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__X, std::make_shared<AttributeX>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__X, std::make_shared<AttributeX>(_messageLogger, _filename, _parserOptions)));
             class AttributeY: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeY(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeY(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3615,11 +3615,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Y, std::make_shared<AttributeY>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Y, std::make_shared<AttributeY>(_messageLogger, _filename, _parserOptions)));
             class AttributeZ: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeZ(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeZ(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3654,7 +3654,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Z, std::make_shared<AttributeZ>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Z, std::make_shared<AttributeZ>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -3665,10 +3665,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        CenterXmlParser::CenterXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        CenterXmlParser::CenterXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3678,7 +3678,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            CentralSwarmObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            CentralSwarmObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> CentralSwarmObjectXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3687,7 +3687,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3719,7 +3719,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -3730,10 +3730,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        CentralSwarmObjectXmlParser::CentralSwarmObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        CentralSwarmObjectXmlParser::CentralSwarmObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3743,7 +3743,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ClothoidXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ClothoidXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ClothoidXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3752,7 +3752,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeCurvature: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCurvature(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCurvature(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3787,11 +3787,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CURVATURE, std::make_shared<AttributeCurvature>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CURVATURE, std::make_shared<AttributeCurvature>(_messageLogger, _filename, _parserOptions)));
             class AttributeCurvatureDot: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCurvatureDot(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCurvatureDot(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3819,9 +3819,12 @@ namespace NET_ASAM_OPENSCENARIO
                     typedObject->PutPropertyEndMarker(OSC_CONSTANTS::ATTRIBUTE__CURVATURE_DOT, std::make_shared<Textmarker>(endMarker));
                      
                     
-                    // This element is deprecated
-					auto msg = FileContentMessage("Attribute '" + attributeName + "' is deprecated since standard version '1.1'. Comment: 'Use instead curvaturePrime.'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), this->_filename));
-					this->_messageLogger.LogMessage(msg);
+					if (!_parserOptions.IsOptionSetSupressDeprecationWarnings())
+					{
+						// This element is deprecated
+						auto msg = FileContentMessage("Attribute '" + attributeName + "' is deprecated since standard version '1.1'. Comment: 'Use instead curvaturePrime.'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), this->_filename));
+						this->_messageLogger.LogMessage(msg);
+					}
                 }
 
                 int GetMinOccur() override
@@ -3829,11 +3832,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CURVATURE_DOT, std::make_shared<AttributeCurvatureDot>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CURVATURE_DOT, std::make_shared<AttributeCurvatureDot>(_messageLogger, _filename, _parserOptions)));
             class AttributeCurvaturePrime: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCurvaturePrime(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCurvaturePrime(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3868,11 +3871,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CURVATURE_PRIME, std::make_shared<AttributeCurvaturePrime>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CURVATURE_PRIME, std::make_shared<AttributeCurvaturePrime>(_messageLogger, _filename, _parserOptions)));
             class AttributeLength: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLength(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLength(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3907,11 +3910,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LENGTH, std::make_shared<AttributeLength>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LENGTH, std::make_shared<AttributeLength>(_messageLogger, _filename, _parserOptions)));
             class AttributeStartTime: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeStartTime(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeStartTime(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3946,11 +3949,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__START_TIME, std::make_shared<AttributeStartTime>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__START_TIME, std::make_shared<AttributeStartTime>(_messageLogger, _filename, _parserOptions)));
             class AttributeStopTime: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeStopTime(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeStopTime(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3985,20 +3988,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STOP_TIME, std::make_shared<AttributeStopTime>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STOP_TIME, std::make_shared<AttributeStopTime>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ClothoidXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ClothoidXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ClothoidXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ClothoidXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4037,10 +4040,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ClothoidXmlParser::ClothoidXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ClothoidXmlParser::ClothoidXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4050,7 +4053,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            CollisionConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            CollisionConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> CollisionConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -4063,14 +4066,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> CollisionConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEntityRefParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementByTypeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEntityRefParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementByTypeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        CollisionConditionXmlParser::SubElementEntityRefParser::SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CollisionConditionXmlParser::SubElementEntityRefParser::SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename);
+            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CollisionConditionXmlParser::SubElementEntityRefParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4108,9 +4111,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENTITY_REF
                     };
         }
-        CollisionConditionXmlParser::SubElementByTypeParser::SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        CollisionConditionXmlParser::SubElementByTypeParser::SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _byObjectTypeXmlParser = std::make_shared<ByObjectTypeXmlParser>(messageLogger, filename);
+            _byObjectTypeXmlParser = std::make_shared<ByObjectTypeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void CollisionConditionXmlParser::SubElementByTypeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4149,10 +4152,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        CollisionConditionXmlParser::CollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        CollisionConditionXmlParser::CollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4162,7 +4165,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -4172,7 +4175,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeConditionEdge: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeConditionEdge(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeConditionEdge(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4199,7 +4202,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (ConditionEdge::IsDeprecated(kResult))
+                        if (ConditionEdge::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  ConditionEdge::GetDeprecatedVersion(kResult) +"'. " + ConditionEdge::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -4216,11 +4219,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONDITION_EDGE, std::make_shared<AttributeConditionEdge>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONDITION_EDGE, std::make_shared<AttributeConditionEdge>(_messageLogger, _filename, _parserOptions)));
             class AttributeDelay: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDelay(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDelay(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4255,11 +4258,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DELAY, std::make_shared<AttributeDelay>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DELAY, std::make_shared<AttributeDelay>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4294,21 +4297,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementByEntityConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementByValueConditionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementByEntityConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementByValueConditionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ConditionXmlParser::SubElementByEntityConditionParser::SubElementByEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ConditionXmlParser::SubElementByEntityConditionParser::SubElementByEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _byEntityConditionXmlParser = std::make_shared<ByEntityConditionXmlParser>(messageLogger, filename);
+            _byEntityConditionXmlParser = std::make_shared<ByEntityConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ConditionXmlParser::SubElementByEntityConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4346,9 +4349,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__BY_ENTITY_CONDITION
                     };
         }
-        ConditionXmlParser::SubElementByValueConditionParser::SubElementByValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ConditionXmlParser::SubElementByValueConditionParser::SubElementByValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _byValueConditionXmlParser = std::make_shared<ByValueConditionXmlParser>(messageLogger, filename);
+            _byValueConditionXmlParser = std::make_shared<ByValueConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ConditionXmlParser::SubElementByValueConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4387,10 +4390,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ConditionXmlParser::ConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ConditionXmlParser::ConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4400,7 +4403,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ConditionGroupXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ConditionGroupXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ConditionGroupXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4412,13 +4415,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ConditionGroupXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementConditionsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementConditionsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ConditionGroupXmlParser::SubElementConditionsParser::SubElementConditionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ConditionGroupXmlParser::SubElementConditionsParser::SubElementConditionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _conditionXmlParser = std::make_shared<ConditionXmlParser>(messageLogger, filename);
+            _conditionXmlParser = std::make_shared<ConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ConditionGroupXmlParser::SubElementConditionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4458,10 +4461,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ConditionGroupXmlParser::ConditionGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ConditionGroupXmlParser::ConditionGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4471,7 +4474,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ControlPointXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ControlPointXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ControlPointXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4480,7 +4483,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeTime: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTime(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTime(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4515,11 +4518,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TIME, std::make_shared<AttributeTime>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TIME, std::make_shared<AttributeTime>(_messageLogger, _filename, _parserOptions)));
             class AttributeWeight: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4554,20 +4557,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ControlPointXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ControlPointXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControlPointXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControlPointXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4606,10 +4609,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ControlPointXmlParser::ControlPointXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ControlPointXmlParser::ControlPointXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4619,7 +4622,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ControllerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ControllerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ControllerXmlParser::GetAttributeNameToAttributeParserMap()
@@ -4629,7 +4632,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4664,21 +4667,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ControllerXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ControllerXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4714,9 +4717,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        ControllerXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename);
+            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerXmlParser::SubElementPropertiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4755,10 +4758,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ControllerXmlParser::ControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ControllerXmlParser::ControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4768,7 +4771,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ControllerActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -4781,15 +4784,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ControllerActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementAssignControllerActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementOverrideControllerValueActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementActivateControllerActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementAssignControllerActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementOverrideControllerValueActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementActivateControllerActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ControllerActionXmlParser::SubElementAssignControllerActionParser::SubElementAssignControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerActionXmlParser::SubElementAssignControllerActionParser::SubElementAssignControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _assignControllerActionXmlParser = std::make_shared<AssignControllerActionXmlParser>(messageLogger, filename);
+            _assignControllerActionXmlParser = std::make_shared<AssignControllerActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerActionXmlParser::SubElementAssignControllerActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4827,9 +4830,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ASSIGN_CONTROLLER_ACTION
                     };
         }
-        ControllerActionXmlParser::SubElementOverrideControllerValueActionParser::SubElementOverrideControllerValueActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerActionXmlParser::SubElementOverrideControllerValueActionParser::SubElementOverrideControllerValueActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _overrideControllerValueActionXmlParser = std::make_shared<OverrideControllerValueActionXmlParser>(messageLogger, filename);
+            _overrideControllerValueActionXmlParser = std::make_shared<OverrideControllerValueActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerActionXmlParser::SubElementOverrideControllerValueActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4867,9 +4870,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__OVERRIDE_CONTROLLER_VALUE_ACTION
                     };
         }
-        ControllerActionXmlParser::SubElementActivateControllerActionParser::SubElementActivateControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerActionXmlParser::SubElementActivateControllerActionParser::SubElementActivateControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _activateControllerActionXmlParser = std::make_shared<ActivateControllerActionXmlParser>(messageLogger, filename);
+            _activateControllerActionXmlParser = std::make_shared<ActivateControllerActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerActionXmlParser::SubElementActivateControllerActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4908,10 +4911,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ControllerActionXmlParser::ControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ControllerActionXmlParser::ControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4921,7 +4924,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ControllerCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ControllerCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ControllerCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -4934,13 +4937,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ControllerCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ControllerCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4979,10 +4982,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ControllerCatalogLocationXmlParser::ControllerCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ControllerCatalogLocationXmlParser::ControllerCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4992,7 +4995,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ControllerDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ControllerDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ControllerDistributionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -5004,13 +5007,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ControllerDistributionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementControllerDistributionEntriesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementControllerDistributionEntriesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ControllerDistributionXmlParser::SubElementControllerDistributionEntriesParser::SubElementControllerDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerDistributionXmlParser::SubElementControllerDistributionEntriesParser::SubElementControllerDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerDistributionEntryXmlParser = std::make_shared<ControllerDistributionEntryXmlParser>(messageLogger, filename);
+            _controllerDistributionEntryXmlParser = std::make_shared<ControllerDistributionEntryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerDistributionXmlParser::SubElementControllerDistributionEntriesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5050,10 +5053,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ControllerDistributionXmlParser::ControllerDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ControllerDistributionXmlParser::ControllerDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5063,7 +5066,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ControllerDistributionEntryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ControllerDistributionEntryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ControllerDistributionEntryXmlParser::GetAttributeNameToAttributeParserMap()
@@ -5073,7 +5076,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeWeight: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5108,21 +5111,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ControllerDistributionEntryXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementControllerParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementControllerParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ControllerDistributionEntryXmlParser::SubElementControllerParser::SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerDistributionEntryXmlParser::SubElementControllerParser::SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename);
+            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerDistributionEntryXmlParser::SubElementControllerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5160,9 +5163,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CONTROLLER
                     };
         }
-        ControllerDistributionEntryXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ControllerDistributionEntryXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ControllerDistributionEntryXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5202,10 +5205,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ControllerDistributionEntryXmlParser::ControllerDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ControllerDistributionEntryXmlParser::ControllerDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5227,7 +5230,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5262,7 +5265,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TYPE, std::make_shared<AttributeType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TYPE, std::make_shared<AttributeType>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
         void CustomCommandActionXmlParser::SetContentProperty(const std::string content, std::shared_ptr<BaseImpl> object)
@@ -5271,8 +5274,8 @@ namespace NET_ASAM_OPENSCENARIO
             typedObject->SetContent(content);
         }
   
-        CustomCommandActionXmlParser::CustomCommandActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlSimpleContentParser(messageLogger, filename) {}
+        CustomCommandActionXmlParser::CustomCommandActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlSimpleContentParser(messageLogger, filename, parserOptions) {}
         
 
         /**
@@ -5281,7 +5284,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DeleteEntityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            DeleteEntityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DeleteEntityActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -5297,10 +5300,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        DeleteEntityActionXmlParser::DeleteEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DeleteEntityActionXmlParser::DeleteEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5310,7 +5313,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DeterministicXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            DeterministicXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DeterministicXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -5322,13 +5325,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> DeterministicXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDeterministicParameterDistributionsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDeterministicParameterDistributionsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        DeterministicXmlParser::SubElementDeterministicParameterDistributionsParser::SubElementDeterministicParameterDistributionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DeterministicXmlParser::SubElementDeterministicParameterDistributionsParser::SubElementDeterministicParameterDistributionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _deterministicParameterDistributionXmlParser = std::make_shared<DeterministicParameterDistributionXmlParser>(messageLogger, filename);
+            _deterministicParameterDistributionXmlParser = std::make_shared<DeterministicParameterDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DeterministicXmlParser::SubElementDeterministicParameterDistributionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5370,10 +5373,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        DeterministicXmlParser::DeterministicXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DeterministicXmlParser::DeterministicXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5383,7 +5386,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DeterministicMultiParameterDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            DeterministicMultiParameterDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DeterministicMultiParameterDistributionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -5395,13 +5398,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> DeterministicMultiParameterDistributionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDeterministicMultiParameterDistributionTypeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDeterministicMultiParameterDistributionTypeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        DeterministicMultiParameterDistributionXmlParser::SubElementDeterministicMultiParameterDistributionTypeParser::SubElementDeterministicMultiParameterDistributionTypeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DeterministicMultiParameterDistributionXmlParser::SubElementDeterministicMultiParameterDistributionTypeParser::SubElementDeterministicMultiParameterDistributionTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _deterministicMultiParameterDistributionTypeXmlParser = std::make_shared<DeterministicMultiParameterDistributionTypeXmlParser>(messageLogger, filename);
+            _deterministicMultiParameterDistributionTypeXmlParser = std::make_shared<DeterministicMultiParameterDistributionTypeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DeterministicMultiParameterDistributionXmlParser::SubElementDeterministicMultiParameterDistributionTypeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5440,10 +5443,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        DeterministicMultiParameterDistributionXmlParser::DeterministicMultiParameterDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DeterministicMultiParameterDistributionXmlParser::DeterministicMultiParameterDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5453,19 +5456,19 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DeterministicMultiParameterDistributionTypeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            DeterministicMultiParameterDistributionTypeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
 
         std::vector<std::shared_ptr<IElementParser>> DeterministicMultiParameterDistributionTypeXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementValueSetDistributionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementValueSetDistributionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        DeterministicMultiParameterDistributionTypeXmlParser::SubElementValueSetDistributionParser::SubElementValueSetDistributionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DeterministicMultiParameterDistributionTypeXmlParser::SubElementValueSetDistributionParser::SubElementValueSetDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _valueSetDistributionXmlParser = std::make_shared<ValueSetDistributionXmlParser>(messageLogger, filename);
+            _valueSetDistributionXmlParser = std::make_shared<ValueSetDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DeterministicMultiParameterDistributionTypeXmlParser::SubElementValueSetDistributionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5504,10 +5507,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        DeterministicMultiParameterDistributionTypeXmlParser::DeterministicMultiParameterDistributionTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        DeterministicMultiParameterDistributionTypeXmlParser::DeterministicMultiParameterDistributionTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5517,21 +5520,21 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DeterministicParameterDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            DeterministicParameterDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
 
         std::vector<std::shared_ptr<IElementParser>> DeterministicParameterDistributionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDeterministicMultiParameterDistributionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementDeterministicSingleParameterDistributionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDeterministicMultiParameterDistributionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementDeterministicSingleParameterDistributionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        DeterministicParameterDistributionXmlParser::SubElementDeterministicMultiParameterDistributionParser::SubElementDeterministicMultiParameterDistributionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DeterministicParameterDistributionXmlParser::SubElementDeterministicMultiParameterDistributionParser::SubElementDeterministicMultiParameterDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _deterministicMultiParameterDistributionXmlParser = std::make_shared<DeterministicMultiParameterDistributionXmlParser>(messageLogger, filename);
+            _deterministicMultiParameterDistributionXmlParser = std::make_shared<DeterministicMultiParameterDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DeterministicParameterDistributionXmlParser::SubElementDeterministicMultiParameterDistributionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5569,9 +5572,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__DETERMINISTIC_MULTI_PARAMETER_DISTRIBUTION
                     };
         }
-        DeterministicParameterDistributionXmlParser::SubElementDeterministicSingleParameterDistributionParser::SubElementDeterministicSingleParameterDistributionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DeterministicParameterDistributionXmlParser::SubElementDeterministicSingleParameterDistributionParser::SubElementDeterministicSingleParameterDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _deterministicSingleParameterDistributionXmlParser = std::make_shared<DeterministicSingleParameterDistributionXmlParser>(messageLogger, filename);
+            _deterministicSingleParameterDistributionXmlParser = std::make_shared<DeterministicSingleParameterDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DeterministicParameterDistributionXmlParser::SubElementDeterministicSingleParameterDistributionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5610,10 +5613,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        DeterministicParameterDistributionXmlParser::DeterministicParameterDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        DeterministicParameterDistributionXmlParser::DeterministicParameterDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5623,7 +5626,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DeterministicSingleParameterDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            DeterministicSingleParameterDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DeterministicSingleParameterDistributionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -5632,7 +5635,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeParameterName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeParameterName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeParameterName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5667,20 +5670,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_NAME, std::make_shared<AttributeParameterName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_NAME, std::make_shared<AttributeParameterName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> DeterministicSingleParameterDistributionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDeterministicSingleParameterDistributionTypeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDeterministicSingleParameterDistributionTypeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        DeterministicSingleParameterDistributionXmlParser::SubElementDeterministicSingleParameterDistributionTypeParser::SubElementDeterministicSingleParameterDistributionTypeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DeterministicSingleParameterDistributionXmlParser::SubElementDeterministicSingleParameterDistributionTypeParser::SubElementDeterministicSingleParameterDistributionTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _deterministicSingleParameterDistributionTypeXmlParser = std::make_shared<DeterministicSingleParameterDistributionTypeXmlParser>(messageLogger, filename);
+            _deterministicSingleParameterDistributionTypeXmlParser = std::make_shared<DeterministicSingleParameterDistributionTypeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DeterministicSingleParameterDistributionXmlParser::SubElementDeterministicSingleParameterDistributionTypeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5723,10 +5726,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        DeterministicSingleParameterDistributionXmlParser::DeterministicSingleParameterDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DeterministicSingleParameterDistributionXmlParser::DeterministicSingleParameterDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5736,22 +5739,22 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DeterministicSingleParameterDistributionTypeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            DeterministicSingleParameterDistributionTypeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
 
         std::vector<std::shared_ptr<IElementParser>> DeterministicSingleParameterDistributionTypeXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDistributionSetParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementDistributionRangeParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementUserDefinedDistributionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDistributionSetParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementDistributionRangeParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementUserDefinedDistributionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        DeterministicSingleParameterDistributionTypeXmlParser::SubElementDistributionSetParser::SubElementDistributionSetParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DeterministicSingleParameterDistributionTypeXmlParser::SubElementDistributionSetParser::SubElementDistributionSetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _distributionSetXmlParser = std::make_shared<DistributionSetXmlParser>(messageLogger, filename);
+            _distributionSetXmlParser = std::make_shared<DistributionSetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DeterministicSingleParameterDistributionTypeXmlParser::SubElementDistributionSetParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5789,9 +5792,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__DISTRIBUTION_SET
                     };
         }
-        DeterministicSingleParameterDistributionTypeXmlParser::SubElementDistributionRangeParser::SubElementDistributionRangeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DeterministicSingleParameterDistributionTypeXmlParser::SubElementDistributionRangeParser::SubElementDistributionRangeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _distributionRangeXmlParser = std::make_shared<DistributionRangeXmlParser>(messageLogger, filename);
+            _distributionRangeXmlParser = std::make_shared<DistributionRangeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DeterministicSingleParameterDistributionTypeXmlParser::SubElementDistributionRangeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5829,9 +5832,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__DISTRIBUTION_RANGE
                     };
         }
-        DeterministicSingleParameterDistributionTypeXmlParser::SubElementUserDefinedDistributionParser::SubElementUserDefinedDistributionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DeterministicSingleParameterDistributionTypeXmlParser::SubElementUserDefinedDistributionParser::SubElementUserDefinedDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _userDefinedDistributionXmlParser = std::make_shared<UserDefinedDistributionXmlParser>(messageLogger, filename);
+            _userDefinedDistributionXmlParser = std::make_shared<UserDefinedDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DeterministicSingleParameterDistributionTypeXmlParser::SubElementUserDefinedDistributionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5870,10 +5873,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        DeterministicSingleParameterDistributionTypeXmlParser::DeterministicSingleParameterDistributionTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        DeterministicSingleParameterDistributionTypeXmlParser::DeterministicSingleParameterDistributionTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5883,7 +5886,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DimensionsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            DimensionsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DimensionsXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -5892,7 +5895,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeHeight: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeHeight(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeHeight(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5927,11 +5930,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__HEIGHT, std::make_shared<AttributeHeight>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__HEIGHT, std::make_shared<AttributeHeight>(_messageLogger, _filename, _parserOptions)));
             class AttributeLength: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLength(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLength(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5966,11 +5969,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LENGTH, std::make_shared<AttributeLength>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LENGTH, std::make_shared<AttributeLength>(_messageLogger, _filename, _parserOptions)));
             class AttributeWidth: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeWidth(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeWidth(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6005,7 +6008,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WIDTH, std::make_shared<AttributeWidth>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WIDTH, std::make_shared<AttributeWidth>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -6016,10 +6019,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        DimensionsXmlParser::DimensionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DimensionsXmlParser::DimensionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6029,7 +6032,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DirectoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            DirectoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DirectoryXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -6038,7 +6041,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributePath: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePath(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePath(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6073,7 +6076,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PATH, std::make_shared<AttributePath>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PATH, std::make_shared<AttributePath>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -6084,10 +6087,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        DirectoryXmlParser::DirectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DirectoryXmlParser::DirectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6097,7 +6100,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DistanceConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            DistanceConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DistanceConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -6107,7 +6110,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeAlongRoute: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeAlongRoute(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeAlongRoute(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6130,9 +6133,12 @@ namespace NET_ASAM_OPENSCENARIO
                     typedObject->PutPropertyEndMarker(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<Textmarker>(endMarker));
                      
                     
-                    // This element is deprecated
-					auto msg = FileContentMessage("Attribute '" + attributeName + "' is deprecated since standard version '1.1'. Comment: 'Use \"coordinateSystem\" and \"relativeDistanceType\"'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), this->_filename));
-					this->_messageLogger.LogMessage(msg);
+					if (!_parserOptions.IsOptionSetSupressDeprecationWarnings())
+					{
+						// This element is deprecated
+						auto msg = FileContentMessage("Attribute '" + attributeName + "' is deprecated since standard version '1.1'. Comment: 'Use \"coordinateSystem\" and \"relativeDistanceType\"'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), this->_filename));
+						this->_messageLogger.LogMessage(msg);
+					}
                 }
 
                 int GetMinOccur() override
@@ -6140,11 +6146,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<AttributeAlongRoute>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<AttributeAlongRoute>(_messageLogger, _filename, _parserOptions)));
             class AttributeCoordinateSystem: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCoordinateSystem(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCoordinateSystem(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6171,7 +6177,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (CoordinateSystem::IsDeprecated(kResult))
+                        if (CoordinateSystem::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  CoordinateSystem::GetDeprecatedVersion(kResult) +"'. " + CoordinateSystem::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -6188,11 +6194,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM, std::make_shared<AttributeCoordinateSystem>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM, std::make_shared<AttributeCoordinateSystem>(_messageLogger, _filename, _parserOptions)));
             class AttributeFreespace: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6222,11 +6228,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename, _parserOptions)));
             class AttributeRelativeDistanceType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRelativeDistanceType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRelativeDistanceType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6253,7 +6259,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (RelativeDistanceType::IsDeprecated(kResult))
+                        if (RelativeDistanceType::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  RelativeDistanceType::GetDeprecatedVersion(kResult) +"'. " + RelativeDistanceType::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -6270,11 +6276,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RELATIVE_DISTANCE_TYPE, std::make_shared<AttributeRelativeDistanceType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RELATIVE_DISTANCE_TYPE, std::make_shared<AttributeRelativeDistanceType>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6301,7 +6307,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (Rule::IsDeprecated(kResult))
+                        if (Rule::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  Rule::GetDeprecatedVersion(kResult) +"'. " + Rule::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -6318,11 +6324,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6357,20 +6363,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> DistanceConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        DistanceConditionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DistanceConditionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DistanceConditionXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6409,10 +6415,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        DistanceConditionXmlParser::DistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DistanceConditionXmlParser::DistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6422,21 +6428,21 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DistributionDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            DistributionDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
 
         std::vector<std::shared_ptr<IElementParser>> DistributionDefinitionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDeterministicParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStochasticParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDeterministicParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStochasticParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        DistributionDefinitionXmlParser::SubElementDeterministicParser::SubElementDeterministicParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DistributionDefinitionXmlParser::SubElementDeterministicParser::SubElementDeterministicParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _deterministicXmlParser = std::make_shared<DeterministicXmlParser>(messageLogger, filename);
+            _deterministicXmlParser = std::make_shared<DeterministicXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DistributionDefinitionXmlParser::SubElementDeterministicParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6474,9 +6480,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__DETERMINISTIC
                     };
         }
-        DistributionDefinitionXmlParser::SubElementStochasticParser::SubElementStochasticParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DistributionDefinitionXmlParser::SubElementStochasticParser::SubElementStochasticParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _stochasticXmlParser = std::make_shared<StochasticXmlParser>(messageLogger, filename);
+            _stochasticXmlParser = std::make_shared<StochasticXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DistributionDefinitionXmlParser::SubElementStochasticParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6515,10 +6521,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        DistributionDefinitionXmlParser::DistributionDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        DistributionDefinitionXmlParser::DistributionDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6528,7 +6534,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DistributionRangeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            DistributionRangeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DistributionRangeXmlParser::GetAttributeNameToAttributeParserMap()
@@ -6538,7 +6544,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeStepWidth: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeStepWidth(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeStepWidth(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6573,20 +6579,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STEP_WIDTH, std::make_shared<AttributeStepWidth>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STEP_WIDTH, std::make_shared<AttributeStepWidth>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> DistributionRangeXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRangeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRangeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        DistributionRangeXmlParser::SubElementRangeParser::SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DistributionRangeXmlParser::SubElementRangeParser::SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _rangeXmlParser = std::make_shared<RangeXmlParser>(messageLogger, filename);
+            _rangeXmlParser = std::make_shared<RangeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DistributionRangeXmlParser::SubElementRangeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6625,10 +6631,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        DistributionRangeXmlParser::DistributionRangeXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DistributionRangeXmlParser::DistributionRangeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6638,7 +6644,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DistributionSetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            DistributionSetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DistributionSetXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -6650,13 +6656,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> DistributionSetXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementElementsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementElementsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        DistributionSetXmlParser::SubElementElementsParser::SubElementElementsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        DistributionSetXmlParser::SubElementElementsParser::SubElementElementsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _distributionSetElementXmlParser = std::make_shared<DistributionSetElementXmlParser>(messageLogger, filename);
+            _distributionSetElementXmlParser = std::make_shared<DistributionSetElementXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void DistributionSetXmlParser::SubElementElementsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6696,10 +6702,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        DistributionSetXmlParser::DistributionSetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DistributionSetXmlParser::DistributionSetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6709,7 +6715,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DistributionSetElementXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            DistributionSetElementXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DistributionSetElementXmlParser::GetAttributeNameToAttributeParserMap()
@@ -6719,7 +6725,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6754,7 +6760,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -6765,10 +6771,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        DistributionSetElementXmlParser::DistributionSetElementXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DistributionSetElementXmlParser::DistributionSetElementXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6778,7 +6784,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            DynamicConstraintsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            DynamicConstraintsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> DynamicConstraintsXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -6787,7 +6793,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMaxAcceleration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxAcceleration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxAcceleration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6822,11 +6828,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_ACCELERATION, std::make_shared<AttributeMaxAcceleration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_ACCELERATION, std::make_shared<AttributeMaxAcceleration>(_messageLogger, _filename, _parserOptions)));
             class AttributeMaxDeceleration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxDeceleration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxDeceleration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6861,11 +6867,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_DECELERATION, std::make_shared<AttributeMaxDeceleration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_DECELERATION, std::make_shared<AttributeMaxDeceleration>(_messageLogger, _filename, _parserOptions)));
             class AttributeMaxSpeed: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxSpeed(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxSpeed(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6900,7 +6906,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_SPEED, std::make_shared<AttributeMaxSpeed>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_SPEED, std::make_shared<AttributeMaxSpeed>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -6911,10 +6917,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        DynamicConstraintsXmlParser::DynamicConstraintsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        DynamicConstraintsXmlParser::DynamicConstraintsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6924,7 +6930,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EndOfRoadConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            EndOfRoadConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EndOfRoadConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -6933,7 +6939,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDuration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6968,7 +6974,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -6979,10 +6985,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        EndOfRoadConditionXmlParser::EndOfRoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EndOfRoadConditionXmlParser::EndOfRoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6992,7 +6998,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EntitiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            EntitiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EntitiesXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -7004,14 +7010,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> EntitiesXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementScenarioObjectsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementEntitySelectionsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementScenarioObjectsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementEntitySelectionsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EntitiesXmlParser::SubElementScenarioObjectsParser::SubElementScenarioObjectsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntitiesXmlParser::SubElementScenarioObjectsParser::SubElementScenarioObjectsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _scenarioObjectXmlParser = std::make_shared<ScenarioObjectXmlParser>(messageLogger, filename);
+            _scenarioObjectXmlParser = std::make_shared<ScenarioObjectXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntitiesXmlParser::SubElementScenarioObjectsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7050,9 +7056,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SCENARIO_OBJECT
                     };
         }
-        EntitiesXmlParser::SubElementEntitySelectionsParser::SubElementEntitySelectionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntitiesXmlParser::SubElementEntitySelectionsParser::SubElementEntitySelectionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entitySelectionXmlParser = std::make_shared<EntitySelectionXmlParser>(messageLogger, filename);
+            _entitySelectionXmlParser = std::make_shared<EntitySelectionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntitiesXmlParser::SubElementEntitySelectionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7092,10 +7098,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EntitiesXmlParser::EntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EntitiesXmlParser::EntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7105,7 +7111,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EntityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            EntityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EntityActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -7115,7 +7121,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7147,21 +7153,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> EntityActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementAddEntityActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementDeleteEntityActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementAddEntityActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementDeleteEntityActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EntityActionXmlParser::SubElementAddEntityActionParser::SubElementAddEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityActionXmlParser::SubElementAddEntityActionParser::SubElementAddEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _addEntityActionXmlParser = std::make_shared<AddEntityActionXmlParser>(messageLogger, filename);
+            _addEntityActionXmlParser = std::make_shared<AddEntityActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityActionXmlParser::SubElementAddEntityActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7199,9 +7205,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ADD_ENTITY_ACTION
                     };
         }
-        EntityActionXmlParser::SubElementDeleteEntityActionParser::SubElementDeleteEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityActionXmlParser::SubElementDeleteEntityActionParser::SubElementDeleteEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _deleteEntityActionXmlParser = std::make_shared<DeleteEntityActionXmlParser>(messageLogger, filename);
+            _deleteEntityActionXmlParser = std::make_shared<DeleteEntityActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityActionXmlParser::SubElementDeleteEntityActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7240,10 +7246,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EntityActionXmlParser::EntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EntityActionXmlParser::EntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7253,7 +7259,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EntityConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            EntityConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EntityConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -7266,25 +7272,25 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> EntityConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEndOfRoadConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCollisionConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementOffroadConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTimeHeadwayConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTimeToCollisionConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementAccelerationConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStandStillConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementSpeedConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRelativeSpeedConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTraveledDistanceConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementReachPositionConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementDistanceConditionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRelativeDistanceConditionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEndOfRoadConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCollisionConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementOffroadConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTimeHeadwayConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTimeToCollisionConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementAccelerationConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStandStillConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementSpeedConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRelativeSpeedConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTraveledDistanceConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementReachPositionConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementDistanceConditionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRelativeDistanceConditionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EntityConditionXmlParser::SubElementEndOfRoadConditionParser::SubElementEndOfRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementEndOfRoadConditionParser::SubElementEndOfRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _endOfRoadConditionXmlParser = std::make_shared<EndOfRoadConditionXmlParser>(messageLogger, filename);
+            _endOfRoadConditionXmlParser = std::make_shared<EndOfRoadConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementEndOfRoadConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7322,9 +7328,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__END_OF_ROAD_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementCollisionConditionParser::SubElementCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementCollisionConditionParser::SubElementCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _collisionConditionXmlParser = std::make_shared<CollisionConditionXmlParser>(messageLogger, filename);
+            _collisionConditionXmlParser = std::make_shared<CollisionConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementCollisionConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7362,9 +7368,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__COLLISION_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementOffroadConditionParser::SubElementOffroadConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementOffroadConditionParser::SubElementOffroadConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _offroadConditionXmlParser = std::make_shared<OffroadConditionXmlParser>(messageLogger, filename);
+            _offroadConditionXmlParser = std::make_shared<OffroadConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementOffroadConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7402,9 +7408,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__OFFROAD_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementTimeHeadwayConditionParser::SubElementTimeHeadwayConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementTimeHeadwayConditionParser::SubElementTimeHeadwayConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _timeHeadwayConditionXmlParser = std::make_shared<TimeHeadwayConditionXmlParser>(messageLogger, filename);
+            _timeHeadwayConditionXmlParser = std::make_shared<TimeHeadwayConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementTimeHeadwayConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7442,9 +7448,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TIME_HEADWAY_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementTimeToCollisionConditionParser::SubElementTimeToCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementTimeToCollisionConditionParser::SubElementTimeToCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _timeToCollisionConditionXmlParser = std::make_shared<TimeToCollisionConditionXmlParser>(messageLogger, filename);
+            _timeToCollisionConditionXmlParser = std::make_shared<TimeToCollisionConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementTimeToCollisionConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7482,9 +7488,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TIME_TO_COLLISION_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementAccelerationConditionParser::SubElementAccelerationConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementAccelerationConditionParser::SubElementAccelerationConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _accelerationConditionXmlParser = std::make_shared<AccelerationConditionXmlParser>(messageLogger, filename);
+            _accelerationConditionXmlParser = std::make_shared<AccelerationConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementAccelerationConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7522,9 +7528,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ACCELERATION_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementStandStillConditionParser::SubElementStandStillConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementStandStillConditionParser::SubElementStandStillConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _standStillConditionXmlParser = std::make_shared<StandStillConditionXmlParser>(messageLogger, filename);
+            _standStillConditionXmlParser = std::make_shared<StandStillConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementStandStillConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7562,9 +7568,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__STAND_STILL_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementSpeedConditionParser::SubElementSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementSpeedConditionParser::SubElementSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _speedConditionXmlParser = std::make_shared<SpeedConditionXmlParser>(messageLogger, filename);
+            _speedConditionXmlParser = std::make_shared<SpeedConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementSpeedConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7602,9 +7608,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SPEED_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementRelativeSpeedConditionParser::SubElementRelativeSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementRelativeSpeedConditionParser::SubElementRelativeSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeSpeedConditionXmlParser = std::make_shared<RelativeSpeedConditionXmlParser>(messageLogger, filename);
+            _relativeSpeedConditionXmlParser = std::make_shared<RelativeSpeedConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementRelativeSpeedConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7642,9 +7648,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_SPEED_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementTraveledDistanceConditionParser::SubElementTraveledDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementTraveledDistanceConditionParser::SubElementTraveledDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _traveledDistanceConditionXmlParser = std::make_shared<TraveledDistanceConditionXmlParser>(messageLogger, filename);
+            _traveledDistanceConditionXmlParser = std::make_shared<TraveledDistanceConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementTraveledDistanceConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7682,9 +7688,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAVELED_DISTANCE_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementReachPositionConditionParser::SubElementReachPositionConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementReachPositionConditionParser::SubElementReachPositionConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _reachPositionConditionXmlParser = std::make_shared<ReachPositionConditionXmlParser>(messageLogger, filename);
+            _reachPositionConditionXmlParser = std::make_shared<ReachPositionConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementReachPositionConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7722,9 +7728,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__REACH_POSITION_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementDistanceConditionParser::SubElementDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementDistanceConditionParser::SubElementDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _distanceConditionXmlParser = std::make_shared<DistanceConditionXmlParser>(messageLogger, filename);
+            _distanceConditionXmlParser = std::make_shared<DistanceConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementDistanceConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7762,9 +7768,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__DISTANCE_CONDITION
                     };
         }
-        EntityConditionXmlParser::SubElementRelativeDistanceConditionParser::SubElementRelativeDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityConditionXmlParser::SubElementRelativeDistanceConditionParser::SubElementRelativeDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeDistanceConditionXmlParser = std::make_shared<RelativeDistanceConditionXmlParser>(messageLogger, filename);
+            _relativeDistanceConditionXmlParser = std::make_shared<RelativeDistanceConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityConditionXmlParser::SubElementRelativeDistanceConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7803,10 +7809,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EntityConditionXmlParser::EntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EntityConditionXmlParser::EntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7816,24 +7822,24 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EntityObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            EntityObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
 
         std::vector<std::shared_ptr<IElementParser>> EntityObjectXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementVehicleParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPedestrianParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementMiscObjectParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementExternalObjectReferenceParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementVehicleParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPedestrianParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementMiscObjectParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementExternalObjectReferenceParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EntityObjectXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityObjectXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityObjectXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7872,9 +7878,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CATALOG_REFERENCE
                     };
         }
-        EntityObjectXmlParser::SubElementVehicleParser::SubElementVehicleParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityObjectXmlParser::SubElementVehicleParser::SubElementVehicleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _vehicleXmlParser = std::make_shared<VehicleXmlParser>(messageLogger, filename);
+            _vehicleXmlParser = std::make_shared<VehicleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityObjectXmlParser::SubElementVehicleParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7912,9 +7918,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__VEHICLE
                     };
         }
-        EntityObjectXmlParser::SubElementPedestrianParser::SubElementPedestrianParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityObjectXmlParser::SubElementPedestrianParser::SubElementPedestrianParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _pedestrianXmlParser = std::make_shared<PedestrianXmlParser>(messageLogger, filename);
+            _pedestrianXmlParser = std::make_shared<PedestrianXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityObjectXmlParser::SubElementPedestrianParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7952,9 +7958,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PEDESTRIAN
                     };
         }
-        EntityObjectXmlParser::SubElementMiscObjectParser::SubElementMiscObjectParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityObjectXmlParser::SubElementMiscObjectParser::SubElementMiscObjectParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _miscObjectXmlParser = std::make_shared<MiscObjectXmlParser>(messageLogger, filename);
+            _miscObjectXmlParser = std::make_shared<MiscObjectXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityObjectXmlParser::SubElementMiscObjectParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7992,9 +7998,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__MISC_OBJECT
                     };
         }
-        EntityObjectXmlParser::SubElementExternalObjectReferenceParser::SubElementExternalObjectReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntityObjectXmlParser::SubElementExternalObjectReferenceParser::SubElementExternalObjectReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _externalObjectReferenceXmlParser = std::make_shared<ExternalObjectReferenceXmlParser>(messageLogger, filename);
+            _externalObjectReferenceXmlParser = std::make_shared<ExternalObjectReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntityObjectXmlParser::SubElementExternalObjectReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8033,10 +8039,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EntityObjectXmlParser::EntityObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        EntityObjectXmlParser::EntityObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8046,7 +8052,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EntityRefXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            EntityRefXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EntityRefXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8055,7 +8061,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8087,7 +8093,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -8098,10 +8104,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        EntityRefXmlParser::EntityRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EntityRefXmlParser::EntityRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8111,7 +8117,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EntitySelectionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            EntitySelectionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EntitySelectionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8120,7 +8126,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8155,20 +8161,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> EntitySelectionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementMembersParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementMembersParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EntitySelectionXmlParser::SubElementMembersParser::SubElementMembersParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EntitySelectionXmlParser::SubElementMembersParser::SubElementMembersParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _selectedEntitiesXmlParser = std::make_shared<SelectedEntitiesXmlParser>(messageLogger, filename);
+            _selectedEntitiesXmlParser = std::make_shared<SelectedEntitiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EntitySelectionXmlParser::SubElementMembersParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8207,10 +8213,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EntitySelectionXmlParser::EntitySelectionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EntitySelectionXmlParser::EntitySelectionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8220,7 +8226,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EnvironmentXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            EnvironmentXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EnvironmentXmlParser::GetAttributeNameToAttributeParserMap()
@@ -8230,7 +8236,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8265,23 +8271,23 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> EnvironmentXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementTimeOfDayParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementWeatherParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRoadConditionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementTimeOfDayParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementWeatherParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRoadConditionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EnvironmentXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EnvironmentXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EnvironmentXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8317,9 +8323,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        EnvironmentXmlParser::SubElementTimeOfDayParser::SubElementTimeOfDayParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EnvironmentXmlParser::SubElementTimeOfDayParser::SubElementTimeOfDayParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _timeOfDayXmlParser = std::make_shared<TimeOfDayXmlParser>(messageLogger, filename);
+            _timeOfDayXmlParser = std::make_shared<TimeOfDayXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EnvironmentXmlParser::SubElementTimeOfDayParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8357,9 +8363,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TIME_OF_DAY
                     };
         }
-        EnvironmentXmlParser::SubElementWeatherParser::SubElementWeatherParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EnvironmentXmlParser::SubElementWeatherParser::SubElementWeatherParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _weatherXmlParser = std::make_shared<WeatherXmlParser>(messageLogger, filename);
+            _weatherXmlParser = std::make_shared<WeatherXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EnvironmentXmlParser::SubElementWeatherParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8397,9 +8403,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__WEATHER
                     };
         }
-        EnvironmentXmlParser::SubElementRoadConditionParser::SubElementRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EnvironmentXmlParser::SubElementRoadConditionParser::SubElementRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _roadConditionXmlParser = std::make_shared<RoadConditionXmlParser>(messageLogger, filename);
+            _roadConditionXmlParser = std::make_shared<RoadConditionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EnvironmentXmlParser::SubElementRoadConditionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8438,10 +8444,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EnvironmentXmlParser::EnvironmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EnvironmentXmlParser::EnvironmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8451,7 +8457,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EnvironmentActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            EnvironmentActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EnvironmentActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -8464,14 +8470,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> EnvironmentActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEnvironmentParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEnvironmentParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EnvironmentActionXmlParser::SubElementEnvironmentParser::SubElementEnvironmentParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EnvironmentActionXmlParser::SubElementEnvironmentParser::SubElementEnvironmentParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _environmentXmlParser = std::make_shared<EnvironmentXmlParser>(messageLogger, filename);
+            _environmentXmlParser = std::make_shared<EnvironmentXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EnvironmentActionXmlParser::SubElementEnvironmentParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8509,9 +8515,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENVIRONMENT
                     };
         }
-        EnvironmentActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EnvironmentActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EnvironmentActionXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8551,10 +8557,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EnvironmentActionXmlParser::EnvironmentActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EnvironmentActionXmlParser::EnvironmentActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8564,7 +8570,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EnvironmentCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            EnvironmentCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EnvironmentCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -8577,13 +8583,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> EnvironmentCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EnvironmentCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EnvironmentCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EnvironmentCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8622,10 +8628,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EnvironmentCatalogLocationXmlParser::EnvironmentCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EnvironmentCatalogLocationXmlParser::EnvironmentCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8635,7 +8641,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            EventXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            EventXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> EventXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8644,7 +8650,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMaximumExecutionCount: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaximumExecutionCount(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaximumExecutionCount(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8679,11 +8685,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAXIMUM_EXECUTION_COUNT, std::make_shared<AttributeMaximumExecutionCount>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAXIMUM_EXECUTION_COUNT, std::make_shared<AttributeMaximumExecutionCount>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8718,11 +8724,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributePriority: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePriority(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePriority(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8749,7 +8755,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (Priority::IsDeprecated(kResult))
+                        if (Priority::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  Priority::GetDeprecatedVersion(kResult) +"'. " + Priority::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -8766,21 +8772,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PRIORITY, std::make_shared<AttributePriority>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PRIORITY, std::make_shared<AttributePriority>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> EventXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementActionsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStartTriggerParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementActionsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStartTriggerParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        EventXmlParser::SubElementActionsParser::SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EventXmlParser::SubElementActionsParser::SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _actionXmlParser = std::make_shared<ActionXmlParser>(messageLogger, filename);
+            _actionXmlParser = std::make_shared<ActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EventXmlParser::SubElementActionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8819,9 +8825,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ACTION
                     };
         }
-        EventXmlParser::SubElementStartTriggerParser::SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        EventXmlParser::SubElementStartTriggerParser::SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename);
+            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void EventXmlParser::SubElementStartTriggerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8860,10 +8866,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        EventXmlParser::EventXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        EventXmlParser::EventXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8873,7 +8879,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ExternalObjectReferenceXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ExternalObjectReferenceXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ExternalObjectReferenceXmlParser::GetAttributeNameToAttributeParserMap()
@@ -8883,7 +8889,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8918,7 +8924,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -8929,10 +8935,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ExternalObjectReferenceXmlParser::ExternalObjectReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ExternalObjectReferenceXmlParser::ExternalObjectReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8942,7 +8948,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            FileXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            FileXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> FileXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8951,7 +8957,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeFilepath: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFilepath(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFilepath(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8986,7 +8992,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FILEPATH, std::make_shared<AttributeFilepath>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FILEPATH, std::make_shared<AttributeFilepath>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -8997,10 +9003,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        FileXmlParser::FileXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        FileXmlParser::FileXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9010,7 +9016,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            FileHeaderXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            FileHeaderXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> FileHeaderXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -9019,7 +9025,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeAuthor: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeAuthor(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeAuthor(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9054,11 +9060,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__AUTHOR, std::make_shared<AttributeAuthor>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__AUTHOR, std::make_shared<AttributeAuthor>(_messageLogger, _filename, _parserOptions)));
             class AttributeDate: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDate(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDate(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9088,11 +9094,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DATE, std::make_shared<AttributeDate>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DATE, std::make_shared<AttributeDate>(_messageLogger, _filename, _parserOptions)));
             class AttributeDescription: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDescription(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDescription(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9127,11 +9133,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DESCRIPTION, std::make_shared<AttributeDescription>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DESCRIPTION, std::make_shared<AttributeDescription>(_messageLogger, _filename, _parserOptions)));
             class AttributeRevMajor: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRevMajor(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRevMajor(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9166,11 +9172,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__REV_MAJOR, std::make_shared<AttributeRevMajor>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__REV_MAJOR, std::make_shared<AttributeRevMajor>(_messageLogger, _filename, _parserOptions)));
             class AttributeRevMinor: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRevMinor(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRevMinor(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9205,20 +9211,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__REV_MINOR, std::make_shared<AttributeRevMinor>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__REV_MINOR, std::make_shared<AttributeRevMinor>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> FileHeaderXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementLicenseParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementLicenseParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        FileHeaderXmlParser::SubElementLicenseParser::SubElementLicenseParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FileHeaderXmlParser::SubElementLicenseParser::SubElementLicenseParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _licenseXmlParser = std::make_shared<LicenseXmlParser>(messageLogger, filename);
+            _licenseXmlParser = std::make_shared<LicenseXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FileHeaderXmlParser::SubElementLicenseParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9257,10 +9263,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        FileHeaderXmlParser::FileHeaderXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        FileHeaderXmlParser::FileHeaderXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9270,7 +9276,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            FinalSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            FinalSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> FinalSpeedXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9283,14 +9289,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> FinalSpeedXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementAbsoluteSpeedParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRelativeSpeedToMasterParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementAbsoluteSpeedParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRelativeSpeedToMasterParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        FinalSpeedXmlParser::SubElementAbsoluteSpeedParser::SubElementAbsoluteSpeedParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FinalSpeedXmlParser::SubElementAbsoluteSpeedParser::SubElementAbsoluteSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _absoluteSpeedXmlParser = std::make_shared<AbsoluteSpeedXmlParser>(messageLogger, filename);
+            _absoluteSpeedXmlParser = std::make_shared<AbsoluteSpeedXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FinalSpeedXmlParser::SubElementAbsoluteSpeedParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9328,9 +9334,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ABSOLUTE_SPEED
                     };
         }
-        FinalSpeedXmlParser::SubElementRelativeSpeedToMasterParser::SubElementRelativeSpeedToMasterParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FinalSpeedXmlParser::SubElementRelativeSpeedToMasterParser::SubElementRelativeSpeedToMasterParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeSpeedToMasterXmlParser = std::make_shared<RelativeSpeedToMasterXmlParser>(messageLogger, filename);
+            _relativeSpeedToMasterXmlParser = std::make_shared<RelativeSpeedToMasterXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FinalSpeedXmlParser::SubElementRelativeSpeedToMasterParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9369,10 +9375,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        FinalSpeedXmlParser::FinalSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        FinalSpeedXmlParser::FinalSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9382,7 +9388,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            FogXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            FogXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> FogXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9392,7 +9398,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeVisualRange: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeVisualRange(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeVisualRange(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9427,20 +9433,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VISUAL_RANGE, std::make_shared<AttributeVisualRange>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VISUAL_RANGE, std::make_shared<AttributeVisualRange>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> FogXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        FogXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FogXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename);
+            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FogXmlParser::SubElementBoundingBoxParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9479,10 +9485,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        FogXmlParser::FogXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        FogXmlParser::FogXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9492,7 +9498,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            FollowTrajectoryActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            FollowTrajectoryActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> FollowTrajectoryActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9502,7 +9508,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeInitialDistanceOffset: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeInitialDistanceOffset(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeInitialDistanceOffset(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9537,24 +9543,24 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__INITIAL_DISTANCE_OFFSET, std::make_shared<AttributeInitialDistanceOffset>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__INITIAL_DISTANCE_OFFSET, std::make_shared<AttributeInitialDistanceOffset>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> FollowTrajectoryActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTrajectoryParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTimeReferenceParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrajectoryFollowingModeParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrajectoryRefParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTrajectoryParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTimeReferenceParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrajectoryFollowingModeParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrajectoryRefParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        FollowTrajectoryActionXmlParser::SubElementTrajectoryParser::SubElementTrajectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FollowTrajectoryActionXmlParser::SubElementTrajectoryParser::SubElementTrajectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trajectoryXmlParser = std::make_shared<TrajectoryXmlParser>(messageLogger, filename);
+            _trajectoryXmlParser = std::make_shared<TrajectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FollowTrajectoryActionXmlParser::SubElementTrajectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9568,11 +9574,14 @@ namespace NET_ASAM_OPENSCENARIO
             typedObject->SetTrajectory(trajectory);
             
             
-            // This element is deprecated
-            std::string name = indexedElement->GetElement()->Name();
-        	Position startPosition = indexedElement->GetStartElementLocation();
-			auto msg = FileContentMessage("Element '" + name + "' is deprecated since standard version '1.1'. Comment: 'Use trajectoryRef instead.'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), _trajectoryXmlParser->_filename));
-			_trajectoryXmlParser->_messageLogger.LogMessage(msg);
+			if (!_trajectoryXmlParser->_parserOptions.IsOptionSetSupressDeprecationWarnings())
+			{
+				// This element is deprecated
+				std::string name = indexedElement->GetElement()->Name();
+				Position startPosition = indexedElement->GetStartElementLocation();
+				auto msg = FileContentMessage("Element '" + name + "' is deprecated since standard version '1.1'. Comment: 'Use trajectoryRef instead.'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), _trajectoryXmlParser->_filename));
+				_trajectoryXmlParser->_messageLogger.LogMessage(msg);
+			}
         }
         
         int FollowTrajectoryActionXmlParser::SubElementTrajectoryParser::GetMinOccur() 
@@ -9597,9 +9606,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAJECTORY
                     };
         }
-        FollowTrajectoryActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FollowTrajectoryActionXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FollowTrajectoryActionXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9614,11 +9623,14 @@ namespace NET_ASAM_OPENSCENARIO
             std::dynamic_pointer_cast<CatalogReferenceParserContext>(parserContext)->AddCatalogReference(std::dynamic_pointer_cast<ICatalogReference>(catalogReference));
             
             
-            // This element is deprecated
-            std::string name = indexedElement->GetElement()->Name();
-        	Position startPosition = indexedElement->GetStartElementLocation();
-			auto msg = FileContentMessage("Element '" + name + "' is deprecated since standard version '1.1'. Comment: 'Use trajectoryRef instead.'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), _catalogReferenceXmlParser->_filename));
-			_catalogReferenceXmlParser->_messageLogger.LogMessage(msg);
+			if (!_catalogReferenceXmlParser->_parserOptions.IsOptionSetSupressDeprecationWarnings())
+			{
+				// This element is deprecated
+				std::string name = indexedElement->GetElement()->Name();
+				Position startPosition = indexedElement->GetStartElementLocation();
+				auto msg = FileContentMessage("Element '" + name + "' is deprecated since standard version '1.1'. Comment: 'Use trajectoryRef instead.'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), _catalogReferenceXmlParser->_filename));
+				_catalogReferenceXmlParser->_messageLogger.LogMessage(msg);
+			}
         }
         
         int FollowTrajectoryActionXmlParser::SubElementCatalogReferenceParser::GetMinOccur() 
@@ -9643,9 +9655,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CATALOG_REFERENCE
                     };
         }
-        FollowTrajectoryActionXmlParser::SubElementTimeReferenceParser::SubElementTimeReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FollowTrajectoryActionXmlParser::SubElementTimeReferenceParser::SubElementTimeReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _timeReferenceXmlParser = std::make_shared<TimeReferenceXmlParser>(messageLogger, filename);
+            _timeReferenceXmlParser = std::make_shared<TimeReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FollowTrajectoryActionXmlParser::SubElementTimeReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9683,9 +9695,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TIME_REFERENCE
                     };
         }
-        FollowTrajectoryActionXmlParser::SubElementTrajectoryFollowingModeParser::SubElementTrajectoryFollowingModeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FollowTrajectoryActionXmlParser::SubElementTrajectoryFollowingModeParser::SubElementTrajectoryFollowingModeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trajectoryFollowingModeXmlParser = std::make_shared<TrajectoryFollowingModeXmlParser>(messageLogger, filename);
+            _trajectoryFollowingModeXmlParser = std::make_shared<TrajectoryFollowingModeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FollowTrajectoryActionXmlParser::SubElementTrajectoryFollowingModeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9723,9 +9735,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAJECTORY_FOLLOWING_MODE
                     };
         }
-        FollowTrajectoryActionXmlParser::SubElementTrajectoryRefParser::SubElementTrajectoryRefParser(IParserMessageLogger& messageLogger, std::string& filename)
+        FollowTrajectoryActionXmlParser::SubElementTrajectoryRefParser::SubElementTrajectoryRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trajectoryRefXmlParser = std::make_shared<TrajectoryRefXmlParser>(messageLogger, filename);
+            _trajectoryRefXmlParser = std::make_shared<TrajectoryRefXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void FollowTrajectoryActionXmlParser::SubElementTrajectoryRefParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9764,10 +9776,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        FollowTrajectoryActionXmlParser::FollowTrajectoryActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        FollowTrajectoryActionXmlParser::FollowTrajectoryActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9777,7 +9789,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            GeoPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            GeoPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> GeoPositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9787,7 +9799,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeHeight: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeHeight(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeHeight(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9822,11 +9834,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__HEIGHT, std::make_shared<AttributeHeight>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__HEIGHT, std::make_shared<AttributeHeight>(_messageLogger, _filename, _parserOptions)));
             class AttributeLatitude: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLatitude(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLatitude(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9861,11 +9873,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LATITUDE, std::make_shared<AttributeLatitude>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LATITUDE, std::make_shared<AttributeLatitude>(_messageLogger, _filename, _parserOptions)));
             class AttributeLongitude: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLongitude(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLongitude(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9900,20 +9912,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LONGITUDE, std::make_shared<AttributeLongitude>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LONGITUDE, std::make_shared<AttributeLongitude>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> GeoPositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        GeoPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        GeoPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void GeoPositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9952,10 +9964,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        GeoPositionXmlParser::GeoPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        GeoPositionXmlParser::GeoPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9965,7 +9977,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            GlobalActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            GlobalActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> GlobalActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9978,17 +9990,17 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> GlobalActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEnvironmentActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementEntityActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementParameterActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementInfrastructureActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEnvironmentActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementEntityActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementParameterActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementInfrastructureActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        GlobalActionXmlParser::SubElementEnvironmentActionParser::SubElementEnvironmentActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        GlobalActionXmlParser::SubElementEnvironmentActionParser::SubElementEnvironmentActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _environmentActionXmlParser = std::make_shared<EnvironmentActionXmlParser>(messageLogger, filename);
+            _environmentActionXmlParser = std::make_shared<EnvironmentActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void GlobalActionXmlParser::SubElementEnvironmentActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10026,9 +10038,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENVIRONMENT_ACTION
                     };
         }
-        GlobalActionXmlParser::SubElementEntityActionParser::SubElementEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        GlobalActionXmlParser::SubElementEntityActionParser::SubElementEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityActionXmlParser = std::make_shared<EntityActionXmlParser>(messageLogger, filename);
+            _entityActionXmlParser = std::make_shared<EntityActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void GlobalActionXmlParser::SubElementEntityActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10066,9 +10078,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENTITY_ACTION
                     };
         }
-        GlobalActionXmlParser::SubElementParameterActionParser::SubElementParameterActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        GlobalActionXmlParser::SubElementParameterActionParser::SubElementParameterActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterActionXmlParser = std::make_shared<ParameterActionXmlParser>(messageLogger, filename);
+            _parameterActionXmlParser = std::make_shared<ParameterActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void GlobalActionXmlParser::SubElementParameterActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10106,9 +10118,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PARAMETER_ACTION
                     };
         }
-        GlobalActionXmlParser::SubElementInfrastructureActionParser::SubElementInfrastructureActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        GlobalActionXmlParser::SubElementInfrastructureActionParser::SubElementInfrastructureActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _infrastructureActionXmlParser = std::make_shared<InfrastructureActionXmlParser>(messageLogger, filename);
+            _infrastructureActionXmlParser = std::make_shared<InfrastructureActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void GlobalActionXmlParser::SubElementInfrastructureActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10146,9 +10158,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__INFRASTRUCTURE_ACTION
                     };
         }
-        GlobalActionXmlParser::SubElementTrafficActionParser::SubElementTrafficActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        GlobalActionXmlParser::SubElementTrafficActionParser::SubElementTrafficActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficActionXmlParser = std::make_shared<TrafficActionXmlParser>(messageLogger, filename);
+            _trafficActionXmlParser = std::make_shared<TrafficActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void GlobalActionXmlParser::SubElementTrafficActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10187,10 +10199,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        GlobalActionXmlParser::GlobalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        GlobalActionXmlParser::GlobalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10200,7 +10212,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            HistogramXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            HistogramXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> HistogramXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10212,13 +10224,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> HistogramXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementBinsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementBinsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        HistogramXmlParser::SubElementBinsParser::SubElementBinsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        HistogramXmlParser::SubElementBinsParser::SubElementBinsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _histogramBinXmlParser = std::make_shared<HistogramBinXmlParser>(messageLogger, filename);
+            _histogramBinXmlParser = std::make_shared<HistogramBinXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void HistogramXmlParser::SubElementBinsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10258,10 +10270,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        HistogramXmlParser::HistogramXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        HistogramXmlParser::HistogramXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10271,7 +10283,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            HistogramBinXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            HistogramBinXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> HistogramBinXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10280,7 +10292,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeWeight: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10315,20 +10327,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> HistogramBinXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRangeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRangeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        HistogramBinXmlParser::SubElementRangeParser::SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        HistogramBinXmlParser::SubElementRangeParser::SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _rangeXmlParser = std::make_shared<RangeXmlParser>(messageLogger, filename);
+            _rangeXmlParser = std::make_shared<RangeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void HistogramBinXmlParser::SubElementRangeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10367,10 +10379,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        HistogramBinXmlParser::HistogramBinXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        HistogramBinXmlParser::HistogramBinXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10380,7 +10392,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            InRoutePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            InRoutePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> InRoutePositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -10393,15 +10405,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> InRoutePositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementFromCurrentEntityParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementFromRoadCoordinatesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementFromLaneCoordinatesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementFromCurrentEntityParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementFromRoadCoordinatesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementFromLaneCoordinatesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        InRoutePositionXmlParser::SubElementFromCurrentEntityParser::SubElementFromCurrentEntityParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InRoutePositionXmlParser::SubElementFromCurrentEntityParser::SubElementFromCurrentEntityParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionOfCurrentEntityXmlParser = std::make_shared<PositionOfCurrentEntityXmlParser>(messageLogger, filename);
+            _positionOfCurrentEntityXmlParser = std::make_shared<PositionOfCurrentEntityXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InRoutePositionXmlParser::SubElementFromCurrentEntityParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10439,9 +10451,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__FROM_CURRENT_ENTITY
                     };
         }
-        InRoutePositionXmlParser::SubElementFromRoadCoordinatesParser::SubElementFromRoadCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InRoutePositionXmlParser::SubElementFromRoadCoordinatesParser::SubElementFromRoadCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionInRoadCoordinatesXmlParser = std::make_shared<PositionInRoadCoordinatesXmlParser>(messageLogger, filename);
+            _positionInRoadCoordinatesXmlParser = std::make_shared<PositionInRoadCoordinatesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InRoutePositionXmlParser::SubElementFromRoadCoordinatesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10479,9 +10491,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__FROM_ROAD_COORDINATES
                     };
         }
-        InRoutePositionXmlParser::SubElementFromLaneCoordinatesParser::SubElementFromLaneCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InRoutePositionXmlParser::SubElementFromLaneCoordinatesParser::SubElementFromLaneCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionInLaneCoordinatesXmlParser = std::make_shared<PositionInLaneCoordinatesXmlParser>(messageLogger, filename);
+            _positionInLaneCoordinatesXmlParser = std::make_shared<PositionInLaneCoordinatesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InRoutePositionXmlParser::SubElementFromLaneCoordinatesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10520,10 +10532,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        InRoutePositionXmlParser::InRoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        InRoutePositionXmlParser::InRoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10533,7 +10545,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            InfrastructureActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            InfrastructureActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> InfrastructureActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -10546,13 +10558,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> InfrastructureActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTrafficSignalActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTrafficSignalActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        InfrastructureActionXmlParser::SubElementTrafficSignalActionParser::SubElementTrafficSignalActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InfrastructureActionXmlParser::SubElementTrafficSignalActionParser::SubElementTrafficSignalActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSignalActionXmlParser = std::make_shared<TrafficSignalActionXmlParser>(messageLogger, filename);
+            _trafficSignalActionXmlParser = std::make_shared<TrafficSignalActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InfrastructureActionXmlParser::SubElementTrafficSignalActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10591,10 +10603,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        InfrastructureActionXmlParser::InfrastructureActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        InfrastructureActionXmlParser::InfrastructureActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10604,7 +10616,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            InitXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            InitXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> InitXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10616,13 +10628,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> InitXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementActionsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementActionsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        InitXmlParser::SubElementActionsParser::SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InitXmlParser::SubElementActionsParser::SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _initActionsXmlParser = std::make_shared<InitActionsXmlParser>(messageLogger, filename);
+            _initActionsXmlParser = std::make_shared<InitActionsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InitXmlParser::SubElementActionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10661,10 +10673,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        InitXmlParser::InitXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        InitXmlParser::InitXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10674,7 +10686,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            InitActionsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            InitActionsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> InitActionsXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10686,15 +10698,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> InitActionsXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementGlobalActionsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementUserDefinedActionsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPrivatesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementGlobalActionsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementUserDefinedActionsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPrivatesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        InitActionsXmlParser::SubElementGlobalActionsParser::SubElementGlobalActionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InitActionsXmlParser::SubElementGlobalActionsParser::SubElementGlobalActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _globalActionXmlParser = std::make_shared<GlobalActionXmlParser>(messageLogger, filename);
+            _globalActionXmlParser = std::make_shared<GlobalActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InitActionsXmlParser::SubElementGlobalActionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10733,9 +10745,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__GLOBAL_ACTION
                     };
         }
-        InitActionsXmlParser::SubElementUserDefinedActionsParser::SubElementUserDefinedActionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InitActionsXmlParser::SubElementUserDefinedActionsParser::SubElementUserDefinedActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _userDefinedActionXmlParser = std::make_shared<UserDefinedActionXmlParser>(messageLogger, filename);
+            _userDefinedActionXmlParser = std::make_shared<UserDefinedActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InitActionsXmlParser::SubElementUserDefinedActionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10774,9 +10786,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__USER_DEFINED_ACTION
                     };
         }
-        InitActionsXmlParser::SubElementPrivatesParser::SubElementPrivatesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        InitActionsXmlParser::SubElementPrivatesParser::SubElementPrivatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _privateXmlParser = std::make_shared<PrivateXmlParser>(messageLogger, filename);
+            _privateXmlParser = std::make_shared<PrivateXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void InitActionsXmlParser::SubElementPrivatesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10816,10 +10828,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        InitActionsXmlParser::InitActionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        InitActionsXmlParser::InitActionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10829,7 +10841,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            KnotXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            KnotXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> KnotXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10838,7 +10850,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10873,7 +10885,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -10884,10 +10896,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        KnotXmlParser::KnotXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        KnotXmlParser::KnotXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10897,7 +10909,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LaneChangeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            LaneChangeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LaneChangeActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -10907,7 +10919,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeTargetLaneOffset: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTargetLaneOffset(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTargetLaneOffset(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10942,21 +10954,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TARGET_LANE_OFFSET, std::make_shared<AttributeTargetLaneOffset>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TARGET_LANE_OFFSET, std::make_shared<AttributeTargetLaneOffset>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> LaneChangeActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementLaneChangeActionDynamicsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementLaneChangeTargetParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementLaneChangeActionDynamicsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementLaneChangeTargetParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LaneChangeActionXmlParser::SubElementLaneChangeActionDynamicsParser::SubElementLaneChangeActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneChangeActionXmlParser::SubElementLaneChangeActionDynamicsParser::SubElementLaneChangeActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _transitionDynamicsXmlParser = std::make_shared<TransitionDynamicsXmlParser>(messageLogger, filename);
+            _transitionDynamicsXmlParser = std::make_shared<TransitionDynamicsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneChangeActionXmlParser::SubElementLaneChangeActionDynamicsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10994,9 +11006,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LANE_CHANGE_ACTION_DYNAMICS
                     };
         }
-        LaneChangeActionXmlParser::SubElementLaneChangeTargetParser::SubElementLaneChangeTargetParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneChangeActionXmlParser::SubElementLaneChangeTargetParser::SubElementLaneChangeTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _laneChangeTargetXmlParser = std::make_shared<LaneChangeTargetXmlParser>(messageLogger, filename);
+            _laneChangeTargetXmlParser = std::make_shared<LaneChangeTargetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneChangeActionXmlParser::SubElementLaneChangeTargetParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11035,10 +11047,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LaneChangeActionXmlParser::LaneChangeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LaneChangeActionXmlParser::LaneChangeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11048,7 +11060,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LaneChangeTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            LaneChangeTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LaneChangeTargetXmlParser::GetAttributeNameToAttributeParserMap()
@@ -11061,14 +11073,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> LaneChangeTargetXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRelativeTargetLaneParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementAbsoluteTargetLaneParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRelativeTargetLaneParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementAbsoluteTargetLaneParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LaneChangeTargetXmlParser::SubElementRelativeTargetLaneParser::SubElementRelativeTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneChangeTargetXmlParser::SubElementRelativeTargetLaneParser::SubElementRelativeTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeTargetLaneXmlParser = std::make_shared<RelativeTargetLaneXmlParser>(messageLogger, filename);
+            _relativeTargetLaneXmlParser = std::make_shared<RelativeTargetLaneXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneChangeTargetXmlParser::SubElementRelativeTargetLaneParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11106,9 +11118,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_TARGET_LANE
                     };
         }
-        LaneChangeTargetXmlParser::SubElementAbsoluteTargetLaneParser::SubElementAbsoluteTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneChangeTargetXmlParser::SubElementAbsoluteTargetLaneParser::SubElementAbsoluteTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _absoluteTargetLaneXmlParser = std::make_shared<AbsoluteTargetLaneXmlParser>(messageLogger, filename);
+            _absoluteTargetLaneXmlParser = std::make_shared<AbsoluteTargetLaneXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneChangeTargetXmlParser::SubElementAbsoluteTargetLaneParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11147,10 +11159,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LaneChangeTargetXmlParser::LaneChangeTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LaneChangeTargetXmlParser::LaneChangeTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11160,7 +11172,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LaneOffsetActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            LaneOffsetActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LaneOffsetActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -11170,7 +11182,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeContinuous: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11200,21 +11212,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> LaneOffsetActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementLaneOffsetActionDynamicsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementLaneOffsetTargetParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementLaneOffsetActionDynamicsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementLaneOffsetTargetParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LaneOffsetActionXmlParser::SubElementLaneOffsetActionDynamicsParser::SubElementLaneOffsetActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneOffsetActionXmlParser::SubElementLaneOffsetActionDynamicsParser::SubElementLaneOffsetActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _laneOffsetActionDynamicsXmlParser = std::make_shared<LaneOffsetActionDynamicsXmlParser>(messageLogger, filename);
+            _laneOffsetActionDynamicsXmlParser = std::make_shared<LaneOffsetActionDynamicsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneOffsetActionXmlParser::SubElementLaneOffsetActionDynamicsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11252,9 +11264,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LANE_OFFSET_ACTION_DYNAMICS
                     };
         }
-        LaneOffsetActionXmlParser::SubElementLaneOffsetTargetParser::SubElementLaneOffsetTargetParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneOffsetActionXmlParser::SubElementLaneOffsetTargetParser::SubElementLaneOffsetTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _laneOffsetTargetXmlParser = std::make_shared<LaneOffsetTargetXmlParser>(messageLogger, filename);
+            _laneOffsetTargetXmlParser = std::make_shared<LaneOffsetTargetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneOffsetActionXmlParser::SubElementLaneOffsetTargetParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11293,10 +11305,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LaneOffsetActionXmlParser::LaneOffsetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LaneOffsetActionXmlParser::LaneOffsetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11306,7 +11318,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LaneOffsetActionDynamicsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            LaneOffsetActionDynamicsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LaneOffsetActionDynamicsXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11315,7 +11327,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDynamicsShape: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDynamicsShape(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDynamicsShape(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11342,7 +11354,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (DynamicsShape::IsDeprecated(kResult))
+                        if (DynamicsShape::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  DynamicsShape::GetDeprecatedVersion(kResult) +"'. " + DynamicsShape::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -11359,11 +11371,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DYNAMICS_SHAPE, std::make_shared<AttributeDynamicsShape>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DYNAMICS_SHAPE, std::make_shared<AttributeDynamicsShape>(_messageLogger, _filename, _parserOptions)));
             class AttributeMaxLateralAcc: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxLateralAcc(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxLateralAcc(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11398,7 +11410,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_LATERAL_ACC, std::make_shared<AttributeMaxLateralAcc>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_LATERAL_ACC, std::make_shared<AttributeMaxLateralAcc>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -11409,10 +11421,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        LaneOffsetActionDynamicsXmlParser::LaneOffsetActionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LaneOffsetActionDynamicsXmlParser::LaneOffsetActionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11422,7 +11434,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LaneOffsetTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            LaneOffsetTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LaneOffsetTargetXmlParser::GetAttributeNameToAttributeParserMap()
@@ -11435,14 +11447,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> LaneOffsetTargetXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRelativeTargetLaneOffsetParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementAbsoluteTargetLaneOffsetParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRelativeTargetLaneOffsetParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementAbsoluteTargetLaneOffsetParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LaneOffsetTargetXmlParser::SubElementRelativeTargetLaneOffsetParser::SubElementRelativeTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneOffsetTargetXmlParser::SubElementRelativeTargetLaneOffsetParser::SubElementRelativeTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeTargetLaneOffsetXmlParser = std::make_shared<RelativeTargetLaneOffsetXmlParser>(messageLogger, filename);
+            _relativeTargetLaneOffsetXmlParser = std::make_shared<RelativeTargetLaneOffsetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneOffsetTargetXmlParser::SubElementRelativeTargetLaneOffsetParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11480,9 +11492,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_TARGET_LANE_OFFSET
                     };
         }
-        LaneOffsetTargetXmlParser::SubElementAbsoluteTargetLaneOffsetParser::SubElementAbsoluteTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LaneOffsetTargetXmlParser::SubElementAbsoluteTargetLaneOffsetParser::SubElementAbsoluteTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _absoluteTargetLaneOffsetXmlParser = std::make_shared<AbsoluteTargetLaneOffsetXmlParser>(messageLogger, filename);
+            _absoluteTargetLaneOffsetXmlParser = std::make_shared<AbsoluteTargetLaneOffsetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LaneOffsetTargetXmlParser::SubElementAbsoluteTargetLaneOffsetParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11521,10 +11533,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LaneOffsetTargetXmlParser::LaneOffsetTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LaneOffsetTargetXmlParser::LaneOffsetTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11534,7 +11546,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LanePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            LanePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LanePositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -11544,7 +11556,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeLaneId: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLaneId(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLaneId(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11579,11 +11591,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LANE_ID, std::make_shared<AttributeLaneId>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LANE_ID, std::make_shared<AttributeLaneId>(_messageLogger, _filename, _parserOptions)));
             class AttributeOffset: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11618,11 +11630,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename, _parserOptions)));
             class AttributeRoadId: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRoadId(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRoadId(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11657,11 +11669,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ROAD_ID, std::make_shared<AttributeRoadId>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ROAD_ID, std::make_shared<AttributeRoadId>(_messageLogger, _filename, _parserOptions)));
             class AttributeS: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeS(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeS(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11696,20 +11708,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__S, std::make_shared<AttributeS>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__S, std::make_shared<AttributeS>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> LanePositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LanePositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LanePositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LanePositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11748,10 +11760,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LanePositionXmlParser::LanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LanePositionXmlParser::LanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11761,7 +11773,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LateralActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            LateralActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LateralActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -11774,15 +11786,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> LateralActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementLaneChangeActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementLaneOffsetActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementLateralDistanceActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementLaneChangeActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementLaneOffsetActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementLateralDistanceActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LateralActionXmlParser::SubElementLaneChangeActionParser::SubElementLaneChangeActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LateralActionXmlParser::SubElementLaneChangeActionParser::SubElementLaneChangeActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _laneChangeActionXmlParser = std::make_shared<LaneChangeActionXmlParser>(messageLogger, filename);
+            _laneChangeActionXmlParser = std::make_shared<LaneChangeActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LateralActionXmlParser::SubElementLaneChangeActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11820,9 +11832,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LANE_CHANGE_ACTION
                     };
         }
-        LateralActionXmlParser::SubElementLaneOffsetActionParser::SubElementLaneOffsetActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LateralActionXmlParser::SubElementLaneOffsetActionParser::SubElementLaneOffsetActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _laneOffsetActionXmlParser = std::make_shared<LaneOffsetActionXmlParser>(messageLogger, filename);
+            _laneOffsetActionXmlParser = std::make_shared<LaneOffsetActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LateralActionXmlParser::SubElementLaneOffsetActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11860,9 +11872,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LANE_OFFSET_ACTION
                     };
         }
-        LateralActionXmlParser::SubElementLateralDistanceActionParser::SubElementLateralDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LateralActionXmlParser::SubElementLateralDistanceActionParser::SubElementLateralDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _lateralDistanceActionXmlParser = std::make_shared<LateralDistanceActionXmlParser>(messageLogger, filename);
+            _lateralDistanceActionXmlParser = std::make_shared<LateralDistanceActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LateralActionXmlParser::SubElementLateralDistanceActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11901,10 +11913,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LateralActionXmlParser::LateralActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LateralActionXmlParser::LateralActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11914,7 +11926,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LateralDistanceActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            LateralDistanceActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LateralDistanceActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -11924,7 +11936,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeContinuous: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11954,11 +11966,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename, _parserOptions)));
             class AttributeCoordinateSystem: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCoordinateSystem(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCoordinateSystem(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11985,7 +11997,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (CoordinateSystem::IsDeprecated(kResult))
+                        if (CoordinateSystem::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  CoordinateSystem::GetDeprecatedVersion(kResult) +"'. " + CoordinateSystem::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -12002,11 +12014,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM, std::make_shared<AttributeCoordinateSystem>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM, std::make_shared<AttributeCoordinateSystem>(_messageLogger, _filename, _parserOptions)));
             class AttributeDisplacement: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDisplacement(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDisplacement(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12033,7 +12045,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (LateralDisplacement::IsDeprecated(kResult))
+                        if (LateralDisplacement::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  LateralDisplacement::GetDeprecatedVersion(kResult) +"'. " + LateralDisplacement::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -12050,11 +12062,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DISPLACEMENT, std::make_shared<AttributeDisplacement>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DISPLACEMENT, std::make_shared<AttributeDisplacement>(_messageLogger, _filename, _parserOptions)));
             class AttributeDistance: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDistance(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDistance(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12089,11 +12101,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DISTANCE, std::make_shared<AttributeDistance>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DISTANCE, std::make_shared<AttributeDistance>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12125,11 +12137,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeFreespace: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12159,20 +12171,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> LateralDistanceActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDynamicConstraintsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDynamicConstraintsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LateralDistanceActionXmlParser::SubElementDynamicConstraintsParser::SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LateralDistanceActionXmlParser::SubElementDynamicConstraintsParser::SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _dynamicConstraintsXmlParser = std::make_shared<DynamicConstraintsXmlParser>(messageLogger, filename);
+            _dynamicConstraintsXmlParser = std::make_shared<DynamicConstraintsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LateralDistanceActionXmlParser::SubElementDynamicConstraintsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12211,10 +12223,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LateralDistanceActionXmlParser::LateralDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LateralDistanceActionXmlParser::LateralDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12236,7 +12248,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12271,11 +12283,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeResource: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeResource(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeResource(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12310,11 +12322,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RESOURCE, std::make_shared<AttributeResource>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RESOURCE, std::make_shared<AttributeResource>(_messageLogger, _filename, _parserOptions)));
             class AttributeSpdxId: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeSpdxId(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeSpdxId(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12349,7 +12361,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SPDX_ID, std::make_shared<AttributeSpdxId>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SPDX_ID, std::make_shared<AttributeSpdxId>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
         void LicenseXmlParser::SetContentProperty(const std::string content, std::shared_ptr<BaseImpl> object)
@@ -12358,8 +12370,8 @@ namespace NET_ASAM_OPENSCENARIO
             typedObject->SetText(content);
         }
   
-        LicenseXmlParser::LicenseXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlSimpleContentParser(messageLogger, filename) {}
+        LicenseXmlParser::LicenseXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlSimpleContentParser(messageLogger, filename, parserOptions) {}
         
 
         /**
@@ -12368,7 +12380,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LongitudinalActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            LongitudinalActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LongitudinalActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -12381,14 +12393,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> LongitudinalActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementSpeedActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementLongitudinalDistanceActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementSpeedActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementLongitudinalDistanceActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LongitudinalActionXmlParser::SubElementSpeedActionParser::SubElementSpeedActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LongitudinalActionXmlParser::SubElementSpeedActionParser::SubElementSpeedActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _speedActionXmlParser = std::make_shared<SpeedActionXmlParser>(messageLogger, filename);
+            _speedActionXmlParser = std::make_shared<SpeedActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LongitudinalActionXmlParser::SubElementSpeedActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12426,9 +12438,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SPEED_ACTION
                     };
         }
-        LongitudinalActionXmlParser::SubElementLongitudinalDistanceActionParser::SubElementLongitudinalDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LongitudinalActionXmlParser::SubElementLongitudinalDistanceActionParser::SubElementLongitudinalDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _longitudinalDistanceActionXmlParser = std::make_shared<LongitudinalDistanceActionXmlParser>(messageLogger, filename);
+            _longitudinalDistanceActionXmlParser = std::make_shared<LongitudinalDistanceActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LongitudinalActionXmlParser::SubElementLongitudinalDistanceActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12467,10 +12479,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LongitudinalActionXmlParser::LongitudinalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LongitudinalActionXmlParser::LongitudinalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12480,7 +12492,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            LongitudinalDistanceActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            LongitudinalDistanceActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> LongitudinalDistanceActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -12490,7 +12502,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeContinuous: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12520,11 +12532,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename, _parserOptions)));
             class AttributeCoordinateSystem: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCoordinateSystem(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCoordinateSystem(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12551,7 +12563,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (CoordinateSystem::IsDeprecated(kResult))
+                        if (CoordinateSystem::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  CoordinateSystem::GetDeprecatedVersion(kResult) +"'. " + CoordinateSystem::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -12568,11 +12580,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM, std::make_shared<AttributeCoordinateSystem>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM, std::make_shared<AttributeCoordinateSystem>(_messageLogger, _filename, _parserOptions)));
             class AttributeDisplacement: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDisplacement(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDisplacement(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12599,7 +12611,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (LongitudinalDisplacement::IsDeprecated(kResult))
+                        if (LongitudinalDisplacement::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  LongitudinalDisplacement::GetDeprecatedVersion(kResult) +"'. " + LongitudinalDisplacement::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -12616,11 +12628,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DISPLACEMENT, std::make_shared<AttributeDisplacement>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DISPLACEMENT, std::make_shared<AttributeDisplacement>(_messageLogger, _filename, _parserOptions)));
             class AttributeDistance: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDistance(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDistance(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12655,11 +12667,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DISTANCE, std::make_shared<AttributeDistance>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DISTANCE, std::make_shared<AttributeDistance>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12691,11 +12703,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeFreespace: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12725,11 +12737,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename, _parserOptions)));
             class AttributeTimeGap: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTimeGap(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTimeGap(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12764,20 +12776,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TIME_GAP, std::make_shared<AttributeTimeGap>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TIME_GAP, std::make_shared<AttributeTimeGap>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> LongitudinalDistanceActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDynamicConstraintsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDynamicConstraintsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        LongitudinalDistanceActionXmlParser::SubElementDynamicConstraintsParser::SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        LongitudinalDistanceActionXmlParser::SubElementDynamicConstraintsParser::SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _dynamicConstraintsXmlParser = std::make_shared<DynamicConstraintsXmlParser>(messageLogger, filename);
+            _dynamicConstraintsXmlParser = std::make_shared<DynamicConstraintsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void LongitudinalDistanceActionXmlParser::SubElementDynamicConstraintsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12816,10 +12828,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        LongitudinalDistanceActionXmlParser::LongitudinalDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        LongitudinalDistanceActionXmlParser::LongitudinalDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12829,7 +12841,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ManeuverXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ManeuverXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ManeuverXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -12838,7 +12850,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12873,21 +12885,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ManeuverXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementEventsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementEventsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ManeuverXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ManeuverXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ManeuverXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12923,9 +12935,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        ManeuverXmlParser::SubElementEventsParser::SubElementEventsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ManeuverXmlParser::SubElementEventsParser::SubElementEventsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _eventXmlParser = std::make_shared<EventXmlParser>(messageLogger, filename);
+            _eventXmlParser = std::make_shared<EventXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ManeuverXmlParser::SubElementEventsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12965,10 +12977,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ManeuverXmlParser::ManeuverXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ManeuverXmlParser::ManeuverXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12978,7 +12990,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ManeuverCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ManeuverCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ManeuverCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -12991,13 +13003,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ManeuverCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ManeuverCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ManeuverCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ManeuverCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13036,10 +13048,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ManeuverCatalogLocationXmlParser::ManeuverCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ManeuverCatalogLocationXmlParser::ManeuverCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13049,7 +13061,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ManeuverGroupXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ManeuverGroupXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ManeuverGroupXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -13058,7 +13070,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMaximumExecutionCount: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaximumExecutionCount(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaximumExecutionCount(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13093,11 +13105,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAXIMUM_EXECUTION_COUNT, std::make_shared<AttributeMaximumExecutionCount>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAXIMUM_EXECUTION_COUNT, std::make_shared<AttributeMaximumExecutionCount>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13132,22 +13144,22 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ManeuverGroupXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementActorsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferencesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementManeuversParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementActorsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferencesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementManeuversParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ManeuverGroupXmlParser::SubElementActorsParser::SubElementActorsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ManeuverGroupXmlParser::SubElementActorsParser::SubElementActorsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _actorsXmlParser = std::make_shared<ActorsXmlParser>(messageLogger, filename);
+            _actorsXmlParser = std::make_shared<ActorsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ManeuverGroupXmlParser::SubElementActorsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13185,9 +13197,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ACTORS
                     };
         }
-        ManeuverGroupXmlParser::SubElementCatalogReferencesParser::SubElementCatalogReferencesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ManeuverGroupXmlParser::SubElementCatalogReferencesParser::SubElementCatalogReferencesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ManeuverGroupXmlParser::SubElementCatalogReferencesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13227,9 +13239,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CATALOG_REFERENCE
                     };
         }
-        ManeuverGroupXmlParser::SubElementManeuversParser::SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ManeuverGroupXmlParser::SubElementManeuversParser::SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _maneuverXmlParser = std::make_shared<ManeuverXmlParser>(messageLogger, filename);
+            _maneuverXmlParser = std::make_shared<ManeuverXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ManeuverGroupXmlParser::SubElementManeuversParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13269,10 +13281,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ManeuverGroupXmlParser::ManeuverGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ManeuverGroupXmlParser::ManeuverGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13282,7 +13294,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            MiscObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            MiscObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> MiscObjectXmlParser::GetAttributeNameToAttributeParserMap()
@@ -13292,7 +13304,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMass: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMass(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMass(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13327,11 +13339,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MASS, std::make_shared<AttributeMass>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MASS, std::make_shared<AttributeMass>(_messageLogger, _filename, _parserOptions)));
             class AttributeMiscObjectCategory: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMiscObjectCategory(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMiscObjectCategory(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13358,7 +13370,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (MiscObjectCategory::IsDeprecated(kResult))
+                        if (MiscObjectCategory::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  MiscObjectCategory::GetDeprecatedVersion(kResult) +"'. " + MiscObjectCategory::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -13375,11 +13387,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MISC_OBJECT_CATEGORY, std::make_shared<AttributeMiscObjectCategory>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MISC_OBJECT_CATEGORY, std::make_shared<AttributeMiscObjectCategory>(_messageLogger, _filename, _parserOptions)));
             class AttributeModel3d: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeModel3d(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeModel3d(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13414,11 +13426,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MODEL3D, std::make_shared<AttributeModel3d>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MODEL3D, std::make_shared<AttributeModel3d>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13453,22 +13465,22 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> MiscObjectXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        MiscObjectXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        MiscObjectXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void MiscObjectXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13504,9 +13516,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        MiscObjectXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename)
+        MiscObjectXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename);
+            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void MiscObjectXmlParser::SubElementBoundingBoxParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13544,9 +13556,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__BOUNDING_BOX
                     };
         }
-        MiscObjectXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        MiscObjectXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename);
+            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void MiscObjectXmlParser::SubElementPropertiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13585,10 +13597,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        MiscObjectXmlParser::MiscObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        MiscObjectXmlParser::MiscObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13598,7 +13610,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            MiscObjectCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            MiscObjectCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> MiscObjectCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -13611,13 +13623,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> MiscObjectCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        MiscObjectCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        MiscObjectCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void MiscObjectCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13656,10 +13668,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        MiscObjectCatalogLocationXmlParser::MiscObjectCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        MiscObjectCatalogLocationXmlParser::MiscObjectCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13669,7 +13681,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ModifyRuleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ModifyRuleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ModifyRuleXmlParser::GetAttributeNameToAttributeParserMap()
@@ -13682,14 +13694,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ModifyRuleXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementAddValueParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementMultiplyByValueParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementAddValueParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementMultiplyByValueParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ModifyRuleXmlParser::SubElementAddValueParser::SubElementAddValueParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ModifyRuleXmlParser::SubElementAddValueParser::SubElementAddValueParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterAddValueRuleXmlParser = std::make_shared<ParameterAddValueRuleXmlParser>(messageLogger, filename);
+            _parameterAddValueRuleXmlParser = std::make_shared<ParameterAddValueRuleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ModifyRuleXmlParser::SubElementAddValueParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13727,9 +13739,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ADD_VALUE
                     };
         }
-        ModifyRuleXmlParser::SubElementMultiplyByValueParser::SubElementMultiplyByValueParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ModifyRuleXmlParser::SubElementMultiplyByValueParser::SubElementMultiplyByValueParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterMultiplyByValueRuleXmlParser = std::make_shared<ParameterMultiplyByValueRuleXmlParser>(messageLogger, filename);
+            _parameterMultiplyByValueRuleXmlParser = std::make_shared<ParameterMultiplyByValueRuleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ModifyRuleXmlParser::SubElementMultiplyByValueParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13768,10 +13780,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ModifyRuleXmlParser::ModifyRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ModifyRuleXmlParser::ModifyRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13781,7 +13793,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            NoneXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            NoneXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> NoneXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -13797,10 +13809,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        NoneXmlParser::NoneXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        NoneXmlParser::NoneXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13810,7 +13822,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            NormalDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            NormalDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> NormalDistributionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -13819,7 +13831,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeExpectedValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeExpectedValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeExpectedValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13854,11 +13866,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__EXPECTED_VALUE, std::make_shared<AttributeExpectedValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__EXPECTED_VALUE, std::make_shared<AttributeExpectedValue>(_messageLogger, _filename, _parserOptions)));
             class AttributeVariance: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeVariance(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeVariance(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13893,20 +13905,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VARIANCE, std::make_shared<AttributeVariance>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VARIANCE, std::make_shared<AttributeVariance>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> NormalDistributionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRangeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRangeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        NormalDistributionXmlParser::SubElementRangeParser::SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        NormalDistributionXmlParser::SubElementRangeParser::SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _rangeXmlParser = std::make_shared<RangeXmlParser>(messageLogger, filename);
+            _rangeXmlParser = std::make_shared<RangeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void NormalDistributionXmlParser::SubElementRangeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13945,10 +13957,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        NormalDistributionXmlParser::NormalDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        NormalDistributionXmlParser::NormalDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13958,7 +13970,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            NurbsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            NurbsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> NurbsXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -13967,7 +13979,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeOrder: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeOrder(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeOrder(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14002,21 +14014,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ORDER, std::make_shared<AttributeOrder>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ORDER, std::make_shared<AttributeOrder>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> NurbsXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementControlPointsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementKnotsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementControlPointsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementKnotsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        NurbsXmlParser::SubElementControlPointsParser::SubElementControlPointsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        NurbsXmlParser::SubElementControlPointsParser::SubElementControlPointsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controlPointXmlParser = std::make_shared<ControlPointXmlParser>(messageLogger, filename);
+            _controlPointXmlParser = std::make_shared<ControlPointXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void NurbsXmlParser::SubElementControlPointsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14055,9 +14067,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CONTROL_POINT
                     };
         }
-        NurbsXmlParser::SubElementKnotsParser::SubElementKnotsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        NurbsXmlParser::SubElementKnotsParser::SubElementKnotsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _knotXmlParser = std::make_shared<KnotXmlParser>(messageLogger, filename);
+            _knotXmlParser = std::make_shared<KnotXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void NurbsXmlParser::SubElementKnotsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14097,10 +14109,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        NurbsXmlParser::NurbsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        NurbsXmlParser::NurbsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14110,7 +14122,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ObjectControllerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ObjectControllerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ObjectControllerXmlParser::GetAttributeNameToAttributeParserMap()
@@ -14123,14 +14135,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ObjectControllerXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementControllerParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementControllerParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ObjectControllerXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ObjectControllerXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ObjectControllerXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14169,9 +14181,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CATALOG_REFERENCE
                     };
         }
-        ObjectControllerXmlParser::SubElementControllerParser::SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ObjectControllerXmlParser::SubElementControllerParser::SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename);
+            _controllerXmlParser = std::make_shared<ControllerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ObjectControllerXmlParser::SubElementControllerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14210,10 +14222,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ObjectControllerXmlParser::ObjectControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ObjectControllerXmlParser::ObjectControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14223,7 +14235,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OffroadConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OffroadConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OffroadConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -14232,7 +14244,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDuration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14267,7 +14279,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -14278,10 +14290,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OffroadConditionXmlParser::OffroadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OffroadConditionXmlParser::OffroadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14291,7 +14303,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OpenScenarioXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OpenScenarioXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OpenScenarioXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -14303,14 +14315,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> OpenScenarioXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementFileHeaderParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementOpenScenarioCategoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementFileHeaderParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementOpenScenarioCategoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        OpenScenarioXmlParser::SubElementFileHeaderParser::SubElementFileHeaderParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OpenScenarioXmlParser::SubElementFileHeaderParser::SubElementFileHeaderParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _fileHeaderXmlParser = std::make_shared<FileHeaderXmlParser>(messageLogger, filename);
+            _fileHeaderXmlParser = std::make_shared<FileHeaderXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OpenScenarioXmlParser::SubElementFileHeaderParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14348,9 +14360,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__FILE_HEADER
                     };
         }
-        OpenScenarioXmlParser::SubElementOpenScenarioCategoryParser::SubElementOpenScenarioCategoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OpenScenarioXmlParser::SubElementOpenScenarioCategoryParser::SubElementOpenScenarioCategoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _openScenarioCategoryXmlParser = std::make_shared<OpenScenarioCategoryXmlParser>(messageLogger, filename);
+            _openScenarioCategoryXmlParser = std::make_shared<OpenScenarioCategoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OpenScenarioXmlParser::SubElementOpenScenarioCategoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14395,10 +14407,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        OpenScenarioXmlParser::OpenScenarioXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OpenScenarioXmlParser::OpenScenarioXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14408,22 +14420,22 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OpenScenarioCategoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            OpenScenarioCategoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
 
         std::vector<std::shared_ptr<IElementParser>> OpenScenarioCategoryXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementScenarioDefinitionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogDefinitionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementParameterValueDistributionDefinitionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementScenarioDefinitionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogDefinitionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementParameterValueDistributionDefinitionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        OpenScenarioCategoryXmlParser::SubElementScenarioDefinitionParser::SubElementScenarioDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OpenScenarioCategoryXmlParser::SubElementScenarioDefinitionParser::SubElementScenarioDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _scenarioDefinitionXmlParser = std::make_shared<ScenarioDefinitionXmlParser>(messageLogger, filename);
+            _scenarioDefinitionXmlParser = std::make_shared<ScenarioDefinitionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OpenScenarioCategoryXmlParser::SubElementScenarioDefinitionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14463,9 +14475,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CATALOG_LOCATIONS
                     };
         }
-        OpenScenarioCategoryXmlParser::SubElementCatalogDefinitionParser::SubElementCatalogDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OpenScenarioCategoryXmlParser::SubElementCatalogDefinitionParser::SubElementCatalogDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogDefinitionXmlParser = std::make_shared<CatalogDefinitionXmlParser>(messageLogger, filename);
+            _catalogDefinitionXmlParser = std::make_shared<CatalogDefinitionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OpenScenarioCategoryXmlParser::SubElementCatalogDefinitionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14503,9 +14515,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CATALOG
                     };
         }
-        OpenScenarioCategoryXmlParser::SubElementParameterValueDistributionDefinitionParser::SubElementParameterValueDistributionDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OpenScenarioCategoryXmlParser::SubElementParameterValueDistributionDefinitionParser::SubElementParameterValueDistributionDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterValueDistributionDefinitionXmlParser = std::make_shared<ParameterValueDistributionDefinitionXmlParser>(messageLogger, filename);
+            _parameterValueDistributionDefinitionXmlParser = std::make_shared<ParameterValueDistributionDefinitionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OpenScenarioCategoryXmlParser::SubElementParameterValueDistributionDefinitionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14544,10 +14556,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        OpenScenarioCategoryXmlParser::OpenScenarioCategoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        OpenScenarioCategoryXmlParser::OpenScenarioCategoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14557,7 +14569,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OrientationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OrientationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OrientationXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -14566,7 +14578,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeH: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeH(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeH(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14601,11 +14613,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__H, std::make_shared<AttributeH>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__H, std::make_shared<AttributeH>(_messageLogger, _filename, _parserOptions)));
             class AttributeP: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeP(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeP(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14640,11 +14652,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__P, std::make_shared<AttributeP>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__P, std::make_shared<AttributeP>(_messageLogger, _filename, _parserOptions)));
             class AttributeR: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeR(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeR(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14679,11 +14691,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__R, std::make_shared<AttributeR>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__R, std::make_shared<AttributeR>(_messageLogger, _filename, _parserOptions)));
             class AttributeType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14710,7 +14722,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (ReferenceContext::IsDeprecated(kResult))
+                        if (ReferenceContext::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  ReferenceContext::GetDeprecatedVersion(kResult) +"'. " + ReferenceContext::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -14727,7 +14739,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TYPE, std::make_shared<AttributeType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TYPE, std::make_shared<AttributeType>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -14738,10 +14750,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OrientationXmlParser::OrientationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OrientationXmlParser::OrientationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14751,7 +14763,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OverrideBrakeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OverrideBrakeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OverrideBrakeActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -14760,7 +14772,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeActive: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14790,11 +14802,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14829,7 +14841,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -14840,10 +14852,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OverrideBrakeActionXmlParser::OverrideBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OverrideBrakeActionXmlParser::OverrideBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14853,7 +14865,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OverrideClutchActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OverrideClutchActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OverrideClutchActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -14862,7 +14874,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeActive: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14892,11 +14904,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14931,7 +14943,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -14942,10 +14954,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OverrideClutchActionXmlParser::OverrideClutchActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OverrideClutchActionXmlParser::OverrideClutchActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14955,7 +14967,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OverrideControllerValueActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            OverrideControllerValueActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OverrideControllerValueActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -14968,18 +14980,18 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> OverrideControllerValueActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementThrottleParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementBrakeParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementClutchParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementParkingBrakeParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementSteeringWheelParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementGearParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementThrottleParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementBrakeParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementClutchParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementParkingBrakeParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementSteeringWheelParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementGearParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        OverrideControllerValueActionXmlParser::SubElementThrottleParser::SubElementThrottleParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OverrideControllerValueActionXmlParser::SubElementThrottleParser::SubElementThrottleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _overrideThrottleActionXmlParser = std::make_shared<OverrideThrottleActionXmlParser>(messageLogger, filename);
+            _overrideThrottleActionXmlParser = std::make_shared<OverrideThrottleActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OverrideControllerValueActionXmlParser::SubElementThrottleParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15017,9 +15029,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__THROTTLE
                     };
         }
-        OverrideControllerValueActionXmlParser::SubElementBrakeParser::SubElementBrakeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OverrideControllerValueActionXmlParser::SubElementBrakeParser::SubElementBrakeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _overrideBrakeActionXmlParser = std::make_shared<OverrideBrakeActionXmlParser>(messageLogger, filename);
+            _overrideBrakeActionXmlParser = std::make_shared<OverrideBrakeActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OverrideControllerValueActionXmlParser::SubElementBrakeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15057,9 +15069,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__BRAKE
                     };
         }
-        OverrideControllerValueActionXmlParser::SubElementClutchParser::SubElementClutchParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OverrideControllerValueActionXmlParser::SubElementClutchParser::SubElementClutchParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _overrideClutchActionXmlParser = std::make_shared<OverrideClutchActionXmlParser>(messageLogger, filename);
+            _overrideClutchActionXmlParser = std::make_shared<OverrideClutchActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OverrideControllerValueActionXmlParser::SubElementClutchParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15097,9 +15109,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CLUTCH
                     };
         }
-        OverrideControllerValueActionXmlParser::SubElementParkingBrakeParser::SubElementParkingBrakeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OverrideControllerValueActionXmlParser::SubElementParkingBrakeParser::SubElementParkingBrakeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _overrideParkingBrakeActionXmlParser = std::make_shared<OverrideParkingBrakeActionXmlParser>(messageLogger, filename);
+            _overrideParkingBrakeActionXmlParser = std::make_shared<OverrideParkingBrakeActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OverrideControllerValueActionXmlParser::SubElementParkingBrakeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15137,9 +15149,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PARKING_BRAKE
                     };
         }
-        OverrideControllerValueActionXmlParser::SubElementSteeringWheelParser::SubElementSteeringWheelParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OverrideControllerValueActionXmlParser::SubElementSteeringWheelParser::SubElementSteeringWheelParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _overrideSteeringWheelActionXmlParser = std::make_shared<OverrideSteeringWheelActionXmlParser>(messageLogger, filename);
+            _overrideSteeringWheelActionXmlParser = std::make_shared<OverrideSteeringWheelActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OverrideControllerValueActionXmlParser::SubElementSteeringWheelParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15177,9 +15189,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__STEERING_WHEEL
                     };
         }
-        OverrideControllerValueActionXmlParser::SubElementGearParser::SubElementGearParser(IParserMessageLogger& messageLogger, std::string& filename)
+        OverrideControllerValueActionXmlParser::SubElementGearParser::SubElementGearParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _overrideGearActionXmlParser = std::make_shared<OverrideGearActionXmlParser>(messageLogger, filename);
+            _overrideGearActionXmlParser = std::make_shared<OverrideGearActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void OverrideControllerValueActionXmlParser::SubElementGearParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15218,10 +15230,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        OverrideControllerValueActionXmlParser::OverrideControllerValueActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OverrideControllerValueActionXmlParser::OverrideControllerValueActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15231,7 +15243,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OverrideGearActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OverrideGearActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OverrideGearActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -15240,7 +15252,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeActive: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15270,11 +15282,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename, _parserOptions)));
             class AttributeNumber: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeNumber(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeNumber(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15309,7 +15321,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NUMBER, std::make_shared<AttributeNumber>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NUMBER, std::make_shared<AttributeNumber>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -15320,10 +15332,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OverrideGearActionXmlParser::OverrideGearActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OverrideGearActionXmlParser::OverrideGearActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15333,7 +15345,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OverrideParkingBrakeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OverrideParkingBrakeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OverrideParkingBrakeActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -15342,7 +15354,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeActive: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15372,11 +15384,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15411,7 +15423,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -15422,10 +15434,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OverrideParkingBrakeActionXmlParser::OverrideParkingBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OverrideParkingBrakeActionXmlParser::OverrideParkingBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15435,7 +15447,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OverrideSteeringWheelActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OverrideSteeringWheelActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OverrideSteeringWheelActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -15444,7 +15456,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeActive: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15474,11 +15486,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15513,7 +15525,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -15524,10 +15536,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OverrideSteeringWheelActionXmlParser::OverrideSteeringWheelActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OverrideSteeringWheelActionXmlParser::OverrideSteeringWheelActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15537,7 +15549,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            OverrideThrottleActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            OverrideThrottleActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> OverrideThrottleActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -15546,7 +15558,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeActive: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeActive(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15576,11 +15588,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ACTIVE, std::make_shared<AttributeActive>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15615,7 +15627,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -15626,10 +15638,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        OverrideThrottleActionXmlParser::OverrideThrottleActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        OverrideThrottleActionXmlParser::OverrideThrottleActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15639,7 +15651,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ParameterActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -15649,7 +15661,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeParameterRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeParameterRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeParameterRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15681,21 +15693,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_REF, std::make_shared<AttributeParameterRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_REF, std::make_shared<AttributeParameterRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ParameterActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementSetActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementModifyActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementSetActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementModifyActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ParameterActionXmlParser::SubElementSetActionParser::SubElementSetActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ParameterActionXmlParser::SubElementSetActionParser::SubElementSetActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterSetActionXmlParser = std::make_shared<ParameterSetActionXmlParser>(messageLogger, filename);
+            _parameterSetActionXmlParser = std::make_shared<ParameterSetActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ParameterActionXmlParser::SubElementSetActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15733,9 +15745,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SET_ACTION
                     };
         }
-        ParameterActionXmlParser::SubElementModifyActionParser::SubElementModifyActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ParameterActionXmlParser::SubElementModifyActionParser::SubElementModifyActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterModifyActionXmlParser = std::make_shared<ParameterModifyActionXmlParser>(messageLogger, filename);
+            _parameterModifyActionXmlParser = std::make_shared<ParameterModifyActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ParameterActionXmlParser::SubElementModifyActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15774,10 +15786,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ParameterActionXmlParser::ParameterActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterActionXmlParser::ParameterActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15787,7 +15799,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterAddValueRuleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterAddValueRuleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterAddValueRuleXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -15796,7 +15808,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15831,7 +15843,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -15842,10 +15854,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ParameterAddValueRuleXmlParser::ParameterAddValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterAddValueRuleXmlParser::ParameterAddValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15855,7 +15867,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterAssignmentXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterAssignmentXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterAssignmentXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -15864,7 +15876,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeParameterRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeParameterRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeParameterRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15885,11 +15897,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_REF, std::make_shared<AttributeParameterRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_REF, std::make_shared<AttributeParameterRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15924,7 +15936,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -15935,10 +15947,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ParameterAssignmentXmlParser::ParameterAssignmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterAssignmentXmlParser::ParameterAssignmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15948,7 +15960,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -15957,7 +15969,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeParameterRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeParameterRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeParameterRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15989,11 +16001,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_REF, std::make_shared<AttributeParameterRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_REF, std::make_shared<AttributeParameterRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -16020,7 +16032,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (Rule::IsDeprecated(kResult))
+                        if (Rule::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  Rule::GetDeprecatedVersion(kResult) +"'. " + Rule::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -16037,11 +16049,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -16076,7 +16088,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -16087,10 +16099,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ParameterConditionXmlParser::ParameterConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterConditionXmlParser::ParameterConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 

--- a/cpp/openScenarioLib/generated/v1_1/xmlParser/XmlParsers2V1_1.cpp
+++ b/cpp/openScenarioLib/generated/v1_1/xmlParser/XmlParsers2V1_1.cpp
@@ -35,7 +35,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterDeclarationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterDeclarationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterDeclarationXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -44,7 +44,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -63,11 +63,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeParameterType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeParameterType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeParameterType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -94,7 +94,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (ParameterType::IsDeprecated(kResult))
+                        if (ParameterType::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  ParameterType::GetDeprecatedVersion(kResult) +"'. " + ParameterType::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -111,11 +111,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_TYPE, std::make_shared<AttributeParameterType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_TYPE, std::make_shared<AttributeParameterType>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -150,20 +150,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ParameterDeclarationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementConstraintGroupsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementConstraintGroupsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ParameterDeclarationXmlParser::SubElementConstraintGroupsParser::SubElementConstraintGroupsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ParameterDeclarationXmlParser::SubElementConstraintGroupsParser::SubElementConstraintGroupsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _valueConstraintGroupXmlParser = std::make_shared<ValueConstraintGroupXmlParser>(messageLogger, filename);
+            _valueConstraintGroupXmlParser = std::make_shared<ValueConstraintGroupXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ParameterDeclarationXmlParser::SubElementConstraintGroupsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -203,10 +203,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ParameterDeclarationXmlParser::ParameterDeclarationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterDeclarationXmlParser::ParameterDeclarationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -216,7 +216,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterModifyActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ParameterModifyActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterModifyActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -229,13 +229,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ParameterModifyActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRuleParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRuleParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ParameterModifyActionXmlParser::SubElementRuleParser::SubElementRuleParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ParameterModifyActionXmlParser::SubElementRuleParser::SubElementRuleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _modifyRuleXmlParser = std::make_shared<ModifyRuleXmlParser>(messageLogger, filename);
+            _modifyRuleXmlParser = std::make_shared<ModifyRuleXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ParameterModifyActionXmlParser::SubElementRuleParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -274,10 +274,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ParameterModifyActionXmlParser::ParameterModifyActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterModifyActionXmlParser::ParameterModifyActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -287,7 +287,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterMultiplyByValueRuleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterMultiplyByValueRuleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterMultiplyByValueRuleXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -296,7 +296,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -331,7 +331,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -342,10 +342,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ParameterMultiplyByValueRuleXmlParser::ParameterMultiplyByValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterMultiplyByValueRuleXmlParser::ParameterMultiplyByValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -355,7 +355,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterSetActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterSetActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterSetActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -364,7 +364,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -399,7 +399,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -410,10 +410,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ParameterSetActionXmlParser::ParameterSetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterSetActionXmlParser::ParameterSetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -423,7 +423,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterValueDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterValueDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterValueDistributionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -435,14 +435,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ParameterValueDistributionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementScenarioFileParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementDistributionDefinitionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementScenarioFileParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementDistributionDefinitionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ParameterValueDistributionXmlParser::SubElementScenarioFileParser::SubElementScenarioFileParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ParameterValueDistributionXmlParser::SubElementScenarioFileParser::SubElementScenarioFileParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _fileXmlParser = std::make_shared<FileXmlParser>(messageLogger, filename);
+            _fileXmlParser = std::make_shared<FileXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ParameterValueDistributionXmlParser::SubElementScenarioFileParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -480,9 +480,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SCENARIO_FILE
                     };
         }
-        ParameterValueDistributionXmlParser::SubElementDistributionDefinitionParser::SubElementDistributionDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ParameterValueDistributionXmlParser::SubElementDistributionDefinitionParser::SubElementDistributionDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _distributionDefinitionXmlParser = std::make_shared<DistributionDefinitionXmlParser>(messageLogger, filename);
+            _distributionDefinitionXmlParser = std::make_shared<DistributionDefinitionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ParameterValueDistributionXmlParser::SubElementDistributionDefinitionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -523,10 +523,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ParameterValueDistributionXmlParser::ParameterValueDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterValueDistributionXmlParser::ParameterValueDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -536,19 +536,19 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterValueDistributionDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterValueDistributionDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
 
         std::vector<std::shared_ptr<IElementParser>> ParameterValueDistributionDefinitionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementParameterValueDistributionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementParameterValueDistributionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ParameterValueDistributionDefinitionXmlParser::SubElementParameterValueDistributionParser::SubElementParameterValueDistributionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ParameterValueDistributionDefinitionXmlParser::SubElementParameterValueDistributionParser::SubElementParameterValueDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterValueDistributionXmlParser = std::make_shared<ParameterValueDistributionXmlParser>(messageLogger, filename);
+            _parameterValueDistributionXmlParser = std::make_shared<ParameterValueDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ParameterValueDistributionDefinitionXmlParser::SubElementParameterValueDistributionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -587,10 +587,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ParameterValueDistributionDefinitionXmlParser::ParameterValueDistributionDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        ParameterValueDistributionDefinitionXmlParser::ParameterValueDistributionDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -600,7 +600,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ParameterValueSetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ParameterValueSetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ParameterValueSetXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -612,13 +612,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ParameterValueSetXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementParameterAssignmentsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementParameterAssignmentsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ParameterValueSetXmlParser::SubElementParameterAssignmentsParser::SubElementParameterAssignmentsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ParameterValueSetXmlParser::SubElementParameterAssignmentsParser::SubElementParameterAssignmentsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterAssignmentXmlParser = std::make_shared<ParameterAssignmentXmlParser>(messageLogger, filename);
+            _parameterAssignmentXmlParser = std::make_shared<ParameterAssignmentXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ParameterValueSetXmlParser::SubElementParameterAssignmentsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -658,10 +658,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ParameterValueSetXmlParser::ParameterValueSetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ParameterValueSetXmlParser::ParameterValueSetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -671,7 +671,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PedestrianXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            PedestrianXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PedestrianXmlParser::GetAttributeNameToAttributeParserMap()
@@ -681,7 +681,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMass: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMass(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMass(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -716,11 +716,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MASS, std::make_shared<AttributeMass>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MASS, std::make_shared<AttributeMass>(_messageLogger, _filename, _parserOptions)));
             class AttributeModel: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeModel(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeModel(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -748,9 +748,12 @@ namespace NET_ASAM_OPENSCENARIO
                     typedObject->PutPropertyEndMarker(OSC_CONSTANTS::ATTRIBUTE__MODEL, std::make_shared<Textmarker>(endMarker));
                      
                     
-                    // This element is deprecated
-					auto msg = FileContentMessage("Attribute '" + attributeName + "' is deprecated since standard version 'n/a'. Comment: 'n/a'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), this->_filename));
-					this->_messageLogger.LogMessage(msg);
+					if (!_parserOptions.IsOptionSetSupressDeprecationWarnings())
+					{
+						// This element is deprecated
+						auto msg = FileContentMessage("Attribute '" + attributeName + "' is deprecated since standard version 'n/a'. Comment: 'n/a'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), this->_filename));
+						this->_messageLogger.LogMessage(msg);
+					}
                 }
 
                 int GetMinOccur() override
@@ -758,11 +761,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MODEL, std::make_shared<AttributeModel>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MODEL, std::make_shared<AttributeModel>(_messageLogger, _filename, _parserOptions)));
             class AttributeModel3d: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeModel3d(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeModel3d(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -797,11 +800,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MODEL3D, std::make_shared<AttributeModel3d>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MODEL3D, std::make_shared<AttributeModel3d>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -836,11 +839,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributePedestrianCategory: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePedestrianCategory(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePedestrianCategory(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -867,7 +870,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (PedestrianCategory::IsDeprecated(kResult))
+                        if (PedestrianCategory::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  PedestrianCategory::GetDeprecatedVersion(kResult) +"'. " + PedestrianCategory::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -884,22 +887,22 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PEDESTRIAN_CATEGORY, std::make_shared<AttributePedestrianCategory>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PEDESTRIAN_CATEGORY, std::make_shared<AttributePedestrianCategory>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> PedestrianXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PedestrianXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PedestrianXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PedestrianXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -935,9 +938,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        PedestrianXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PedestrianXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename);
+            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PedestrianXmlParser::SubElementBoundingBoxParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -975,9 +978,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__BOUNDING_BOX
                     };
         }
-        PedestrianXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PedestrianXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename);
+            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PedestrianXmlParser::SubElementPropertiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1016,10 +1019,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PedestrianXmlParser::PedestrianXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PedestrianXmlParser::PedestrianXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1029,7 +1032,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PedestrianCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            PedestrianCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PedestrianCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -1042,13 +1045,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> PedestrianCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PedestrianCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PedestrianCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PedestrianCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1087,10 +1090,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PedestrianCatalogLocationXmlParser::PedestrianCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PedestrianCatalogLocationXmlParser::PedestrianCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1100,7 +1103,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PerformanceXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PerformanceXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PerformanceXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1109,7 +1112,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMaxAcceleration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxAcceleration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxAcceleration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1144,11 +1147,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_ACCELERATION, std::make_shared<AttributeMaxAcceleration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_ACCELERATION, std::make_shared<AttributeMaxAcceleration>(_messageLogger, _filename, _parserOptions)));
             class AttributeMaxDeceleration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxDeceleration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxDeceleration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1183,11 +1186,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_DECELERATION, std::make_shared<AttributeMaxDeceleration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_DECELERATION, std::make_shared<AttributeMaxDeceleration>(_messageLogger, _filename, _parserOptions)));
             class AttributeMaxSpeed: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMaxSpeed(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMaxSpeed(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1222,7 +1225,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_SPEED, std::make_shared<AttributeMaxSpeed>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MAX_SPEED, std::make_shared<AttributeMaxSpeed>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -1233,10 +1236,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        PerformanceXmlParser::PerformanceXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PerformanceXmlParser::PerformanceXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1246,7 +1249,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PhaseXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PhaseXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PhaseXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1255,7 +1258,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDuration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1290,11 +1293,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1329,20 +1332,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> PhaseXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTrafficSignalStatesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTrafficSignalStatesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PhaseXmlParser::SubElementTrafficSignalStatesParser::SubElementTrafficSignalStatesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PhaseXmlParser::SubElementTrafficSignalStatesParser::SubElementTrafficSignalStatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSignalStateXmlParser = std::make_shared<TrafficSignalStateXmlParser>(messageLogger, filename);
+            _trafficSignalStateXmlParser = std::make_shared<TrafficSignalStateXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PhaseXmlParser::SubElementTrafficSignalStatesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1382,10 +1385,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PhaseXmlParser::PhaseXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PhaseXmlParser::PhaseXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1395,7 +1398,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PoissonDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PoissonDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PoissonDistributionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1404,7 +1407,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeExpectedValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeExpectedValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeExpectedValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -1439,20 +1442,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__EXPECTED_VALUE, std::make_shared<AttributeExpectedValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__EXPECTED_VALUE, std::make_shared<AttributeExpectedValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> PoissonDistributionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRangeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRangeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PoissonDistributionXmlParser::SubElementRangeParser::SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PoissonDistributionXmlParser::SubElementRangeParser::SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _rangeXmlParser = std::make_shared<RangeXmlParser>(messageLogger, filename);
+            _rangeXmlParser = std::make_shared<RangeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PoissonDistributionXmlParser::SubElementRangeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1491,10 +1494,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PoissonDistributionXmlParser::PoissonDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PoissonDistributionXmlParser::PoissonDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1504,7 +1507,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PolylineXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PolylineXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PolylineXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -1516,13 +1519,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> PolylineXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementVerticesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementVerticesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PolylineXmlParser::SubElementVerticesParser::SubElementVerticesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PolylineXmlParser::SubElementVerticesParser::SubElementVerticesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _vertexXmlParser = std::make_shared<VertexXmlParser>(messageLogger, filename);
+            _vertexXmlParser = std::make_shared<VertexXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PolylineXmlParser::SubElementVerticesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1562,10 +1565,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PolylineXmlParser::PolylineXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PolylineXmlParser::PolylineXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -1575,7 +1578,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            PositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -1588,22 +1591,22 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> PositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementWorldPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRelativeWorldPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRelativeObjectPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRoadPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRelativeRoadPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementLanePositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRelativeLanePositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRoutePositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementGeoPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrajectoryPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementWorldPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRelativeWorldPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRelativeObjectPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRoadPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRelativeRoadPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementLanePositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRelativeLanePositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRoutePositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementGeoPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrajectoryPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PositionXmlParser::SubElementWorldPositionParser::SubElementWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementWorldPositionParser::SubElementWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _worldPositionXmlParser = std::make_shared<WorldPositionXmlParser>(messageLogger, filename);
+            _worldPositionXmlParser = std::make_shared<WorldPositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementWorldPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1641,9 +1644,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__WORLD_POSITION
                     };
         }
-        PositionXmlParser::SubElementRelativeWorldPositionParser::SubElementRelativeWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementRelativeWorldPositionParser::SubElementRelativeWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeWorldPositionXmlParser = std::make_shared<RelativeWorldPositionXmlParser>(messageLogger, filename);
+            _relativeWorldPositionXmlParser = std::make_shared<RelativeWorldPositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementRelativeWorldPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1681,9 +1684,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_WORLD_POSITION
                     };
         }
-        PositionXmlParser::SubElementRelativeObjectPositionParser::SubElementRelativeObjectPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementRelativeObjectPositionParser::SubElementRelativeObjectPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeObjectPositionXmlParser = std::make_shared<RelativeObjectPositionXmlParser>(messageLogger, filename);
+            _relativeObjectPositionXmlParser = std::make_shared<RelativeObjectPositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementRelativeObjectPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1721,9 +1724,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_OBJECT_POSITION
                     };
         }
-        PositionXmlParser::SubElementRoadPositionParser::SubElementRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementRoadPositionParser::SubElementRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _roadPositionXmlParser = std::make_shared<RoadPositionXmlParser>(messageLogger, filename);
+            _roadPositionXmlParser = std::make_shared<RoadPositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementRoadPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1761,9 +1764,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ROAD_POSITION
                     };
         }
-        PositionXmlParser::SubElementRelativeRoadPositionParser::SubElementRelativeRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementRelativeRoadPositionParser::SubElementRelativeRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeRoadPositionXmlParser = std::make_shared<RelativeRoadPositionXmlParser>(messageLogger, filename);
+            _relativeRoadPositionXmlParser = std::make_shared<RelativeRoadPositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementRelativeRoadPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1801,9 +1804,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_ROAD_POSITION
                     };
         }
-        PositionXmlParser::SubElementLanePositionParser::SubElementLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementLanePositionParser::SubElementLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _lanePositionXmlParser = std::make_shared<LanePositionXmlParser>(messageLogger, filename);
+            _lanePositionXmlParser = std::make_shared<LanePositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementLanePositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1841,9 +1844,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LANE_POSITION
                     };
         }
-        PositionXmlParser::SubElementRelativeLanePositionParser::SubElementRelativeLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementRelativeLanePositionParser::SubElementRelativeLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeLanePositionXmlParser = std::make_shared<RelativeLanePositionXmlParser>(messageLogger, filename);
+            _relativeLanePositionXmlParser = std::make_shared<RelativeLanePositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementRelativeLanePositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1881,9 +1884,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_LANE_POSITION
                     };
         }
-        PositionXmlParser::SubElementRoutePositionParser::SubElementRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementRoutePositionParser::SubElementRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _routePositionXmlParser = std::make_shared<RoutePositionXmlParser>(messageLogger, filename);
+            _routePositionXmlParser = std::make_shared<RoutePositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementRoutePositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1921,9 +1924,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ROUTE_POSITION
                     };
         }
-        PositionXmlParser::SubElementGeoPositionParser::SubElementGeoPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementGeoPositionParser::SubElementGeoPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _geoPositionXmlParser = std::make_shared<GeoPositionXmlParser>(messageLogger, filename);
+            _geoPositionXmlParser = std::make_shared<GeoPositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementGeoPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -1961,9 +1964,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__GEO_POSITION
                     };
         }
-        PositionXmlParser::SubElementTrajectoryPositionParser::SubElementTrajectoryPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PositionXmlParser::SubElementTrajectoryPositionParser::SubElementTrajectoryPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trajectoryPositionXmlParser = std::make_shared<TrajectoryPositionXmlParser>(messageLogger, filename);
+            _trajectoryPositionXmlParser = std::make_shared<TrajectoryPositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PositionXmlParser::SubElementTrajectoryPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2002,10 +2005,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PositionXmlParser::PositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PositionXmlParser::PositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2015,7 +2018,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PositionInLaneCoordinatesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PositionInLaneCoordinatesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PositionInLaneCoordinatesXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2024,7 +2027,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeLaneId: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLaneId(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLaneId(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2059,11 +2062,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LANE_ID, std::make_shared<AttributeLaneId>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LANE_ID, std::make_shared<AttributeLaneId>(_messageLogger, _filename, _parserOptions)));
             class AttributeLaneOffset: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLaneOffset(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLaneOffset(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2098,11 +2101,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LANE_OFFSET, std::make_shared<AttributeLaneOffset>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LANE_OFFSET, std::make_shared<AttributeLaneOffset>(_messageLogger, _filename, _parserOptions)));
             class AttributePathS: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePathS(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePathS(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2137,7 +2140,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PATH_S, std::make_shared<AttributePathS>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PATH_S, std::make_shared<AttributePathS>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -2148,10 +2151,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        PositionInLaneCoordinatesXmlParser::PositionInLaneCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PositionInLaneCoordinatesXmlParser::PositionInLaneCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2161,7 +2164,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PositionInRoadCoordinatesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PositionInRoadCoordinatesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PositionInRoadCoordinatesXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2170,7 +2173,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributePathS: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePathS(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePathS(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2205,11 +2208,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PATH_S, std::make_shared<AttributePathS>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PATH_S, std::make_shared<AttributePathS>(_messageLogger, _filename, _parserOptions)));
             class AttributeT: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeT(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeT(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2244,7 +2247,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__T, std::make_shared<AttributeT>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__T, std::make_shared<AttributeT>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -2255,10 +2258,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        PositionInRoadCoordinatesXmlParser::PositionInRoadCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PositionInRoadCoordinatesXmlParser::PositionInRoadCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2268,7 +2271,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PositionOfCurrentEntityXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PositionOfCurrentEntityXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PositionOfCurrentEntityXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2277,7 +2280,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2309,7 +2312,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -2320,10 +2323,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        PositionOfCurrentEntityXmlParser::PositionOfCurrentEntityXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PositionOfCurrentEntityXmlParser::PositionOfCurrentEntityXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2333,7 +2336,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PrecipitationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PrecipitationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PrecipitationXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2342,7 +2345,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeIntensity: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeIntensity(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeIntensity(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2370,9 +2373,12 @@ namespace NET_ASAM_OPENSCENARIO
                     typedObject->PutPropertyEndMarker(OSC_CONSTANTS::ATTRIBUTE__INTENSITY, std::make_shared<Textmarker>(endMarker));
                      
                     
-                    // This element is deprecated
-					auto msg = FileContentMessage("Attribute '" + attributeName + "' is deprecated since standard version '1.1'. Comment: 'Use instead precipitationIntensity.'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), this->_filename));
-					this->_messageLogger.LogMessage(msg);
+					if (!_parserOptions.IsOptionSetSupressDeprecationWarnings())
+					{
+						// This element is deprecated
+						auto msg = FileContentMessage("Attribute '" + attributeName + "' is deprecated since standard version '1.1'. Comment: 'Use instead precipitationIntensity.'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), this->_filename));
+						this->_messageLogger.LogMessage(msg);
+					}
                 }
 
                 int GetMinOccur() override
@@ -2380,11 +2386,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__INTENSITY, std::make_shared<AttributeIntensity>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__INTENSITY, std::make_shared<AttributeIntensity>(_messageLogger, _filename, _parserOptions)));
             class AttributePrecipitationIntensity: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePrecipitationIntensity(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePrecipitationIntensity(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2419,11 +2425,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PRECIPITATION_INTENSITY, std::make_shared<AttributePrecipitationIntensity>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PRECIPITATION_INTENSITY, std::make_shared<AttributePrecipitationIntensity>(_messageLogger, _filename, _parserOptions)));
             class AttributePrecipitationType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePrecipitationType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePrecipitationType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2450,7 +2456,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (PrecipitationType::IsDeprecated(kResult))
+                        if (PrecipitationType::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  PrecipitationType::GetDeprecatedVersion(kResult) +"'. " + PrecipitationType::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -2467,7 +2473,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PRECIPITATION_TYPE, std::make_shared<AttributePrecipitationType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PRECIPITATION_TYPE, std::make_shared<AttributePrecipitationType>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -2478,10 +2484,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        PrecipitationXmlParser::PrecipitationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PrecipitationXmlParser::PrecipitationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2491,7 +2497,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PrivateXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PrivateXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PrivateXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2500,7 +2506,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -2532,20 +2538,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> PrivateXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPrivateActionsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPrivateActionsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PrivateXmlParser::SubElementPrivateActionsParser::SubElementPrivateActionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateXmlParser::SubElementPrivateActionsParser::SubElementPrivateActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _privateActionXmlParser = std::make_shared<PrivateActionXmlParser>(messageLogger, filename);
+            _privateActionXmlParser = std::make_shared<PrivateActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateXmlParser::SubElementPrivateActionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2585,10 +2591,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PrivateXmlParser::PrivateXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PrivateXmlParser::PrivateXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2598,7 +2604,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PrivateActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            PrivateActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PrivateActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -2611,20 +2617,20 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> PrivateActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementLongitudinalActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementLateralActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementVisibilityActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementSynchronizeActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementActivateControllerActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementControllerActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTeleportActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRoutingActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementLongitudinalActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementLateralActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementVisibilityActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementSynchronizeActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementActivateControllerActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementControllerActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTeleportActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRoutingActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PrivateActionXmlParser::SubElementLongitudinalActionParser::SubElementLongitudinalActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementLongitudinalActionParser::SubElementLongitudinalActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _longitudinalActionXmlParser = std::make_shared<LongitudinalActionXmlParser>(messageLogger, filename);
+            _longitudinalActionXmlParser = std::make_shared<LongitudinalActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementLongitudinalActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2662,9 +2668,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LONGITUDINAL_ACTION
                     };
         }
-        PrivateActionXmlParser::SubElementLateralActionParser::SubElementLateralActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementLateralActionParser::SubElementLateralActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _lateralActionXmlParser = std::make_shared<LateralActionXmlParser>(messageLogger, filename);
+            _lateralActionXmlParser = std::make_shared<LateralActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementLateralActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2702,9 +2708,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LATERAL_ACTION
                     };
         }
-        PrivateActionXmlParser::SubElementVisibilityActionParser::SubElementVisibilityActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementVisibilityActionParser::SubElementVisibilityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _visibilityActionXmlParser = std::make_shared<VisibilityActionXmlParser>(messageLogger, filename);
+            _visibilityActionXmlParser = std::make_shared<VisibilityActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementVisibilityActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2742,9 +2748,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__VISIBILITY_ACTION
                     };
         }
-        PrivateActionXmlParser::SubElementSynchronizeActionParser::SubElementSynchronizeActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementSynchronizeActionParser::SubElementSynchronizeActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _synchronizeActionXmlParser = std::make_shared<SynchronizeActionXmlParser>(messageLogger, filename);
+            _synchronizeActionXmlParser = std::make_shared<SynchronizeActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementSynchronizeActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2782,9 +2788,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SYNCHRONIZE_ACTION
                     };
         }
-        PrivateActionXmlParser::SubElementActivateControllerActionParser::SubElementActivateControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementActivateControllerActionParser::SubElementActivateControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _activateControllerActionXmlParser = std::make_shared<ActivateControllerActionXmlParser>(messageLogger, filename);
+            _activateControllerActionXmlParser = std::make_shared<ActivateControllerActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementActivateControllerActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2798,11 +2804,14 @@ namespace NET_ASAM_OPENSCENARIO
             typedObject->SetActivateControllerAction(activateControllerAction);
             
             
-            // This element is deprecated
-            std::string name = indexedElement->GetElement()->Name();
-        	Position startPosition = indexedElement->GetStartElementLocation();
-			auto msg = FileContentMessage("Element '" + name + "' is deprecated since standard version '1.1'. Comment: 'Moved to ControllerAction'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), _activateControllerActionXmlParser->_filename));
-			_activateControllerActionXmlParser->_messageLogger.LogMessage(msg);
+			if (!_activateControllerActionXmlParser->_parserOptions.IsOptionSetSupressDeprecationWarnings())
+			{
+				// This element is deprecated
+				std::string name = indexedElement->GetElement()->Name();
+				Position startPosition = indexedElement->GetStartElementLocation();
+				auto msg = FileContentMessage("Element '" + name + "' is deprecated since standard version '1.1'. Comment: 'Moved to ControllerAction'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), _activateControllerActionXmlParser->_filename));
+				_activateControllerActionXmlParser->_messageLogger.LogMessage(msg);
+			}
         }
         
         int PrivateActionXmlParser::SubElementActivateControllerActionParser::GetMinOccur() 
@@ -2827,9 +2836,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ACTIVATE_CONTROLLER_ACTION
                     };
         }
-        PrivateActionXmlParser::SubElementControllerActionParser::SubElementControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementControllerActionParser::SubElementControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerActionXmlParser = std::make_shared<ControllerActionXmlParser>(messageLogger, filename);
+            _controllerActionXmlParser = std::make_shared<ControllerActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementControllerActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2867,9 +2876,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CONTROLLER_ACTION
                     };
         }
-        PrivateActionXmlParser::SubElementTeleportActionParser::SubElementTeleportActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementTeleportActionParser::SubElementTeleportActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _teleportActionXmlParser = std::make_shared<TeleportActionXmlParser>(messageLogger, filename);
+            _teleportActionXmlParser = std::make_shared<TeleportActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementTeleportActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2907,9 +2916,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TELEPORT_ACTION
                     };
         }
-        PrivateActionXmlParser::SubElementRoutingActionParser::SubElementRoutingActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PrivateActionXmlParser::SubElementRoutingActionParser::SubElementRoutingActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _routingActionXmlParser = std::make_shared<RoutingActionXmlParser>(messageLogger, filename);
+            _routingActionXmlParser = std::make_shared<RoutingActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PrivateActionXmlParser::SubElementRoutingActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -2948,10 +2957,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PrivateActionXmlParser::PrivateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PrivateActionXmlParser::PrivateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -2961,7 +2970,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ProbabilityDistributionSetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ProbabilityDistributionSetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ProbabilityDistributionSetXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -2973,13 +2982,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ProbabilityDistributionSetXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementElementsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementElementsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ProbabilityDistributionSetXmlParser::SubElementElementsParser::SubElementElementsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ProbabilityDistributionSetXmlParser::SubElementElementsParser::SubElementElementsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _probabilityDistributionSetElementXmlParser = std::make_shared<ProbabilityDistributionSetElementXmlParser>(messageLogger, filename);
+            _probabilityDistributionSetElementXmlParser = std::make_shared<ProbabilityDistributionSetElementXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ProbabilityDistributionSetXmlParser::SubElementElementsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3019,10 +3028,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ProbabilityDistributionSetXmlParser::ProbabilityDistributionSetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ProbabilityDistributionSetXmlParser::ProbabilityDistributionSetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3032,7 +3041,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ProbabilityDistributionSetElementXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ProbabilityDistributionSetElementXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ProbabilityDistributionSetElementXmlParser::GetAttributeNameToAttributeParserMap()
@@ -3042,7 +3051,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3077,11 +3086,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             class AttributeWeight: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3116,7 +3125,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -3127,10 +3136,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ProbabilityDistributionSetElementXmlParser::ProbabilityDistributionSetElementXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ProbabilityDistributionSetElementXmlParser::ProbabilityDistributionSetElementXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3140,7 +3149,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PropertiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PropertiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PropertiesXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3152,14 +3161,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> PropertiesXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementFilesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementFilesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        PropertiesXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PropertiesXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _propertyXmlParser = std::make_shared<PropertyXmlParser>(messageLogger, filename);
+            _propertyXmlParser = std::make_shared<PropertyXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PropertiesXmlParser::SubElementPropertiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3198,9 +3207,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PROPERTY
                     };
         }
-        PropertiesXmlParser::SubElementFilesParser::SubElementFilesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        PropertiesXmlParser::SubElementFilesParser::SubElementFilesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _fileXmlParser = std::make_shared<FileXmlParser>(messageLogger, filename);
+            _fileXmlParser = std::make_shared<FileXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void PropertiesXmlParser::SubElementFilesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3240,10 +3249,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        PropertiesXmlParser::PropertiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PropertiesXmlParser::PropertiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3253,7 +3262,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            PropertyXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            PropertyXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> PropertyXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3262,7 +3271,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3297,11 +3306,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3336,7 +3345,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -3347,10 +3356,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        PropertyXmlParser::PropertyXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        PropertyXmlParser::PropertyXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3360,7 +3369,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RangeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RangeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RangeXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3369,7 +3378,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeLowerLimit: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeLowerLimit(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeLowerLimit(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3404,11 +3413,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LOWER_LIMIT, std::make_shared<AttributeLowerLimit>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__LOWER_LIMIT, std::make_shared<AttributeLowerLimit>(_messageLogger, _filename, _parserOptions)));
             class AttributeUpperLimit: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeUpperLimit(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeUpperLimit(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3443,7 +3452,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__UPPER_LIMIT, std::make_shared<AttributeUpperLimit>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__UPPER_LIMIT, std::make_shared<AttributeUpperLimit>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -3454,10 +3463,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        RangeXmlParser::RangeXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RangeXmlParser::RangeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3467,7 +3476,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ReachPositionConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ReachPositionConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ReachPositionConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -3477,7 +3486,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeTolerance: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTolerance(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTolerance(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3512,20 +3521,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TOLERANCE, std::make_shared<AttributeTolerance>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TOLERANCE, std::make_shared<AttributeTolerance>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ReachPositionConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ReachPositionConditionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ReachPositionConditionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ReachPositionConditionXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -3564,10 +3573,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ReachPositionConditionXmlParser::ReachPositionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ReachPositionConditionXmlParser::ReachPositionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3577,7 +3586,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeDistanceConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RelativeDistanceConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeDistanceConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -3586,7 +3595,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeCoordinateSystem: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCoordinateSystem(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCoordinateSystem(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3613,7 +3622,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (CoordinateSystem::IsDeprecated(kResult))
+                        if (CoordinateSystem::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  CoordinateSystem::GetDeprecatedVersion(kResult) +"'. " + CoordinateSystem::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -3630,11 +3639,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM, std::make_shared<AttributeCoordinateSystem>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM, std::make_shared<AttributeCoordinateSystem>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3666,11 +3675,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeFreespace: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3700,11 +3709,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename, _parserOptions)));
             class AttributeRelativeDistanceType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRelativeDistanceType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRelativeDistanceType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3731,7 +3740,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (RelativeDistanceType::IsDeprecated(kResult))
+                        if (RelativeDistanceType::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  RelativeDistanceType::GetDeprecatedVersion(kResult) +"'. " + RelativeDistanceType::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -3748,11 +3757,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RELATIVE_DISTANCE_TYPE, std::make_shared<AttributeRelativeDistanceType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RELATIVE_DISTANCE_TYPE, std::make_shared<AttributeRelativeDistanceType>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3779,7 +3788,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (Rule::IsDeprecated(kResult))
+                        if (Rule::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  Rule::GetDeprecatedVersion(kResult) +"'. " + Rule::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -3796,11 +3805,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3835,7 +3844,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -3846,10 +3855,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        RelativeDistanceConditionXmlParser::RelativeDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeDistanceConditionXmlParser::RelativeDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -3859,7 +3868,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeLanePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            RelativeLanePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeLanePositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -3869,7 +3878,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDLane: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDLane(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDLane(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3904,11 +3913,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__D_LANE, std::make_shared<AttributeDLane>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__D_LANE, std::make_shared<AttributeDLane>(_messageLogger, _filename, _parserOptions)));
             class AttributeDs: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDs(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDs(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3943,11 +3952,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DS, std::make_shared<AttributeDs>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DS, std::make_shared<AttributeDs>(_messageLogger, _filename, _parserOptions)));
             class AttributeDsLane: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDsLane(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDsLane(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -3982,11 +3991,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DS_LANE, std::make_shared<AttributeDsLane>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DS_LANE, std::make_shared<AttributeDsLane>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4018,11 +4027,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeOffset: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4057,20 +4066,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RelativeLanePositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RelativeLanePositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RelativeLanePositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RelativeLanePositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4109,10 +4118,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RelativeLanePositionXmlParser::RelativeLanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeLanePositionXmlParser::RelativeLanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4122,7 +4131,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeObjectPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            RelativeObjectPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeObjectPositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -4132,7 +4141,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDx: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDx(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDx(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4167,11 +4176,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DX, std::make_shared<AttributeDx>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DX, std::make_shared<AttributeDx>(_messageLogger, _filename, _parserOptions)));
             class AttributeDy: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDy(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDy(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4206,11 +4215,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DY, std::make_shared<AttributeDy>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DY, std::make_shared<AttributeDy>(_messageLogger, _filename, _parserOptions)));
             class AttributeDz: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDz(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDz(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4245,11 +4254,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DZ, std::make_shared<AttributeDz>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DZ, std::make_shared<AttributeDz>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4281,20 +4290,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RelativeObjectPositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RelativeObjectPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RelativeObjectPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RelativeObjectPositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4333,10 +4342,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RelativeObjectPositionXmlParser::RelativeObjectPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeObjectPositionXmlParser::RelativeObjectPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4346,7 +4355,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeRoadPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            RelativeRoadPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeRoadPositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -4356,7 +4365,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDs: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDs(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDs(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4391,11 +4400,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DS, std::make_shared<AttributeDs>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DS, std::make_shared<AttributeDs>(_messageLogger, _filename, _parserOptions)));
             class AttributeDt: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDt(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDt(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4430,11 +4439,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DT, std::make_shared<AttributeDt>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DT, std::make_shared<AttributeDt>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4466,20 +4475,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RelativeRoadPositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RelativeRoadPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RelativeRoadPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RelativeRoadPositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4518,10 +4527,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RelativeRoadPositionXmlParser::RelativeRoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeRoadPositionXmlParser::RelativeRoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4531,7 +4540,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeSpeedConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RelativeSpeedConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeSpeedConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4540,7 +4549,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4572,11 +4581,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4603,7 +4612,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (Rule::IsDeprecated(kResult))
+                        if (Rule::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  Rule::GetDeprecatedVersion(kResult) +"'. " + Rule::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -4620,11 +4629,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4659,7 +4668,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -4670,10 +4679,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        RelativeSpeedConditionXmlParser::RelativeSpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeSpeedConditionXmlParser::RelativeSpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4683,7 +4692,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeSpeedToMasterXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RelativeSpeedToMasterXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeSpeedToMasterXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4692,7 +4701,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeSpeedTargetValueType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeSpeedTargetValueType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeSpeedTargetValueType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4719,7 +4728,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (SpeedTargetValueType::IsDeprecated(kResult))
+                        if (SpeedTargetValueType::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  SpeedTargetValueType::GetDeprecatedVersion(kResult) +"'. " + SpeedTargetValueType::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -4736,11 +4745,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SPEED_TARGET_VALUE_TYPE, std::make_shared<AttributeSpeedTargetValueType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SPEED_TARGET_VALUE_TYPE, std::make_shared<AttributeSpeedTargetValueType>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4775,20 +4784,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RelativeSpeedToMasterXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementSteadyStateParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementSteadyStateParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RelativeSpeedToMasterXmlParser::SubElementSteadyStateParser::SubElementSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RelativeSpeedToMasterXmlParser::SubElementSteadyStateParser::SubElementSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _steadyStateXmlParser = std::make_shared<SteadyStateXmlParser>(messageLogger, filename);
+            _steadyStateXmlParser = std::make_shared<SteadyStateXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RelativeSpeedToMasterXmlParser::SubElementSteadyStateParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -4829,10 +4838,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RelativeSpeedToMasterXmlParser::RelativeSpeedToMasterXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeSpeedToMasterXmlParser::RelativeSpeedToMasterXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4842,7 +4851,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeTargetLaneXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RelativeTargetLaneXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeTargetLaneXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4851,7 +4860,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4883,11 +4892,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4922,7 +4931,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -4933,10 +4942,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        RelativeTargetLaneXmlParser::RelativeTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeTargetLaneXmlParser::RelativeTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -4946,7 +4955,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeTargetLaneOffsetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RelativeTargetLaneOffsetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeTargetLaneOffsetXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -4955,7 +4964,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -4987,11 +4996,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5026,7 +5035,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -5037,10 +5046,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        RelativeTargetLaneOffsetXmlParser::RelativeTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeTargetLaneOffsetXmlParser::RelativeTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5050,7 +5059,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeTargetSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RelativeTargetSpeedXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeTargetSpeedXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -5059,7 +5068,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeContinuous: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeContinuous(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5089,11 +5098,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CONTINUOUS, std::make_shared<AttributeContinuous>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5125,11 +5134,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeSpeedTargetValueType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeSpeedTargetValueType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeSpeedTargetValueType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5156,7 +5165,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (SpeedTargetValueType::IsDeprecated(kResult))
+                        if (SpeedTargetValueType::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  SpeedTargetValueType::GetDeprecatedVersion(kResult) +"'. " + SpeedTargetValueType::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -5173,11 +5182,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SPEED_TARGET_VALUE_TYPE, std::make_shared<AttributeSpeedTargetValueType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SPEED_TARGET_VALUE_TYPE, std::make_shared<AttributeSpeedTargetValueType>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5212,7 +5221,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -5223,10 +5232,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        RelativeTargetSpeedXmlParser::RelativeTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeTargetSpeedXmlParser::RelativeTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5236,7 +5245,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RelativeWorldPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            RelativeWorldPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RelativeWorldPositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -5246,7 +5255,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDx: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDx(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDx(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5281,11 +5290,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DX, std::make_shared<AttributeDx>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DX, std::make_shared<AttributeDx>(_messageLogger, _filename, _parserOptions)));
             class AttributeDy: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDy(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDy(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5320,11 +5329,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DY, std::make_shared<AttributeDy>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DY, std::make_shared<AttributeDy>(_messageLogger, _filename, _parserOptions)));
             class AttributeDz: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDz(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDz(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5359,11 +5368,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DZ, std::make_shared<AttributeDz>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DZ, std::make_shared<AttributeDz>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5395,20 +5404,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RelativeWorldPositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RelativeWorldPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RelativeWorldPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RelativeWorldPositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5447,10 +5456,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RelativeWorldPositionXmlParser::RelativeWorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RelativeWorldPositionXmlParser::RelativeWorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5460,7 +5469,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RoadConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RoadConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RoadConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -5469,7 +5478,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeFrictionScaleFactor: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFrictionScaleFactor(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFrictionScaleFactor(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5504,20 +5513,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FRICTION_SCALE_FACTOR, std::make_shared<AttributeFrictionScaleFactor>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FRICTION_SCALE_FACTOR, std::make_shared<AttributeFrictionScaleFactor>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RoadConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RoadConditionXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoadConditionXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename);
+            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoadConditionXmlParser::SubElementPropertiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5556,10 +5565,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RoadConditionXmlParser::RoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RoadConditionXmlParser::RoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5569,7 +5578,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RoadNetworkXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RoadNetworkXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RoadNetworkXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -5581,16 +5590,16 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> RoadNetworkXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementLogicFileParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementSceneGraphFileParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementTrafficSignalsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__TRAFFIC_SIGNALS) );
-            result.push_back(std::make_shared<SubElementUsedAreaParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementLogicFileParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementSceneGraphFileParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementTrafficSignalsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__TRAFFIC_SIGNALS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementUsedAreaParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RoadNetworkXmlParser::SubElementLogicFileParser::SubElementLogicFileParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoadNetworkXmlParser::SubElementLogicFileParser::SubElementLogicFileParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _fileXmlParser = std::make_shared<FileXmlParser>(messageLogger, filename);
+            _fileXmlParser = std::make_shared<FileXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoadNetworkXmlParser::SubElementLogicFileParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5628,9 +5637,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__LOGIC_FILE
                     };
         }
-        RoadNetworkXmlParser::SubElementSceneGraphFileParser::SubElementSceneGraphFileParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoadNetworkXmlParser::SubElementSceneGraphFileParser::SubElementSceneGraphFileParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _fileXmlParser = std::make_shared<FileXmlParser>(messageLogger, filename);
+            _fileXmlParser = std::make_shared<FileXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoadNetworkXmlParser::SubElementSceneGraphFileParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5668,9 +5677,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SCENE_GRAPH_FILE
                     };
         }
-        RoadNetworkXmlParser::SubElementTrafficSignalsParser::SubElementTrafficSignalsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoadNetworkXmlParser::SubElementTrafficSignalsParser::SubElementTrafficSignalsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSignalControllerXmlParser = std::make_shared<TrafficSignalControllerXmlParser>(messageLogger, filename);
+            _trafficSignalControllerXmlParser = std::make_shared<TrafficSignalControllerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoadNetworkXmlParser::SubElementTrafficSignalsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5706,9 +5715,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__TRAFFIC_SIGNAL_CONTROLLER};
         }
-        RoadNetworkXmlParser::SubElementUsedAreaParser::SubElementUsedAreaParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoadNetworkXmlParser::SubElementUsedAreaParser::SubElementUsedAreaParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _usedAreaXmlParser = std::make_shared<UsedAreaXmlParser>(messageLogger, filename);
+            _usedAreaXmlParser = std::make_shared<UsedAreaXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoadNetworkXmlParser::SubElementUsedAreaParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5747,10 +5756,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RoadNetworkXmlParser::RoadNetworkXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RoadNetworkXmlParser::RoadNetworkXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5760,7 +5769,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RoadPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            RoadPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RoadPositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -5770,7 +5779,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRoadId: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRoadId(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRoadId(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5805,11 +5814,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ROAD_ID, std::make_shared<AttributeRoadId>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ROAD_ID, std::make_shared<AttributeRoadId>(_messageLogger, _filename, _parserOptions)));
             class AttributeS: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeS(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeS(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5844,11 +5853,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__S, std::make_shared<AttributeS>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__S, std::make_shared<AttributeS>(_messageLogger, _filename, _parserOptions)));
             class AttributeT: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeT(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeT(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5883,20 +5892,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__T, std::make_shared<AttributeT>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__T, std::make_shared<AttributeT>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RoadPositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RoadPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoadPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoadPositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -5935,10 +5944,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RoadPositionXmlParser::RoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RoadPositionXmlParser::RoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -5948,7 +5957,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RouteXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            RouteXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RouteXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -5957,7 +5966,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeClosed: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeClosed(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeClosed(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -5987,11 +5996,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CLOSED, std::make_shared<AttributeClosed>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CLOSED, std::make_shared<AttributeClosed>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6026,21 +6035,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> RouteXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementWaypointsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementWaypointsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RouteXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RouteXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RouteXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6076,9 +6085,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        RouteXmlParser::SubElementWaypointsParser::SubElementWaypointsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RouteXmlParser::SubElementWaypointsParser::SubElementWaypointsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _waypointXmlParser = std::make_shared<WaypointXmlParser>(messageLogger, filename);
+            _waypointXmlParser = std::make_shared<WaypointXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RouteXmlParser::SubElementWaypointsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6118,10 +6127,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RouteXmlParser::RouteXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RouteXmlParser::RouteXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6131,7 +6140,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RouteCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            RouteCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RouteCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -6144,13 +6153,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> RouteCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RouteCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RouteCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RouteCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6189,10 +6198,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RouteCatalogLocationXmlParser::RouteCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RouteCatalogLocationXmlParser::RouteCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6202,7 +6211,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RoutePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            RoutePositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RoutePositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -6215,15 +6224,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> RoutePositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRouteRefParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementInRoutePositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRouteRefParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementInRoutePositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RoutePositionXmlParser::SubElementRouteRefParser::SubElementRouteRefParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoutePositionXmlParser::SubElementRouteRefParser::SubElementRouteRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _routeRefXmlParser = std::make_shared<RouteRefXmlParser>(messageLogger, filename);
+            _routeRefXmlParser = std::make_shared<RouteRefXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoutePositionXmlParser::SubElementRouteRefParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6261,9 +6270,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ROUTE_REF
                     };
         }
-        RoutePositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoutePositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoutePositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6301,9 +6310,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ORIENTATION
                     };
         }
-        RoutePositionXmlParser::SubElementInRoutePositionParser::SubElementInRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoutePositionXmlParser::SubElementInRoutePositionParser::SubElementInRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _inRoutePositionXmlParser = std::make_shared<InRoutePositionXmlParser>(messageLogger, filename);
+            _inRoutePositionXmlParser = std::make_shared<InRoutePositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoutePositionXmlParser::SubElementInRoutePositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6342,10 +6351,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RoutePositionXmlParser::RoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RoutePositionXmlParser::RoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6355,7 +6364,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RouteRefXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            RouteRefXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RouteRefXmlParser::GetAttributeNameToAttributeParserMap()
@@ -6368,14 +6377,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> RouteRefXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRouteParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRouteParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RouteRefXmlParser::SubElementRouteParser::SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RouteRefXmlParser::SubElementRouteParser::SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _routeXmlParser = std::make_shared<RouteXmlParser>(messageLogger, filename);
+            _routeXmlParser = std::make_shared<RouteXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RouteRefXmlParser::SubElementRouteParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6413,9 +6422,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ROUTE
                     };
         }
-        RouteRefXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RouteRefXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RouteRefXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6455,10 +6464,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RouteRefXmlParser::RouteRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RouteRefXmlParser::RouteRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6468,7 +6477,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            RoutingActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            RoutingActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> RoutingActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -6481,15 +6490,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> RoutingActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementAssignRouteActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementFollowTrajectoryActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementAcquirePositionActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementAssignRouteActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementFollowTrajectoryActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementAcquirePositionActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        RoutingActionXmlParser::SubElementAssignRouteActionParser::SubElementAssignRouteActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoutingActionXmlParser::SubElementAssignRouteActionParser::SubElementAssignRouteActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _assignRouteActionXmlParser = std::make_shared<AssignRouteActionXmlParser>(messageLogger, filename);
+            _assignRouteActionXmlParser = std::make_shared<AssignRouteActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoutingActionXmlParser::SubElementAssignRouteActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6527,9 +6536,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ASSIGN_ROUTE_ACTION
                     };
         }
-        RoutingActionXmlParser::SubElementFollowTrajectoryActionParser::SubElementFollowTrajectoryActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoutingActionXmlParser::SubElementFollowTrajectoryActionParser::SubElementFollowTrajectoryActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _followTrajectoryActionXmlParser = std::make_shared<FollowTrajectoryActionXmlParser>(messageLogger, filename);
+            _followTrajectoryActionXmlParser = std::make_shared<FollowTrajectoryActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoutingActionXmlParser::SubElementFollowTrajectoryActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6567,9 +6576,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__FOLLOW_TRAJECTORY_ACTION
                     };
         }
-        RoutingActionXmlParser::SubElementAcquirePositionActionParser::SubElementAcquirePositionActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        RoutingActionXmlParser::SubElementAcquirePositionActionParser::SubElementAcquirePositionActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _acquirePositionActionXmlParser = std::make_shared<AcquirePositionActionXmlParser>(messageLogger, filename);
+            _acquirePositionActionXmlParser = std::make_shared<AcquirePositionActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void RoutingActionXmlParser::SubElementAcquirePositionActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6608,10 +6617,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        RoutingActionXmlParser::RoutingActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        RoutingActionXmlParser::RoutingActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6621,23 +6630,23 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ScenarioDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ScenarioDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
 
         std::vector<std::shared_ptr<IElementParser>> ScenarioDefinitionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementCatalogLocationsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementRoadNetworkParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementEntitiesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStoryboardParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementCatalogLocationsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementRoadNetworkParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementEntitiesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStoryboardParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ScenarioDefinitionXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ScenarioDefinitionXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ScenarioDefinitionXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6673,9 +6682,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        ScenarioDefinitionXmlParser::SubElementCatalogLocationsParser::SubElementCatalogLocationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ScenarioDefinitionXmlParser::SubElementCatalogLocationsParser::SubElementCatalogLocationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogLocationsXmlParser = std::make_shared<CatalogLocationsXmlParser>(messageLogger, filename);
+            _catalogLocationsXmlParser = std::make_shared<CatalogLocationsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ScenarioDefinitionXmlParser::SubElementCatalogLocationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6713,9 +6722,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CATALOG_LOCATIONS
                     };
         }
-        ScenarioDefinitionXmlParser::SubElementRoadNetworkParser::SubElementRoadNetworkParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ScenarioDefinitionXmlParser::SubElementRoadNetworkParser::SubElementRoadNetworkParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _roadNetworkXmlParser = std::make_shared<RoadNetworkXmlParser>(messageLogger, filename);
+            _roadNetworkXmlParser = std::make_shared<RoadNetworkXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ScenarioDefinitionXmlParser::SubElementRoadNetworkParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6753,9 +6762,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ROAD_NETWORK
                     };
         }
-        ScenarioDefinitionXmlParser::SubElementEntitiesParser::SubElementEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ScenarioDefinitionXmlParser::SubElementEntitiesParser::SubElementEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entitiesXmlParser = std::make_shared<EntitiesXmlParser>(messageLogger, filename);
+            _entitiesXmlParser = std::make_shared<EntitiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ScenarioDefinitionXmlParser::SubElementEntitiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6793,9 +6802,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENTITIES
                     };
         }
-        ScenarioDefinitionXmlParser::SubElementStoryboardParser::SubElementStoryboardParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ScenarioDefinitionXmlParser::SubElementStoryboardParser::SubElementStoryboardParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _storyboardXmlParser = std::make_shared<StoryboardXmlParser>(messageLogger, filename);
+            _storyboardXmlParser = std::make_shared<StoryboardXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ScenarioDefinitionXmlParser::SubElementStoryboardParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6834,10 +6843,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ScenarioDefinitionXmlParser::ScenarioDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        ScenarioDefinitionXmlParser::ScenarioDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -6847,7 +6856,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ScenarioObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ScenarioObjectXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ScenarioObjectXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -6856,7 +6865,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -6891,21 +6900,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> ScenarioObjectXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEntityObjectParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementObjectControllerParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEntityObjectParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementObjectControllerParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ScenarioObjectXmlParser::SubElementEntityObjectParser::SubElementEntityObjectParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ScenarioObjectXmlParser::SubElementEntityObjectParser::SubElementEntityObjectParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityObjectXmlParser = std::make_shared<EntityObjectXmlParser>(messageLogger, filename);
+            _entityObjectXmlParser = std::make_shared<EntityObjectXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ScenarioObjectXmlParser::SubElementEntityObjectParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6951,9 +6960,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__EXTERNAL_OBJECT_REFERENCE
                     };
         }
-        ScenarioObjectXmlParser::SubElementObjectControllerParser::SubElementObjectControllerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ScenarioObjectXmlParser::SubElementObjectControllerParser::SubElementObjectControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _objectControllerXmlParser = std::make_shared<ObjectControllerXmlParser>(messageLogger, filename);
+            _objectControllerXmlParser = std::make_shared<ObjectControllerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ScenarioObjectXmlParser::SubElementObjectControllerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -6992,10 +7001,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ScenarioObjectXmlParser::ScenarioObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ScenarioObjectXmlParser::ScenarioObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7005,7 +7014,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SelectedEntitiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            SelectedEntitiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> SelectedEntitiesXmlParser::GetAttributeNameToAttributeParserMap()
@@ -7018,14 +7027,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> SelectedEntitiesXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEntityRefParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementByTypeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEntityRefParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementByTypeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        SelectedEntitiesXmlParser::SubElementEntityRefParser::SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SelectedEntitiesXmlParser::SubElementEntityRefParser::SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename);
+            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SelectedEntitiesXmlParser::SubElementEntityRefParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7064,9 +7073,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ENTITY_REF
                     };
         }
-        SelectedEntitiesXmlParser::SubElementByTypeParser::SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SelectedEntitiesXmlParser::SubElementByTypeParser::SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _byTypeXmlParser = std::make_shared<ByTypeXmlParser>(messageLogger, filename);
+            _byTypeXmlParser = std::make_shared<ByTypeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SelectedEntitiesXmlParser::SubElementByTypeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7106,10 +7115,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        SelectedEntitiesXmlParser::SelectedEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        SelectedEntitiesXmlParser::SelectedEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7119,7 +7128,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ShapeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            ShapeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ShapeXmlParser::GetAttributeNameToAttributeParserMap()
@@ -7132,15 +7141,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ShapeXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPolylineParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementClothoidParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementNurbsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPolylineParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementClothoidParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementNurbsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ShapeXmlParser::SubElementPolylineParser::SubElementPolylineParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ShapeXmlParser::SubElementPolylineParser::SubElementPolylineParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _polylineXmlParser = std::make_shared<PolylineXmlParser>(messageLogger, filename);
+            _polylineXmlParser = std::make_shared<PolylineXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ShapeXmlParser::SubElementPolylineParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7178,9 +7187,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__POLYLINE
                     };
         }
-        ShapeXmlParser::SubElementClothoidParser::SubElementClothoidParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ShapeXmlParser::SubElementClothoidParser::SubElementClothoidParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _clothoidXmlParser = std::make_shared<ClothoidXmlParser>(messageLogger, filename);
+            _clothoidXmlParser = std::make_shared<ClothoidXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ShapeXmlParser::SubElementClothoidParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7218,9 +7227,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CLOTHOID
                     };
         }
-        ShapeXmlParser::SubElementNurbsParser::SubElementNurbsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ShapeXmlParser::SubElementNurbsParser::SubElementNurbsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _nurbsXmlParser = std::make_shared<NurbsXmlParser>(messageLogger, filename);
+            _nurbsXmlParser = std::make_shared<NurbsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ShapeXmlParser::SubElementNurbsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7259,10 +7268,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ShapeXmlParser::ShapeXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ShapeXmlParser::ShapeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7272,7 +7281,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SimulationTimeConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            SimulationTimeConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> SimulationTimeConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -7281,7 +7290,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7308,7 +7317,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (Rule::IsDeprecated(kResult))
+                        if (Rule::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  Rule::GetDeprecatedVersion(kResult) +"'. " + Rule::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -7325,11 +7334,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7364,7 +7373,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -7375,10 +7384,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        SimulationTimeConditionXmlParser::SimulationTimeConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        SimulationTimeConditionXmlParser::SimulationTimeConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7388,7 +7397,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SpeedActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            SpeedActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> SpeedActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -7401,14 +7410,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> SpeedActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementSpeedActionDynamicsParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementSpeedActionTargetParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementSpeedActionDynamicsParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementSpeedActionTargetParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        SpeedActionXmlParser::SubElementSpeedActionDynamicsParser::SubElementSpeedActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SpeedActionXmlParser::SubElementSpeedActionDynamicsParser::SubElementSpeedActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _transitionDynamicsXmlParser = std::make_shared<TransitionDynamicsXmlParser>(messageLogger, filename);
+            _transitionDynamicsXmlParser = std::make_shared<TransitionDynamicsXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SpeedActionXmlParser::SubElementSpeedActionDynamicsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7446,9 +7455,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SPEED_ACTION_DYNAMICS
                     };
         }
-        SpeedActionXmlParser::SubElementSpeedActionTargetParser::SubElementSpeedActionTargetParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SpeedActionXmlParser::SubElementSpeedActionTargetParser::SubElementSpeedActionTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _speedActionTargetXmlParser = std::make_shared<SpeedActionTargetXmlParser>(messageLogger, filename);
+            _speedActionTargetXmlParser = std::make_shared<SpeedActionTargetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SpeedActionXmlParser::SubElementSpeedActionTargetParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7487,10 +7496,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        SpeedActionXmlParser::SpeedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        SpeedActionXmlParser::SpeedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7500,7 +7509,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SpeedActionTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            SpeedActionTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> SpeedActionTargetXmlParser::GetAttributeNameToAttributeParserMap()
@@ -7513,14 +7522,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> SpeedActionTargetXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRelativeTargetSpeedParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementAbsoluteTargetSpeedParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRelativeTargetSpeedParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementAbsoluteTargetSpeedParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        SpeedActionTargetXmlParser::SubElementRelativeTargetSpeedParser::SubElementRelativeTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SpeedActionTargetXmlParser::SubElementRelativeTargetSpeedParser::SubElementRelativeTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _relativeTargetSpeedXmlParser = std::make_shared<RelativeTargetSpeedXmlParser>(messageLogger, filename);
+            _relativeTargetSpeedXmlParser = std::make_shared<RelativeTargetSpeedXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SpeedActionTargetXmlParser::SubElementRelativeTargetSpeedParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7558,9 +7567,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__RELATIVE_TARGET_SPEED
                     };
         }
-        SpeedActionTargetXmlParser::SubElementAbsoluteTargetSpeedParser::SubElementAbsoluteTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SpeedActionTargetXmlParser::SubElementAbsoluteTargetSpeedParser::SubElementAbsoluteTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _absoluteTargetSpeedXmlParser = std::make_shared<AbsoluteTargetSpeedXmlParser>(messageLogger, filename);
+            _absoluteTargetSpeedXmlParser = std::make_shared<AbsoluteTargetSpeedXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SpeedActionTargetXmlParser::SubElementAbsoluteTargetSpeedParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7599,10 +7608,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        SpeedActionTargetXmlParser::SpeedActionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        SpeedActionTargetXmlParser::SpeedActionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7612,7 +7621,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SpeedConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            SpeedConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> SpeedConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -7621,7 +7630,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7648,7 +7657,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (Rule::IsDeprecated(kResult))
+                        if (Rule::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  Rule::GetDeprecatedVersion(kResult) +"'. " + Rule::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -7665,11 +7674,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7704,7 +7713,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -7715,10 +7724,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        SpeedConditionXmlParser::SpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        SpeedConditionXmlParser::SpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7728,7 +7737,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            StandStillConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            StandStillConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> StandStillConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -7737,7 +7746,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDuration: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDuration(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7772,7 +7781,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DURATION, std::make_shared<AttributeDuration>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -7783,10 +7792,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        StandStillConditionXmlParser::StandStillConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        StandStillConditionXmlParser::StandStillConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7796,21 +7805,21 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SteadyStateXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            SteadyStateXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
 
         std::vector<std::shared_ptr<IElementParser>> SteadyStateXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTargetDistanceSteadyStateParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTargetTimeSteadyStateParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTargetDistanceSteadyStateParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTargetTimeSteadyStateParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        SteadyStateXmlParser::SubElementTargetDistanceSteadyStateParser::SubElementTargetDistanceSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SteadyStateXmlParser::SubElementTargetDistanceSteadyStateParser::SubElementTargetDistanceSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _targetDistanceSteadyStateXmlParser = std::make_shared<TargetDistanceSteadyStateXmlParser>(messageLogger, filename);
+            _targetDistanceSteadyStateXmlParser = std::make_shared<TargetDistanceSteadyStateXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SteadyStateXmlParser::SubElementTargetDistanceSteadyStateParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7848,9 +7857,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TARGET_DISTANCE_STEADY_STATE
                     };
         }
-        SteadyStateXmlParser::SubElementTargetTimeSteadyStateParser::SubElementTargetTimeSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SteadyStateXmlParser::SubElementTargetTimeSteadyStateParser::SubElementTargetTimeSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _targetTimeSteadyStateXmlParser = std::make_shared<TargetTimeSteadyStateXmlParser>(messageLogger, filename);
+            _targetTimeSteadyStateXmlParser = std::make_shared<TargetTimeSteadyStateXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SteadyStateXmlParser::SubElementTargetTimeSteadyStateParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -7889,10 +7898,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        SteadyStateXmlParser::SteadyStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        SteadyStateXmlParser::SteadyStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -7902,7 +7911,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            StochasticXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            StochasticXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> StochasticXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -7911,7 +7920,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeNumberOfTestRuns: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeNumberOfTestRuns(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeNumberOfTestRuns(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7946,11 +7955,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NUMBER_OF_TEST_RUNS, std::make_shared<AttributeNumberOfTestRuns>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NUMBER_OF_TEST_RUNS, std::make_shared<AttributeNumberOfTestRuns>(_messageLogger, _filename, _parserOptions)));
             class AttributeRandomSeed: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRandomSeed(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRandomSeed(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -7985,20 +7994,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RANDOM_SEED, std::make_shared<AttributeRandomSeed>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RANDOM_SEED, std::make_shared<AttributeRandomSeed>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> StochasticXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementStochasticDistributionsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementStochasticDistributionsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        StochasticXmlParser::SubElementStochasticDistributionsParser::SubElementStochasticDistributionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StochasticXmlParser::SubElementStochasticDistributionsParser::SubElementStochasticDistributionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _stochasticDistributionXmlParser = std::make_shared<StochasticDistributionXmlParser>(messageLogger, filename);
+            _stochasticDistributionXmlParser = std::make_shared<StochasticDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StochasticXmlParser::SubElementStochasticDistributionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8038,10 +8047,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        StochasticXmlParser::StochasticXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        StochasticXmlParser::StochasticXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8051,7 +8060,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            StochasticDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            StochasticDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> StochasticDistributionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8060,7 +8069,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeParameterName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeParameterName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeParameterName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8095,20 +8104,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_NAME, std::make_shared<AttributeParameterName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PARAMETER_NAME, std::make_shared<AttributeParameterName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> StochasticDistributionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementStochasticDistributionTypeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementStochasticDistributionTypeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        StochasticDistributionXmlParser::SubElementStochasticDistributionTypeParser::SubElementStochasticDistributionTypeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StochasticDistributionXmlParser::SubElementStochasticDistributionTypeParser::SubElementStochasticDistributionTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _stochasticDistributionTypeXmlParser = std::make_shared<StochasticDistributionTypeXmlParser>(messageLogger, filename);
+            _stochasticDistributionTypeXmlParser = std::make_shared<StochasticDistributionTypeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StochasticDistributionXmlParser::SubElementStochasticDistributionTypeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8157,10 +8166,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        StochasticDistributionXmlParser::StochasticDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        StochasticDistributionXmlParser::StochasticDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8170,25 +8179,25 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            StochasticDistributionTypeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            StochasticDistributionTypeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
 
         std::vector<std::shared_ptr<IElementParser>> StochasticDistributionTypeXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementProbabilityDistributionSetParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementNormalDistributionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementUniformDistributionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPoissonDistributionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementHistogramParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementUserDefinedDistributionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementProbabilityDistributionSetParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementNormalDistributionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementUniformDistributionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPoissonDistributionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementHistogramParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementUserDefinedDistributionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        StochasticDistributionTypeXmlParser::SubElementProbabilityDistributionSetParser::SubElementProbabilityDistributionSetParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StochasticDistributionTypeXmlParser::SubElementProbabilityDistributionSetParser::SubElementProbabilityDistributionSetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _probabilityDistributionSetXmlParser = std::make_shared<ProbabilityDistributionSetXmlParser>(messageLogger, filename);
+            _probabilityDistributionSetXmlParser = std::make_shared<ProbabilityDistributionSetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StochasticDistributionTypeXmlParser::SubElementProbabilityDistributionSetParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8226,9 +8235,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PROBABILITY_DISTRIBUTION_SET
                     };
         }
-        StochasticDistributionTypeXmlParser::SubElementNormalDistributionParser::SubElementNormalDistributionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StochasticDistributionTypeXmlParser::SubElementNormalDistributionParser::SubElementNormalDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _normalDistributionXmlParser = std::make_shared<NormalDistributionXmlParser>(messageLogger, filename);
+            _normalDistributionXmlParser = std::make_shared<NormalDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StochasticDistributionTypeXmlParser::SubElementNormalDistributionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8266,9 +8275,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__NORMAL_DISTRIBUTION
                     };
         }
-        StochasticDistributionTypeXmlParser::SubElementUniformDistributionParser::SubElementUniformDistributionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StochasticDistributionTypeXmlParser::SubElementUniformDistributionParser::SubElementUniformDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _uniformDistributionXmlParser = std::make_shared<UniformDistributionXmlParser>(messageLogger, filename);
+            _uniformDistributionXmlParser = std::make_shared<UniformDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StochasticDistributionTypeXmlParser::SubElementUniformDistributionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8306,9 +8315,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__UNIFORM_DISTRIBUTION
                     };
         }
-        StochasticDistributionTypeXmlParser::SubElementPoissonDistributionParser::SubElementPoissonDistributionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StochasticDistributionTypeXmlParser::SubElementPoissonDistributionParser::SubElementPoissonDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _poissonDistributionXmlParser = std::make_shared<PoissonDistributionXmlParser>(messageLogger, filename);
+            _poissonDistributionXmlParser = std::make_shared<PoissonDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StochasticDistributionTypeXmlParser::SubElementPoissonDistributionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8346,9 +8355,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__POISSON_DISTRIBUTION
                     };
         }
-        StochasticDistributionTypeXmlParser::SubElementHistogramParser::SubElementHistogramParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StochasticDistributionTypeXmlParser::SubElementHistogramParser::SubElementHistogramParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _histogramXmlParser = std::make_shared<HistogramXmlParser>(messageLogger, filename);
+            _histogramXmlParser = std::make_shared<HistogramXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StochasticDistributionTypeXmlParser::SubElementHistogramParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8386,9 +8395,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__HISTOGRAM
                     };
         }
-        StochasticDistributionTypeXmlParser::SubElementUserDefinedDistributionParser::SubElementUserDefinedDistributionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StochasticDistributionTypeXmlParser::SubElementUserDefinedDistributionParser::SubElementUserDefinedDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _userDefinedDistributionXmlParser = std::make_shared<UserDefinedDistributionXmlParser>(messageLogger, filename);
+            _userDefinedDistributionXmlParser = std::make_shared<UserDefinedDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StochasticDistributionTypeXmlParser::SubElementUserDefinedDistributionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8427,10 +8436,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        StochasticDistributionTypeXmlParser::StochasticDistributionTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlGroupParser(messageLogger, filename)
+        StochasticDistributionTypeXmlParser::StochasticDistributionTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8440,7 +8449,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            StoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            StoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> StoryXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8449,7 +8458,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8484,21 +8493,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> StoryXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementActsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementActsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        StoryXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StoryXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StoryXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8534,9 +8543,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        StoryXmlParser::SubElementActsParser::SubElementActsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StoryXmlParser::SubElementActsParser::SubElementActsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _actXmlParser = std::make_shared<ActXmlParser>(messageLogger, filename);
+            _actXmlParser = std::make_shared<ActXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StoryXmlParser::SubElementActsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8576,10 +8585,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        StoryXmlParser::StoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        StoryXmlParser::StoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8589,7 +8598,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            StoryboardXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            StoryboardXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> StoryboardXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8601,15 +8610,15 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> StoryboardXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementInitParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStoriesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementStopTriggerParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementInitParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStoriesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementStopTriggerParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        StoryboardXmlParser::SubElementInitParser::SubElementInitParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StoryboardXmlParser::SubElementInitParser::SubElementInitParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _initXmlParser = std::make_shared<InitXmlParser>(messageLogger, filename);
+            _initXmlParser = std::make_shared<InitXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StoryboardXmlParser::SubElementInitParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8647,9 +8656,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__INIT
                     };
         }
-        StoryboardXmlParser::SubElementStoriesParser::SubElementStoriesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StoryboardXmlParser::SubElementStoriesParser::SubElementStoriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _storyXmlParser = std::make_shared<StoryXmlParser>(messageLogger, filename);
+            _storyXmlParser = std::make_shared<StoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StoryboardXmlParser::SubElementStoriesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8688,9 +8697,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__STORY
                     };
         }
-        StoryboardXmlParser::SubElementStopTriggerParser::SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename)
+        StoryboardXmlParser::SubElementStopTriggerParser::SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename);
+            _triggerXmlParser = std::make_shared<TriggerXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void StoryboardXmlParser::SubElementStopTriggerParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -8729,10 +8738,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        StoryboardXmlParser::StoryboardXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        StoryboardXmlParser::StoryboardXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8742,7 +8751,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            StoryboardElementStateConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            StoryboardElementStateConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> StoryboardElementStateConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8751,7 +8760,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeState: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeState(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeState(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8778,7 +8787,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (StoryboardElementState::IsDeprecated(kResult))
+                        if (StoryboardElementState::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  StoryboardElementState::GetDeprecatedVersion(kResult) +"'. " + StoryboardElementState::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -8795,11 +8804,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename, _parserOptions)));
             class AttributeStoryboardElementRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeStoryboardElementRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeStoryboardElementRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8831,11 +8840,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STORYBOARD_ELEMENT_REF, std::make_shared<AttributeStoryboardElementRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STORYBOARD_ELEMENT_REF, std::make_shared<AttributeStoryboardElementRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeStoryboardElementType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeStoryboardElementType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeStoryboardElementType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8862,7 +8871,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (StoryboardElementType::IsDeprecated(kResult))
+                        if (StoryboardElementType::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  StoryboardElementType::GetDeprecatedVersion(kResult) +"'. " + StoryboardElementType::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -8879,7 +8888,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STORYBOARD_ELEMENT_TYPE, std::make_shared<AttributeStoryboardElementType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STORYBOARD_ELEMENT_TYPE, std::make_shared<AttributeStoryboardElementType>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -8890,10 +8899,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        StoryboardElementStateConditionXmlParser::StoryboardElementStateConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        StoryboardElementStateConditionXmlParser::StoryboardElementStateConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -8903,7 +8912,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SunXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            SunXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> SunXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -8912,7 +8921,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeAzimuth: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeAzimuth(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeAzimuth(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8947,11 +8956,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__AZIMUTH, std::make_shared<AttributeAzimuth>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__AZIMUTH, std::make_shared<AttributeAzimuth>(_messageLogger, _filename, _parserOptions)));
             class AttributeElevation: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeElevation(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeElevation(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -8986,11 +8995,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ELEVATION, std::make_shared<AttributeElevation>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ELEVATION, std::make_shared<AttributeElevation>(_messageLogger, _filename, _parserOptions)));
             class AttributeIntensity: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeIntensity(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeIntensity(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9025,7 +9034,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__INTENSITY, std::make_shared<AttributeIntensity>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__INTENSITY, std::make_shared<AttributeIntensity>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -9036,10 +9045,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        SunXmlParser::SunXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        SunXmlParser::SunXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9049,7 +9058,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            SynchronizeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            SynchronizeActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> SynchronizeActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9059,7 +9068,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMasterEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMasterEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMasterEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9091,11 +9100,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MASTER_ENTITY_REF, std::make_shared<AttributeMasterEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MASTER_ENTITY_REF, std::make_shared<AttributeMasterEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeTargetTolerance: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTargetTolerance(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTargetTolerance(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9130,11 +9139,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TARGET_TOLERANCE, std::make_shared<AttributeTargetTolerance>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TARGET_TOLERANCE, std::make_shared<AttributeTargetTolerance>(_messageLogger, _filename, _parserOptions)));
             class AttributeTargetToleranceMaster: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTargetToleranceMaster(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTargetToleranceMaster(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9169,22 +9178,22 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TARGET_TOLERANCE_MASTER, std::make_shared<AttributeTargetToleranceMaster>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TARGET_TOLERANCE_MASTER, std::make_shared<AttributeTargetToleranceMaster>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> SynchronizeActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTargetPositionMasterParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTargetPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementFinalSpeedParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTargetPositionMasterParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTargetPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementFinalSpeedParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        SynchronizeActionXmlParser::SubElementTargetPositionMasterParser::SubElementTargetPositionMasterParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SynchronizeActionXmlParser::SubElementTargetPositionMasterParser::SubElementTargetPositionMasterParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SynchronizeActionXmlParser::SubElementTargetPositionMasterParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9222,9 +9231,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TARGET_POSITION_MASTER
                     };
         }
-        SynchronizeActionXmlParser::SubElementTargetPositionParser::SubElementTargetPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SynchronizeActionXmlParser::SubElementTargetPositionParser::SubElementTargetPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SynchronizeActionXmlParser::SubElementTargetPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9262,9 +9271,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TARGET_POSITION
                     };
         }
-        SynchronizeActionXmlParser::SubElementFinalSpeedParser::SubElementFinalSpeedParser(IParserMessageLogger& messageLogger, std::string& filename)
+        SynchronizeActionXmlParser::SubElementFinalSpeedParser::SubElementFinalSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _finalSpeedXmlParser = std::make_shared<FinalSpeedXmlParser>(messageLogger, filename);
+            _finalSpeedXmlParser = std::make_shared<FinalSpeedXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void SynchronizeActionXmlParser::SubElementFinalSpeedParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9303,10 +9312,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        SynchronizeActionXmlParser::SynchronizeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        SynchronizeActionXmlParser::SynchronizeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9316,7 +9325,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TargetDistanceSteadyStateXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            TargetDistanceSteadyStateXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TargetDistanceSteadyStateXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9326,7 +9335,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDistance: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDistance(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDistance(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9361,7 +9370,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DISTANCE, std::make_shared<AttributeDistance>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DISTANCE, std::make_shared<AttributeDistance>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -9372,10 +9381,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TargetDistanceSteadyStateXmlParser::TargetDistanceSteadyStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TargetDistanceSteadyStateXmlParser::TargetDistanceSteadyStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9385,7 +9394,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TargetTimeSteadyStateXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            TargetTimeSteadyStateXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TargetTimeSteadyStateXmlParser::GetAttributeNameToAttributeParserMap()
@@ -9395,7 +9404,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeTime: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTime(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTime(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9430,7 +9439,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TIME, std::make_shared<AttributeTime>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TIME, std::make_shared<AttributeTime>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -9441,10 +9450,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TargetTimeSteadyStateXmlParser::TargetTimeSteadyStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TargetTimeSteadyStateXmlParser::TargetTimeSteadyStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9454,7 +9463,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TeleportActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TeleportActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TeleportActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -9466,13 +9475,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> TeleportActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TeleportActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TeleportActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TeleportActionXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -9511,10 +9520,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TeleportActionXmlParser::TeleportActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TeleportActionXmlParser::TeleportActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9524,7 +9533,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TimeHeadwayConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TimeHeadwayConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TimeHeadwayConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -9533,7 +9542,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeAlongRoute: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeAlongRoute(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeAlongRoute(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9556,9 +9565,12 @@ namespace NET_ASAM_OPENSCENARIO
                     typedObject->PutPropertyEndMarker(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<Textmarker>(endMarker));
                      
                     
-                    // This element is deprecated
-					auto msg = FileContentMessage("Attribute '" + attributeName + "' is deprecated since standard version '1.1'. Comment: 'Use relativeDistanceType and coordinateSystem'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), this->_filename));
-					this->_messageLogger.LogMessage(msg);
+					if (!_parserOptions.IsOptionSetSupressDeprecationWarnings())
+					{
+						// This element is deprecated
+						auto msg = FileContentMessage("Attribute '" + attributeName + "' is deprecated since standard version '1.1'. Comment: 'Use relativeDistanceType and coordinateSystem'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), this->_filename));
+						this->_messageLogger.LogMessage(msg);
+					}
                 }
 
                 int GetMinOccur() override
@@ -9566,11 +9578,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<AttributeAlongRoute>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<AttributeAlongRoute>(_messageLogger, _filename, _parserOptions)));
             class AttributeCoordinateSystem: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCoordinateSystem(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCoordinateSystem(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9597,7 +9609,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (CoordinateSystem::IsDeprecated(kResult))
+                        if (CoordinateSystem::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  CoordinateSystem::GetDeprecatedVersion(kResult) +"'. " + CoordinateSystem::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -9614,11 +9626,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM, std::make_shared<AttributeCoordinateSystem>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM, std::make_shared<AttributeCoordinateSystem>(_messageLogger, _filename, _parserOptions)));
             class AttributeEntityRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeEntityRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9650,11 +9662,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ENTITY_REF, std::make_shared<AttributeEntityRef>(_messageLogger, _filename, _parserOptions)));
             class AttributeFreespace: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9684,11 +9696,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename, _parserOptions)));
             class AttributeRelativeDistanceType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRelativeDistanceType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRelativeDistanceType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9715,7 +9727,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (RelativeDistanceType::IsDeprecated(kResult))
+                        if (RelativeDistanceType::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  RelativeDistanceType::GetDeprecatedVersion(kResult) +"'. " + RelativeDistanceType::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -9732,11 +9744,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RELATIVE_DISTANCE_TYPE, std::make_shared<AttributeRelativeDistanceType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RELATIVE_DISTANCE_TYPE, std::make_shared<AttributeRelativeDistanceType>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9763,7 +9775,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (Rule::IsDeprecated(kResult))
+                        if (Rule::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  Rule::GetDeprecatedVersion(kResult) +"'. " + Rule::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -9780,11 +9792,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9819,7 +9831,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -9830,10 +9842,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TimeHeadwayConditionXmlParser::TimeHeadwayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TimeHeadwayConditionXmlParser::TimeHeadwayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9843,7 +9855,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TimeOfDayXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TimeOfDayXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TimeOfDayXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -9852,7 +9864,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeAnimation: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeAnimation(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeAnimation(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9882,11 +9894,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ANIMATION, std::make_shared<AttributeAnimation>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ANIMATION, std::make_shared<AttributeAnimation>(_messageLogger, _filename, _parserOptions)));
             class AttributeDateTime: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDateTime(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDateTime(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9916,7 +9928,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DATE_TIME, std::make_shared<AttributeDateTime>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DATE_TIME, std::make_shared<AttributeDateTime>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -9927,10 +9939,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TimeOfDayXmlParser::TimeOfDayXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TimeOfDayXmlParser::TimeOfDayXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -9940,7 +9952,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TimeOfDayConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TimeOfDayConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TimeOfDayConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -9949,7 +9961,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDateTime: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDateTime(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDateTime(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -9979,11 +9991,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DATE_TIME, std::make_shared<AttributeDateTime>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DATE_TIME, std::make_shared<AttributeDateTime>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10010,7 +10022,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (Rule::IsDeprecated(kResult))
+                        if (Rule::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  Rule::GetDeprecatedVersion(kResult) +"'. " + Rule::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -10027,7 +10039,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -10038,10 +10050,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TimeOfDayConditionXmlParser::TimeOfDayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TimeOfDayConditionXmlParser::TimeOfDayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10051,7 +10063,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TimeReferenceXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            TimeReferenceXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TimeReferenceXmlParser::GetAttributeNameToAttributeParserMap()
@@ -10064,14 +10076,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> TimeReferenceXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementNoneParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTimingParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementNoneParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTimingParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TimeReferenceXmlParser::SubElementNoneParser::SubElementNoneParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TimeReferenceXmlParser::SubElementNoneParser::SubElementNoneParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _noneXmlParser = std::make_shared<NoneXmlParser>(messageLogger, filename);
+            _noneXmlParser = std::make_shared<NoneXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TimeReferenceXmlParser::SubElementNoneParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10109,9 +10121,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__NONE
                     };
         }
-        TimeReferenceXmlParser::SubElementTimingParser::SubElementTimingParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TimeReferenceXmlParser::SubElementTimingParser::SubElementTimingParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _timingXmlParser = std::make_shared<TimingXmlParser>(messageLogger, filename);
+            _timingXmlParser = std::make_shared<TimingXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TimeReferenceXmlParser::SubElementTimingParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10150,10 +10162,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TimeReferenceXmlParser::TimeReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TimeReferenceXmlParser::TimeReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10163,7 +10175,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TimeToCollisionConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            TimeToCollisionConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TimeToCollisionConditionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -10173,7 +10185,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeAlongRoute: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeAlongRoute(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeAlongRoute(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10196,9 +10208,12 @@ namespace NET_ASAM_OPENSCENARIO
                     typedObject->PutPropertyEndMarker(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<Textmarker>(endMarker));
                      
                     
-                    // This element is deprecated
-					auto msg = FileContentMessage("Attribute '" + attributeName + "' is deprecated since standard version '1.1'. Comment: 'Use \"coordiateSystem\" and \"relativeDistanceType\"'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), this->_filename));
-					this->_messageLogger.LogMessage(msg);
+					if (!_parserOptions.IsOptionSetSupressDeprecationWarnings())
+					{
+						// This element is deprecated
+						auto msg = FileContentMessage("Attribute '" + attributeName + "' is deprecated since standard version '1.1'. Comment: 'Use \"coordiateSystem\" and \"relativeDistanceType\"'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), this->_filename));
+						this->_messageLogger.LogMessage(msg);
+					}
                 }
 
                 int GetMinOccur() override
@@ -10206,11 +10221,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<AttributeAlongRoute>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ALONG_ROUTE, std::make_shared<AttributeAlongRoute>(_messageLogger, _filename, _parserOptions)));
             class AttributeCoordinateSystem: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCoordinateSystem(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCoordinateSystem(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10237,7 +10252,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (CoordinateSystem::IsDeprecated(kResult))
+                        if (CoordinateSystem::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  CoordinateSystem::GetDeprecatedVersion(kResult) +"'. " + CoordinateSystem::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -10254,11 +10269,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM, std::make_shared<AttributeCoordinateSystem>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__COORDINATE_SYSTEM, std::make_shared<AttributeCoordinateSystem>(_messageLogger, _filename, _parserOptions)));
             class AttributeFreespace: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFreespace(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10288,11 +10303,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FREESPACE, std::make_shared<AttributeFreespace>(_messageLogger, _filename, _parserOptions)));
             class AttributeRelativeDistanceType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRelativeDistanceType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRelativeDistanceType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10319,7 +10334,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (RelativeDistanceType::IsDeprecated(kResult))
+                        if (RelativeDistanceType::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  RelativeDistanceType::GetDeprecatedVersion(kResult) +"'. " + RelativeDistanceType::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -10336,11 +10351,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RELATIVE_DISTANCE_TYPE, std::make_shared<AttributeRelativeDistanceType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RELATIVE_DISTANCE_TYPE, std::make_shared<AttributeRelativeDistanceType>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10367,7 +10382,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (Rule::IsDeprecated(kResult))
+                        if (Rule::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  Rule::GetDeprecatedVersion(kResult) +"'. " + Rule::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -10384,11 +10399,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10423,20 +10438,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TimeToCollisionConditionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTimeToCollisionConditionTargetParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTimeToCollisionConditionTargetParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TimeToCollisionConditionXmlParser::SubElementTimeToCollisionConditionTargetParser::SubElementTimeToCollisionConditionTargetParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TimeToCollisionConditionXmlParser::SubElementTimeToCollisionConditionTargetParser::SubElementTimeToCollisionConditionTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _timeToCollisionConditionTargetXmlParser = std::make_shared<TimeToCollisionConditionTargetXmlParser>(messageLogger, filename);
+            _timeToCollisionConditionTargetXmlParser = std::make_shared<TimeToCollisionConditionTargetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TimeToCollisionConditionXmlParser::SubElementTimeToCollisionConditionTargetParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10475,10 +10490,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TimeToCollisionConditionXmlParser::TimeToCollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TimeToCollisionConditionXmlParser::TimeToCollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10488,7 +10503,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TimeToCollisionConditionTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            TimeToCollisionConditionTargetXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TimeToCollisionConditionTargetXmlParser::GetAttributeNameToAttributeParserMap()
@@ -10501,14 +10516,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> TimeToCollisionConditionTargetXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementEntityRefParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementEntityRefParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TimeToCollisionConditionTargetXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TimeToCollisionConditionTargetXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TimeToCollisionConditionTargetXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10546,9 +10561,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__POSITION
                     };
         }
-        TimeToCollisionConditionTargetXmlParser::SubElementEntityRefParser::SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TimeToCollisionConditionTargetXmlParser::SubElementEntityRefParser::SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename);
+            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TimeToCollisionConditionTargetXmlParser::SubElementEntityRefParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10587,10 +10602,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TimeToCollisionConditionTargetXmlParser::TimeToCollisionConditionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TimeToCollisionConditionTargetXmlParser::TimeToCollisionConditionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10600,7 +10615,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TimingXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TimingXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TimingXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -10609,7 +10624,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDomainAbsoluteRelative: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDomainAbsoluteRelative(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDomainAbsoluteRelative(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10636,7 +10651,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (ReferenceContext::IsDeprecated(kResult))
+                        if (ReferenceContext::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  ReferenceContext::GetDeprecatedVersion(kResult) +"'. " + ReferenceContext::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -10653,11 +10668,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DOMAIN_ABSOLUTE_RELATIVE, std::make_shared<AttributeDomainAbsoluteRelative>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DOMAIN_ABSOLUTE_RELATIVE, std::make_shared<AttributeDomainAbsoluteRelative>(_messageLogger, _filename, _parserOptions)));
             class AttributeOffset: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10692,11 +10707,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename, _parserOptions)));
             class AttributeScale: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeScale(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeScale(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10731,7 +10746,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SCALE, std::make_shared<AttributeScale>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SCALE, std::make_shared<AttributeScale>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -10742,10 +10757,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TimingXmlParser::TimingXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TimingXmlParser::TimingXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10755,7 +10770,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            TrafficActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -10765,7 +10780,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeTrafficName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTrafficName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTrafficName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -10800,23 +10815,23 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC_NAME, std::make_shared<AttributeTrafficName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC_NAME, std::make_shared<AttributeTrafficName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TrafficActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTrafficSourceActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficSinkActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficSwarmActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficStopActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTrafficSourceActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficSinkActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficSwarmActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficStopActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrafficActionXmlParser::SubElementTrafficSourceActionParser::SubElementTrafficSourceActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficActionXmlParser::SubElementTrafficSourceActionParser::SubElementTrafficSourceActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSourceActionXmlParser = std::make_shared<TrafficSourceActionXmlParser>(messageLogger, filename);
+            _trafficSourceActionXmlParser = std::make_shared<TrafficSourceActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficActionXmlParser::SubElementTrafficSourceActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10854,9 +10869,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAFFIC_SOURCE_ACTION
                     };
         }
-        TrafficActionXmlParser::SubElementTrafficSinkActionParser::SubElementTrafficSinkActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficActionXmlParser::SubElementTrafficSinkActionParser::SubElementTrafficSinkActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSinkActionXmlParser = std::make_shared<TrafficSinkActionXmlParser>(messageLogger, filename);
+            _trafficSinkActionXmlParser = std::make_shared<TrafficSinkActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficActionXmlParser::SubElementTrafficSinkActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10894,9 +10909,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAFFIC_SINK_ACTION
                     };
         }
-        TrafficActionXmlParser::SubElementTrafficSwarmActionParser::SubElementTrafficSwarmActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficActionXmlParser::SubElementTrafficSwarmActionParser::SubElementTrafficSwarmActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSwarmActionXmlParser = std::make_shared<TrafficSwarmActionXmlParser>(messageLogger, filename);
+            _trafficSwarmActionXmlParser = std::make_shared<TrafficSwarmActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficActionXmlParser::SubElementTrafficSwarmActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10934,9 +10949,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAFFIC_SWARM_ACTION
                     };
         }
-        TrafficActionXmlParser::SubElementTrafficStopActionParser::SubElementTrafficStopActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficActionXmlParser::SubElementTrafficStopActionParser::SubElementTrafficStopActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficStopActionXmlParser = std::make_shared<TrafficStopActionXmlParser>(messageLogger, filename);
+            _trafficStopActionXmlParser = std::make_shared<TrafficStopActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficActionXmlParser::SubElementTrafficStopActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -10975,10 +10990,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrafficActionXmlParser::TrafficActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficActionXmlParser::TrafficActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -10988,7 +11003,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            TrafficDefinitionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficDefinitionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -10998,7 +11013,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11033,21 +11048,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TrafficDefinitionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementVehicleCategoryDistributionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementControllerDistributionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementVehicleCategoryDistributionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementControllerDistributionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrafficDefinitionXmlParser::SubElementVehicleCategoryDistributionParser::SubElementVehicleCategoryDistributionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficDefinitionXmlParser::SubElementVehicleCategoryDistributionParser::SubElementVehicleCategoryDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _vehicleCategoryDistributionXmlParser = std::make_shared<VehicleCategoryDistributionXmlParser>(messageLogger, filename);
+            _vehicleCategoryDistributionXmlParser = std::make_shared<VehicleCategoryDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficDefinitionXmlParser::SubElementVehicleCategoryDistributionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11085,9 +11100,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__VEHICLE_CATEGORY_DISTRIBUTION
                     };
         }
-        TrafficDefinitionXmlParser::SubElementControllerDistributionParser::SubElementControllerDistributionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficDefinitionXmlParser::SubElementControllerDistributionParser::SubElementControllerDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _controllerDistributionXmlParser = std::make_shared<ControllerDistributionXmlParser>(messageLogger, filename);
+            _controllerDistributionXmlParser = std::make_shared<ControllerDistributionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficDefinitionXmlParser::SubElementControllerDistributionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11126,10 +11141,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrafficDefinitionXmlParser::TrafficDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficDefinitionXmlParser::TrafficDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11139,7 +11154,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSignalActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            TrafficSignalActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSignalActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -11152,14 +11167,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> TrafficSignalActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTrafficSignalControllerActionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficSignalStateActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTrafficSignalControllerActionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficSignalStateActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrafficSignalActionXmlParser::SubElementTrafficSignalControllerActionParser::SubElementTrafficSignalControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSignalActionXmlParser::SubElementTrafficSignalControllerActionParser::SubElementTrafficSignalControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSignalControllerActionXmlParser = std::make_shared<TrafficSignalControllerActionXmlParser>(messageLogger, filename);
+            _trafficSignalControllerActionXmlParser = std::make_shared<TrafficSignalControllerActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSignalActionXmlParser::SubElementTrafficSignalControllerActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11197,9 +11212,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAFFIC_SIGNAL_CONTROLLER_ACTION
                     };
         }
-        TrafficSignalActionXmlParser::SubElementTrafficSignalStateActionParser::SubElementTrafficSignalStateActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSignalActionXmlParser::SubElementTrafficSignalStateActionParser::SubElementTrafficSignalStateActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficSignalStateActionXmlParser = std::make_shared<TrafficSignalStateActionXmlParser>(messageLogger, filename);
+            _trafficSignalStateActionXmlParser = std::make_shared<TrafficSignalStateActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSignalActionXmlParser::SubElementTrafficSignalStateActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11238,10 +11253,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrafficSignalActionXmlParser::TrafficSignalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSignalActionXmlParser::TrafficSignalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11251,7 +11266,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSignalConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrafficSignalConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSignalConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11260,7 +11275,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11295,11 +11310,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeState: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeState(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeState(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11334,7 +11349,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -11345,10 +11360,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TrafficSignalConditionXmlParser::TrafficSignalConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSignalConditionXmlParser::TrafficSignalConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11358,7 +11373,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSignalControllerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrafficSignalControllerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSignalControllerXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11367,7 +11382,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDelay: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDelay(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDelay(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11402,11 +11417,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DELAY, std::make_shared<AttributeDelay>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DELAY, std::make_shared<AttributeDelay>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11441,11 +11456,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeReference: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeReference(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeReference(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11480,20 +11495,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__REFERENCE, std::make_shared<AttributeReference>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__REFERENCE, std::make_shared<AttributeReference>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TrafficSignalControllerXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPhasesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPhasesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrafficSignalControllerXmlParser::SubElementPhasesParser::SubElementPhasesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSignalControllerXmlParser::SubElementPhasesParser::SubElementPhasesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _phaseXmlParser = std::make_shared<PhaseXmlParser>(messageLogger, filename);
+            _phaseXmlParser = std::make_shared<PhaseXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSignalControllerXmlParser::SubElementPhasesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -11533,10 +11548,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrafficSignalControllerXmlParser::TrafficSignalControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSignalControllerXmlParser::TrafficSignalControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11546,7 +11561,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSignalControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrafficSignalControllerActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSignalControllerActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11555,7 +11570,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributePhase: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePhase(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePhase(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11590,11 +11605,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PHASE, std::make_shared<AttributePhase>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PHASE, std::make_shared<AttributePhase>(_messageLogger, _filename, _parserOptions)));
             class AttributeTrafficSignalControllerRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTrafficSignalControllerRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTrafficSignalControllerRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11626,7 +11641,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC_SIGNAL_CONTROLLER_REF, std::make_shared<AttributeTrafficSignalControllerRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC_SIGNAL_CONTROLLER_REF, std::make_shared<AttributeTrafficSignalControllerRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -11637,10 +11652,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TrafficSignalControllerActionXmlParser::TrafficSignalControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSignalControllerActionXmlParser::TrafficSignalControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11650,7 +11665,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSignalControllerConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrafficSignalControllerConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSignalControllerConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11659,7 +11674,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributePhase: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributePhase(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributePhase(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11694,11 +11709,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PHASE, std::make_shared<AttributePhase>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__PHASE, std::make_shared<AttributePhase>(_messageLogger, _filename, _parserOptions)));
             class AttributeTrafficSignalControllerRef: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTrafficSignalControllerRef(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTrafficSignalControllerRef(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11730,7 +11745,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC_SIGNAL_CONTROLLER_REF, std::make_shared<AttributeTrafficSignalControllerRef>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC_SIGNAL_CONTROLLER_REF, std::make_shared<AttributeTrafficSignalControllerRef>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -11741,10 +11756,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TrafficSignalControllerConditionXmlParser::TrafficSignalControllerConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSignalControllerConditionXmlParser::TrafficSignalControllerConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11754,7 +11769,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSignalStateXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrafficSignalStateXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSignalStateXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11763,7 +11778,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeState: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeState(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeState(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11798,11 +11813,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename, _parserOptions)));
             class AttributeTrafficSignalId: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTrafficSignalId(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTrafficSignalId(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11837,7 +11852,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC_SIGNAL_ID, std::make_shared<AttributeTrafficSignalId>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC_SIGNAL_ID, std::make_shared<AttributeTrafficSignalId>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -11848,10 +11863,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TrafficSignalStateXmlParser::TrafficSignalStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSignalStateXmlParser::TrafficSignalStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11861,7 +11876,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSignalStateActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrafficSignalStateActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSignalStateActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -11870,7 +11885,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11905,11 +11920,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeState: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeState(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeState(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -11944,7 +11959,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__STATE, std::make_shared<AttributeState>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -11955,10 +11970,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TrafficSignalStateActionXmlParser::TrafficSignalStateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSignalStateActionXmlParser::TrafficSignalStateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -11968,7 +11983,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSinkActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            TrafficSinkActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSinkActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -11978,7 +11993,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRadius: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRadius(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRadius(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12013,11 +12028,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RADIUS, std::make_shared<AttributeRadius>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RADIUS, std::make_shared<AttributeRadius>(_messageLogger, _filename, _parserOptions)));
             class AttributeRate: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRate(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRate(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12052,21 +12067,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RATE, std::make_shared<AttributeRate>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RATE, std::make_shared<AttributeRate>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TrafficSinkActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficDefinitionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficDefinitionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrafficSinkActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSinkActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSinkActionXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12104,9 +12119,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__POSITION
                     };
         }
-        TrafficSinkActionXmlParser::SubElementTrafficDefinitionParser::SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSinkActionXmlParser::SubElementTrafficDefinitionParser::SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficDefinitionXmlParser = std::make_shared<TrafficDefinitionXmlParser>(messageLogger, filename);
+            _trafficDefinitionXmlParser = std::make_shared<TrafficDefinitionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSinkActionXmlParser::SubElementTrafficDefinitionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12145,10 +12160,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrafficSinkActionXmlParser::TrafficSinkActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSinkActionXmlParser::TrafficSinkActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12158,7 +12173,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSourceActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            TrafficSourceActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSourceActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -12168,7 +12183,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRadius: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRadius(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRadius(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12203,11 +12218,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RADIUS, std::make_shared<AttributeRadius>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RADIUS, std::make_shared<AttributeRadius>(_messageLogger, _filename, _parserOptions)));
             class AttributeRate: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRate(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRate(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12242,11 +12257,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RATE, std::make_shared<AttributeRate>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RATE, std::make_shared<AttributeRate>(_messageLogger, _filename, _parserOptions)));
             class AttributeVelocity: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeVelocity(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeVelocity(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12281,21 +12296,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VELOCITY, std::make_shared<AttributeVelocity>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VELOCITY, std::make_shared<AttributeVelocity>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TrafficSourceActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficDefinitionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficDefinitionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrafficSourceActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSourceActionXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSourceActionXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12333,9 +12348,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__POSITION
                     };
         }
-        TrafficSourceActionXmlParser::SubElementTrafficDefinitionParser::SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSourceActionXmlParser::SubElementTrafficDefinitionParser::SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficDefinitionXmlParser = std::make_shared<TrafficDefinitionXmlParser>(messageLogger, filename);
+            _trafficDefinitionXmlParser = std::make_shared<TrafficDefinitionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSourceActionXmlParser::SubElementTrafficDefinitionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12374,10 +12389,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrafficSourceActionXmlParser::TrafficSourceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSourceActionXmlParser::TrafficSourceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12387,7 +12402,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficStopActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrafficStopActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficStopActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -12403,10 +12418,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TrafficStopActionXmlParser::TrafficStopActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficStopActionXmlParser::TrafficStopActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12416,7 +12431,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrafficSwarmActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            TrafficSwarmActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrafficSwarmActionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -12426,7 +12441,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeInnerRadius: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeInnerRadius(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeInnerRadius(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12461,11 +12476,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__INNER_RADIUS, std::make_shared<AttributeInnerRadius>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__INNER_RADIUS, std::make_shared<AttributeInnerRadius>(_messageLogger, _filename, _parserOptions)));
             class AttributeNumberOfVehicles: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeNumberOfVehicles(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeNumberOfVehicles(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12500,11 +12515,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NUMBER_OF_VEHICLES, std::make_shared<AttributeNumberOfVehicles>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NUMBER_OF_VEHICLES, std::make_shared<AttributeNumberOfVehicles>(_messageLogger, _filename, _parserOptions)));
             class AttributeOffset: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeOffset(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12539,11 +12554,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__OFFSET, std::make_shared<AttributeOffset>(_messageLogger, _filename, _parserOptions)));
             class AttributeSemiMajorAxis: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeSemiMajorAxis(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeSemiMajorAxis(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12578,11 +12593,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SEMI_MAJOR_AXIS, std::make_shared<AttributeSemiMajorAxis>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SEMI_MAJOR_AXIS, std::make_shared<AttributeSemiMajorAxis>(_messageLogger, _filename, _parserOptions)));
             class AttributeSemiMinorAxis: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeSemiMinorAxis(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeSemiMinorAxis(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12617,11 +12632,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SEMI_MINOR_AXIS, std::make_shared<AttributeSemiMinorAxis>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SEMI_MINOR_AXIS, std::make_shared<AttributeSemiMinorAxis>(_messageLogger, _filename, _parserOptions)));
             class AttributeVelocity: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeVelocity(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeVelocity(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12656,21 +12671,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VELOCITY, std::make_shared<AttributeVelocity>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VELOCITY, std::make_shared<AttributeVelocity>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TrafficSwarmActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementCentralObjectParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrafficDefinitionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementCentralObjectParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrafficDefinitionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrafficSwarmActionXmlParser::SubElementCentralObjectParser::SubElementCentralObjectParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSwarmActionXmlParser::SubElementCentralObjectParser::SubElementCentralObjectParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _centralSwarmObjectXmlParser = std::make_shared<CentralSwarmObjectXmlParser>(messageLogger, filename);
+            _centralSwarmObjectXmlParser = std::make_shared<CentralSwarmObjectXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSwarmActionXmlParser::SubElementCentralObjectParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12708,9 +12723,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__CENTRAL_OBJECT
                     };
         }
-        TrafficSwarmActionXmlParser::SubElementTrafficDefinitionParser::SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrafficSwarmActionXmlParser::SubElementTrafficDefinitionParser::SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trafficDefinitionXmlParser = std::make_shared<TrafficDefinitionXmlParser>(messageLogger, filename);
+            _trafficDefinitionXmlParser = std::make_shared<TrafficDefinitionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrafficSwarmActionXmlParser::SubElementTrafficDefinitionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12749,10 +12764,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrafficSwarmActionXmlParser::TrafficSwarmActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrafficSwarmActionXmlParser::TrafficSwarmActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12762,7 +12777,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrajectoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrajectoryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrajectoryXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -12771,7 +12786,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeClosed: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeClosed(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeClosed(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12801,11 +12816,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CLOSED, std::make_shared<AttributeClosed>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CLOSED, std::make_shared<AttributeClosed>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -12840,21 +12855,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TrajectoryXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementShapeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementShapeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrajectoryXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrajectoryXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrajectoryXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12890,9 +12905,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        TrajectoryXmlParser::SubElementShapeParser::SubElementShapeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrajectoryXmlParser::SubElementShapeParser::SubElementShapeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _shapeXmlParser = std::make_shared<ShapeXmlParser>(messageLogger, filename);
+            _shapeXmlParser = std::make_shared<ShapeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrajectoryXmlParser::SubElementShapeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -12931,10 +12946,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrajectoryXmlParser::TrajectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrajectoryXmlParser::TrajectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -12944,7 +12959,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrajectoryCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            TrajectoryCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrajectoryCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -12957,13 +12972,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> TrajectoryCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrajectoryCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrajectoryCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrajectoryCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13002,10 +13017,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrajectoryCatalogLocationXmlParser::TrajectoryCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrajectoryCatalogLocationXmlParser::TrajectoryCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13015,7 +13030,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrajectoryFollowingModeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TrajectoryFollowingModeXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrajectoryFollowingModeXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -13024,7 +13039,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeFollowingMode: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeFollowingMode(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeFollowingMode(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13051,7 +13066,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (FollowingMode::IsDeprecated(kResult))
+                        if (FollowingMode::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  FollowingMode::GetDeprecatedVersion(kResult) +"'. " + FollowingMode::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -13068,7 +13083,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FOLLOWING_MODE, std::make_shared<AttributeFollowingMode>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__FOLLOWING_MODE, std::make_shared<AttributeFollowingMode>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -13079,10 +13094,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TrajectoryFollowingModeXmlParser::TrajectoryFollowingModeXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrajectoryFollowingModeXmlParser::TrajectoryFollowingModeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13092,7 +13107,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrajectoryPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            TrajectoryPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrajectoryPositionXmlParser::GetAttributeNameToAttributeParserMap()
@@ -13102,7 +13117,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeS: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeS(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeS(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13137,11 +13152,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__S, std::make_shared<AttributeS>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__S, std::make_shared<AttributeS>(_messageLogger, _filename, _parserOptions)));
             class AttributeT: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeT(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeT(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13176,21 +13191,21 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__T, std::make_shared<AttributeT>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__T, std::make_shared<AttributeT>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TrajectoryPositionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementTrajectoryRefParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementOrientationParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementTrajectoryRefParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrajectoryPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrajectoryPositionXmlParser::SubElementOrientationParser::SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename);
+            _orientationXmlParser = std::make_shared<OrientationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrajectoryPositionXmlParser::SubElementOrientationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13228,9 +13243,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__ORIENTATION
                     };
         }
-        TrajectoryPositionXmlParser::SubElementTrajectoryRefParser::SubElementTrajectoryRefParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrajectoryPositionXmlParser::SubElementTrajectoryRefParser::SubElementTrajectoryRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trajectoryRefXmlParser = std::make_shared<TrajectoryRefXmlParser>(messageLogger, filename);
+            _trajectoryRefXmlParser = std::make_shared<TrajectoryRefXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrajectoryPositionXmlParser::SubElementTrajectoryRefParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13269,10 +13284,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrajectoryPositionXmlParser::TrajectoryPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrajectoryPositionXmlParser::TrajectoryPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13282,7 +13297,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TrajectoryRefXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            TrajectoryRefXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TrajectoryRefXmlParser::GetAttributeNameToAttributeParserMap()
@@ -13295,14 +13310,14 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> TrajectoryRefXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementTrajectoryParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementTrajectoryParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementCatalogReferenceParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TrajectoryRefXmlParser::SubElementTrajectoryParser::SubElementTrajectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrajectoryRefXmlParser::SubElementTrajectoryParser::SubElementTrajectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _trajectoryXmlParser = std::make_shared<TrajectoryXmlParser>(messageLogger, filename);
+            _trajectoryXmlParser = std::make_shared<TrajectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrajectoryRefXmlParser::SubElementTrajectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13340,9 +13355,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__TRAJECTORY
                     };
         }
-        TrajectoryRefXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TrajectoryRefXmlParser::SubElementCatalogReferenceParser::SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename);
+            _catalogReferenceXmlParser = std::make_shared<CatalogReferenceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TrajectoryRefXmlParser::SubElementCatalogReferenceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13382,10 +13397,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TrajectoryRefXmlParser::TrajectoryRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TrajectoryRefXmlParser::TrajectoryRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13395,7 +13410,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TransitionDynamicsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TransitionDynamicsXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TransitionDynamicsXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -13404,7 +13419,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDynamicsDimension: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDynamicsDimension(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDynamicsDimension(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13431,7 +13446,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (DynamicsDimension::IsDeprecated(kResult))
+                        if (DynamicsDimension::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  DynamicsDimension::GetDeprecatedVersion(kResult) +"'. " + DynamicsDimension::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -13448,11 +13463,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DYNAMICS_DIMENSION, std::make_shared<AttributeDynamicsDimension>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DYNAMICS_DIMENSION, std::make_shared<AttributeDynamicsDimension>(_messageLogger, _filename, _parserOptions)));
             class AttributeDynamicsShape: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDynamicsShape(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDynamicsShape(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13479,7 +13494,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (DynamicsShape::IsDeprecated(kResult))
+                        if (DynamicsShape::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  DynamicsShape::GetDeprecatedVersion(kResult) +"'. " + DynamicsShape::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -13496,11 +13511,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DYNAMICS_SHAPE, std::make_shared<AttributeDynamicsShape>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DYNAMICS_SHAPE, std::make_shared<AttributeDynamicsShape>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13535,7 +13550,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -13546,10 +13561,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TransitionDynamicsXmlParser::TransitionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TransitionDynamicsXmlParser::TransitionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13559,7 +13574,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TraveledDistanceConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TraveledDistanceConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TraveledDistanceConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -13568,7 +13583,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13603,7 +13618,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -13614,10 +13629,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        TraveledDistanceConditionXmlParser::TraveledDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TraveledDistanceConditionXmlParser::TraveledDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13627,7 +13642,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TriggerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TriggerXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TriggerXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -13639,13 +13654,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> TriggerXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementConditionGroupsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementConditionGroupsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TriggerXmlParser::SubElementConditionGroupsParser::SubElementConditionGroupsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TriggerXmlParser::SubElementConditionGroupsParser::SubElementConditionGroupsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _conditionGroupXmlParser = std::make_shared<ConditionGroupXmlParser>(messageLogger, filename);
+            _conditionGroupXmlParser = std::make_shared<ConditionGroupXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TriggerXmlParser::SubElementConditionGroupsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13685,10 +13700,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TriggerXmlParser::TriggerXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TriggerXmlParser::TriggerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13698,7 +13713,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            TriggeringEntitiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            TriggeringEntitiesXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> TriggeringEntitiesXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -13707,7 +13722,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeTriggeringEntitiesRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTriggeringEntitiesRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTriggeringEntitiesRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -13734,7 +13749,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (TriggeringEntitiesRule::IsDeprecated(kResult))
+                        if (TriggeringEntitiesRule::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  TriggeringEntitiesRule::GetDeprecatedVersion(kResult) +"'. " + TriggeringEntitiesRule::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -13751,20 +13766,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRIGGERING_ENTITIES_RULE, std::make_shared<AttributeTriggeringEntitiesRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRIGGERING_ENTITIES_RULE, std::make_shared<AttributeTriggeringEntitiesRule>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> TriggeringEntitiesXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementEntityRefsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementEntityRefsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        TriggeringEntitiesXmlParser::SubElementEntityRefsParser::SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        TriggeringEntitiesXmlParser::SubElementEntityRefsParser::SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename);
+            _entityRefXmlParser = std::make_shared<EntityRefXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void TriggeringEntitiesXmlParser::SubElementEntityRefsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13804,10 +13819,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        TriggeringEntitiesXmlParser::TriggeringEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        TriggeringEntitiesXmlParser::TriggeringEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13817,7 +13832,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            UniformDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            UniformDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> UniformDistributionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -13829,13 +13844,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> UniformDistributionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementRangeParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementRangeParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        UniformDistributionXmlParser::SubElementRangeParser::SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename)
+        UniformDistributionXmlParser::SubElementRangeParser::SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _rangeXmlParser = std::make_shared<RangeXmlParser>(messageLogger, filename);
+            _rangeXmlParser = std::make_shared<RangeXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void UniformDistributionXmlParser::SubElementRangeParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13874,10 +13889,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        UniformDistributionXmlParser::UniformDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        UniformDistributionXmlParser::UniformDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13887,7 +13902,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            UsedAreaXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            UsedAreaXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> UsedAreaXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -13899,13 +13914,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> UsedAreaXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        UsedAreaXmlParser::SubElementPositionsParser::SubElementPositionsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        UsedAreaXmlParser::SubElementPositionsParser::SubElementPositionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void UsedAreaXmlParser::SubElementPositionsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -13945,10 +13960,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        UsedAreaXmlParser::UsedAreaXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        UsedAreaXmlParser::UsedAreaXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -13958,7 +13973,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            UserDefinedActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            UserDefinedActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> UserDefinedActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -13970,13 +13985,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> UserDefinedActionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementCustomCommandActionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementCustomCommandActionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        UserDefinedActionXmlParser::SubElementCustomCommandActionParser::SubElementCustomCommandActionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        UserDefinedActionXmlParser::SubElementCustomCommandActionParser::SubElementCustomCommandActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _customCommandActionXmlParser = std::make_shared<CustomCommandActionXmlParser>(messageLogger, filename);
+            _customCommandActionXmlParser = std::make_shared<CustomCommandActionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void UserDefinedActionXmlParser::SubElementCustomCommandActionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14015,10 +14030,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        UserDefinedActionXmlParser::UserDefinedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        UserDefinedActionXmlParser::UserDefinedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14040,7 +14055,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeType: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeType(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeType(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14075,7 +14090,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TYPE, std::make_shared<AttributeType>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TYPE, std::make_shared<AttributeType>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
         void UserDefinedDistributionXmlParser::SetContentProperty(const std::string content, std::shared_ptr<BaseImpl> object)
@@ -14084,8 +14099,8 @@ namespace NET_ASAM_OPENSCENARIO
             typedObject->SetContent(content);
         }
   
-        UserDefinedDistributionXmlParser::UserDefinedDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlSimpleContentParser(messageLogger, filename) {}
+        UserDefinedDistributionXmlParser::UserDefinedDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlSimpleContentParser(messageLogger, filename, parserOptions) {}
         
 
         /**
@@ -14094,7 +14109,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            UserDefinedValueConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            UserDefinedValueConditionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> UserDefinedValueConditionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -14103,7 +14118,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14138,11 +14153,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14169,7 +14184,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (Rule::IsDeprecated(kResult))
+                        if (Rule::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  Rule::GetDeprecatedVersion(kResult) +"'. " + Rule::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -14186,11 +14201,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14225,7 +14240,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -14236,10 +14251,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        UserDefinedValueConditionXmlParser::UserDefinedValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        UserDefinedValueConditionXmlParser::UserDefinedValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14249,7 +14264,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ValueConstraintXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            ValueConstraintXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ValueConstraintXmlParser::GetAttributeNameToAttributeParserMap()
@@ -14259,7 +14274,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRule: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRule(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14286,7 +14301,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (Rule::IsDeprecated(kResult))
+                        if (Rule::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  Rule::GetDeprecatedVersion(kResult) +"'. " + Rule::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -14303,11 +14318,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__RULE, std::make_shared<AttributeRule>(_messageLogger, _filename, _parserOptions)));
             class AttributeValue: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeValue(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14342,7 +14357,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VALUE, std::make_shared<AttributeValue>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -14353,10 +14368,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        ValueConstraintXmlParser::ValueConstraintXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ValueConstraintXmlParser::ValueConstraintXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14366,7 +14381,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ValueConstraintGroupXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ValueConstraintGroupXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ValueConstraintGroupXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -14378,13 +14393,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ValueConstraintGroupXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementConstraintsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementConstraintsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ValueConstraintGroupXmlParser::SubElementConstraintsParser::SubElementConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ValueConstraintGroupXmlParser::SubElementConstraintsParser::SubElementConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _valueConstraintXmlParser = std::make_shared<ValueConstraintXmlParser>(messageLogger, filename);
+            _valueConstraintXmlParser = std::make_shared<ValueConstraintXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ValueConstraintGroupXmlParser::SubElementConstraintsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14424,10 +14439,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ValueConstraintGroupXmlParser::ValueConstraintGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ValueConstraintGroupXmlParser::ValueConstraintGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14437,7 +14452,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            ValueSetDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            ValueSetDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> ValueSetDistributionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -14449,13 +14464,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> ValueSetDistributionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementParameterValueSetsParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementParameterValueSetsParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        ValueSetDistributionXmlParser::SubElementParameterValueSetsParser::SubElementParameterValueSetsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        ValueSetDistributionXmlParser::SubElementParameterValueSetsParser::SubElementParameterValueSetsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterValueSetXmlParser = std::make_shared<ParameterValueSetXmlParser>(messageLogger, filename);
+            _parameterValueSetXmlParser = std::make_shared<ParameterValueSetXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void ValueSetDistributionXmlParser::SubElementParameterValueSetsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14495,10 +14510,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        ValueSetDistributionXmlParser::ValueSetDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        ValueSetDistributionXmlParser::ValueSetDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14508,7 +14523,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            VehicleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            VehicleXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> VehicleXmlParser::GetAttributeNameToAttributeParserMap()
@@ -14518,7 +14533,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeMass: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeMass(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeMass(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14553,11 +14568,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MASS, std::make_shared<AttributeMass>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MASS, std::make_shared<AttributeMass>(_messageLogger, _filename, _parserOptions)));
             class AttributeModel3d: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeModel3d(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeModel3d(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14592,11 +14607,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MODEL3D, std::make_shared<AttributeModel3d>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__MODEL3D, std::make_shared<AttributeModel3d>(_messageLogger, _filename, _parserOptions)));
             class AttributeName: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeName(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeName(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14631,11 +14646,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__NAME, std::make_shared<AttributeName>(_messageLogger, _filename, _parserOptions)));
             class AttributeVehicleCategory: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeVehicleCategory(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeVehicleCategory(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -14662,7 +14677,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (VehicleCategory::IsDeprecated(kResult))
+                        if (VehicleCategory::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  VehicleCategory::GetDeprecatedVersion(kResult) +"'. " + VehicleCategory::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -14679,24 +14694,24 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VEHICLE_CATEGORY, std::make_shared<AttributeVehicleCategory>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__VEHICLE_CATEGORY, std::make_shared<AttributeVehicleCategory>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> VehicleXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS) );
-            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPerformanceParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementAxlesParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElementParameterDeclarationsParser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATIONS, _parserOptions) );
+            result.push_back(std::make_shared<SubElementBoundingBoxParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPerformanceParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementAxlesParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPropertiesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        VehicleXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VehicleXmlParser::SubElementParameterDeclarationsParser::SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename);
+            _parameterDeclarationXmlParser = std::make_shared<ParameterDeclarationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VehicleXmlParser::SubElementParameterDeclarationsParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14732,9 +14747,9 @@ namespace NET_ASAM_OPENSCENARIO
         {
             return {OSC_CONSTANTS::ELEMENT__PARAMETER_DECLARATION};
         }
-        VehicleXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VehicleXmlParser::SubElementBoundingBoxParser::SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename);
+            _boundingBoxXmlParser = std::make_shared<BoundingBoxXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VehicleXmlParser::SubElementBoundingBoxParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14772,9 +14787,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__BOUNDING_BOX
                     };
         }
-        VehicleXmlParser::SubElementPerformanceParser::SubElementPerformanceParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VehicleXmlParser::SubElementPerformanceParser::SubElementPerformanceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _performanceXmlParser = std::make_shared<PerformanceXmlParser>(messageLogger, filename);
+            _performanceXmlParser = std::make_shared<PerformanceXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VehicleXmlParser::SubElementPerformanceParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14812,9 +14827,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PERFORMANCE
                     };
         }
-        VehicleXmlParser::SubElementAxlesParser::SubElementAxlesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VehicleXmlParser::SubElementAxlesParser::SubElementAxlesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _axlesXmlParser = std::make_shared<AxlesXmlParser>(messageLogger, filename);
+            _axlesXmlParser = std::make_shared<AxlesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VehicleXmlParser::SubElementAxlesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14852,9 +14867,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__AXLES
                     };
         }
-        VehicleXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VehicleXmlParser::SubElementPropertiesParser::SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename);
+            _propertiesXmlParser = std::make_shared<PropertiesXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VehicleXmlParser::SubElementPropertiesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14893,10 +14908,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        VehicleXmlParser::VehicleXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        VehicleXmlParser::VehicleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14906,7 +14921,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            VehicleCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            VehicleCatalogLocationXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> VehicleCatalogLocationXmlParser::GetAttributeNameToAttributeParserMap()
@@ -14919,13 +14934,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> VehicleCatalogLocationXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementDirectoryParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        VehicleCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VehicleCatalogLocationXmlParser::SubElementDirectoryParser::SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename);
+            _directoryXmlParser = std::make_shared<DirectoryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VehicleCatalogLocationXmlParser::SubElementDirectoryParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -14964,10 +14979,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        VehicleCatalogLocationXmlParser::VehicleCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        VehicleCatalogLocationXmlParser::VehicleCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -14977,7 +14992,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            VehicleCategoryDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            VehicleCategoryDistributionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> VehicleCategoryDistributionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -14989,13 +15004,13 @@ namespace NET_ASAM_OPENSCENARIO
         std::vector<std::shared_ptr<IElementParser>> VehicleCategoryDistributionXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementVehicleCategoryDistributionEntriesParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementVehicleCategoryDistributionEntriesParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        VehicleCategoryDistributionXmlParser::SubElementVehicleCategoryDistributionEntriesParser::SubElementVehicleCategoryDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VehicleCategoryDistributionXmlParser::SubElementVehicleCategoryDistributionEntriesParser::SubElementVehicleCategoryDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _vehicleCategoryDistributionEntryXmlParser = std::make_shared<VehicleCategoryDistributionEntryXmlParser>(messageLogger, filename);
+            _vehicleCategoryDistributionEntryXmlParser = std::make_shared<VehicleCategoryDistributionEntryXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VehicleCategoryDistributionXmlParser::SubElementVehicleCategoryDistributionEntriesParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15035,10 +15050,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        VehicleCategoryDistributionXmlParser::VehicleCategoryDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        VehicleCategoryDistributionXmlParser::VehicleCategoryDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15048,7 +15063,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            VehicleCategoryDistributionEntryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            VehicleCategoryDistributionEntryXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> VehicleCategoryDistributionEntryXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -15057,7 +15072,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeCategory: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCategory(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCategory(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15084,7 +15099,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (VehicleCategory::IsDeprecated(kResult))
+                        if (VehicleCategory::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  VehicleCategory::GetDeprecatedVersion(kResult) +"'. " + VehicleCategory::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -15101,11 +15116,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CATEGORY, std::make_shared<AttributeCategory>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CATEGORY, std::make_shared<AttributeCategory>(_messageLogger, _filename, _parserOptions)));
             class AttributeWeight: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeWeight(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15140,7 +15155,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__WEIGHT, std::make_shared<AttributeWeight>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -15151,10 +15166,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        VehicleCategoryDistributionEntryXmlParser::VehicleCategoryDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        VehicleCategoryDistributionEntryXmlParser::VehicleCategoryDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15164,7 +15179,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            VertexXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            VertexXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> VertexXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -15173,7 +15188,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeTime: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTime(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTime(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15208,20 +15223,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TIME, std::make_shared<AttributeTime>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TIME, std::make_shared<AttributeTime>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> VertexXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        VertexXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        VertexXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void VertexXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15260,10 +15275,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        VertexXmlParser::VertexXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        VertexXmlParser::VertexXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15273,7 +15288,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            VisibilityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            VisibilityActionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> VisibilityActionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -15282,7 +15297,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeGraphics: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeGraphics(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeGraphics(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15312,11 +15327,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__GRAPHICS, std::make_shared<AttributeGraphics>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__GRAPHICS, std::make_shared<AttributeGraphics>(_messageLogger, _filename, _parserOptions)));
             class AttributeSensors: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeSensors(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeSensors(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15346,11 +15361,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SENSORS, std::make_shared<AttributeSensors>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SENSORS, std::make_shared<AttributeSensors>(_messageLogger, _filename, _parserOptions)));
             class AttributeTraffic: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTraffic(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTraffic(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15380,7 +15395,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC, std::make_shared<AttributeTraffic>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TRAFFIC, std::make_shared<AttributeTraffic>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -15391,10 +15406,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        VisibilityActionXmlParser::VisibilityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        VisibilityActionXmlParser::VisibilityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15404,7 +15419,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            WaypointXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            WaypointXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> WaypointXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -15413,7 +15428,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeRouteStrategy: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeRouteStrategy(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeRouteStrategy(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15440,7 +15455,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (RouteStrategy::IsDeprecated(kResult))
+                        if (RouteStrategy::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  RouteStrategy::GetDeprecatedVersion(kResult) +"'. " + RouteStrategy::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -15457,20 +15472,20 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ROUTE_STRATEGY, std::make_shared<AttributeRouteStrategy>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ROUTE_STRATEGY, std::make_shared<AttributeRouteStrategy>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> WaypointXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementPositionParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        WaypointXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename)
+        WaypointXmlParser::SubElementPositionParser::SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename);
+            _positionXmlParser = std::make_shared<PositionXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void WaypointXmlParser::SubElementPositionParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15509,10 +15524,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        WaypointXmlParser::WaypointXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        WaypointXmlParser::WaypointXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15522,7 +15537,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            WeatherXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            WeatherXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> WeatherXmlParser::GetAttributeNameToAttributeParserMap()
@@ -15532,7 +15547,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeAtmosphericPressure: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeAtmosphericPressure(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeAtmosphericPressure(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15567,11 +15582,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ATMOSPHERIC_PRESSURE, std::make_shared<AttributeAtmosphericPressure>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__ATMOSPHERIC_PRESSURE, std::make_shared<AttributeAtmosphericPressure>(_messageLogger, _filename, _parserOptions)));
             class AttributeCloudState: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeCloudState(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeCloudState(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15598,7 +15613,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (CloudState::IsDeprecated(kResult))
+                        if (CloudState::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  CloudState::GetDeprecatedVersion(kResult) +"'. " + CloudState::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -15615,11 +15630,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CLOUD_STATE, std::make_shared<AttributeCloudState>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__CLOUD_STATE, std::make_shared<AttributeCloudState>(_messageLogger, _filename, _parserOptions)));
             class AttributeTemperature: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeTemperature(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeTemperature(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15654,23 +15669,23 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TEMPERATURE, std::make_shared<AttributeTemperature>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__TEMPERATURE, std::make_shared<AttributeTemperature>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
         std::vector<std::shared_ptr<IElementParser>> WeatherXmlParser::SubElementParser::CreateParserList()
         {
             std::vector<std::shared_ptr<IElementParser>> result;
-            result.push_back(std::make_shared<SubElementSunParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementFogParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementPrecipitationParser>(_messageLogger, _filename));
-            result.push_back(std::make_shared<SubElementWindParser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElementSunParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementFogParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementPrecipitationParser>(_messageLogger, _filename, _parserOptions));
+            result.push_back(std::make_shared<SubElementWindParser>(_messageLogger, _filename, _parserOptions));
             return result;
         }
 
-        WeatherXmlParser::SubElementSunParser::SubElementSunParser(IParserMessageLogger& messageLogger, std::string& filename)
+        WeatherXmlParser::SubElementSunParser::SubElementSunParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _sunXmlParser = std::make_shared<SunXmlParser>(messageLogger, filename);
+            _sunXmlParser = std::make_shared<SunXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void WeatherXmlParser::SubElementSunParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15708,9 +15723,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__SUN
                     };
         }
-        WeatherXmlParser::SubElementFogParser::SubElementFogParser(IParserMessageLogger& messageLogger, std::string& filename)
+        WeatherXmlParser::SubElementFogParser::SubElementFogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _fogXmlParser = std::make_shared<FogXmlParser>(messageLogger, filename);
+            _fogXmlParser = std::make_shared<FogXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void WeatherXmlParser::SubElementFogParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15748,9 +15763,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__FOG
                     };
         }
-        WeatherXmlParser::SubElementPrecipitationParser::SubElementPrecipitationParser(IParserMessageLogger& messageLogger, std::string& filename)
+        WeatherXmlParser::SubElementPrecipitationParser::SubElementPrecipitationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _precipitationXmlParser = std::make_shared<PrecipitationXmlParser>(messageLogger, filename);
+            _precipitationXmlParser = std::make_shared<PrecipitationXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void WeatherXmlParser::SubElementPrecipitationParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15788,9 +15803,9 @@ namespace NET_ASAM_OPENSCENARIO
                 OSC_CONSTANTS::ELEMENT__PRECIPITATION
                     };
         }
-        WeatherXmlParser::SubElementWindParser::SubElementWindParser(IParserMessageLogger& messageLogger, std::string& filename)
+        WeatherXmlParser::SubElementWindParser::SubElementWindParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _windXmlParser = std::make_shared<WindXmlParser>(messageLogger, filename);
+            _windXmlParser = std::make_shared<WindXmlParser>(messageLogger, filename, parserOptions);
         }
 
         void WeatherXmlParser::SubElementWindParser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -15829,10 +15844,10 @@ namespace NET_ASAM_OPENSCENARIO
                     };
         }
   
-        WeatherXmlParser::WeatherXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        WeatherXmlParser::WeatherXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15842,7 +15857,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            WindXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            WindXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> WindXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -15851,7 +15866,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeDirection: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeDirection(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeDirection(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15886,11 +15901,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DIRECTION, std::make_shared<AttributeDirection>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__DIRECTION, std::make_shared<AttributeDirection>(_messageLogger, _filename, _parserOptions)));
             class AttributeSpeed: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeSpeed(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeSpeed(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15925,7 +15940,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SPEED, std::make_shared<AttributeSpeed>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__SPEED, std::make_shared<AttributeSpeed>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -15936,10 +15951,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        WindXmlParser::WindXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        WindXmlParser::WindXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 
@@ -15949,7 +15964,7 @@ namespace NET_ASAM_OPENSCENARIO
          * 
          * @author RA Consulting OpenSCENARIO generation facility
         */
-            WorldPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            WorldPositionXmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
 
         std::map<std::string, std::shared_ptr<IAttributeParser>> WorldPositionXmlParser::GetAttributeNameToAttributeParserMap()
         {
@@ -15958,7 +15973,7 @@ namespace NET_ASAM_OPENSCENARIO
             class AttributeH: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeH(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeH(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -15993,11 +16008,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__H, std::make_shared<AttributeH>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__H, std::make_shared<AttributeH>(_messageLogger, _filename, _parserOptions)));
             class AttributeP: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeP(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeP(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -16032,11 +16047,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__P, std::make_shared<AttributeP>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__P, std::make_shared<AttributeP>(_messageLogger, _filename, _parserOptions)));
             class AttributeR: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeR(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeR(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -16071,11 +16086,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__R, std::make_shared<AttributeR>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__R, std::make_shared<AttributeR>(_messageLogger, _filename, _parserOptions)));
             class AttributeX: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeX(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeX(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -16110,11 +16125,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__X, std::make_shared<AttributeX>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__X, std::make_shared<AttributeX>(_messageLogger, _filename, _parserOptions)));
             class AttributeY: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeY(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeY(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -16149,11 +16164,11 @@ namespace NET_ASAM_OPENSCENARIO
                     return 1;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Y, std::make_shared<AttributeY>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Y, std::make_shared<AttributeY>(_messageLogger, _filename, _parserOptions)));
             class AttributeZ: public IAttributeParser, public XmlParserBase
             {
             public:
-                AttributeZ(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                AttributeZ(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -16188,7 +16203,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return 0;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Z, std::make_shared<AttributeZ>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__Z, std::make_shared<AttributeZ>(_messageLogger, _filename, _parserOptions)));
             return result;
         }
 
@@ -16199,10 +16214,10 @@ namespace NET_ASAM_OPENSCENARIO
         }
 
   
-        WorldPositionXmlParser::WorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
-        XmlComplexTypeParser(messageLogger, filename)
+        WorldPositionXmlParser::WorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         
 

--- a/cpp/openScenarioLib/generated/v1_1/xmlParser/XmlParsersV1_1.h
+++ b/cpp/openScenarioLib/generated/v1_1/xmlParser/XmlParsersV1_1.h
@@ -287,8 +287,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -308,7 +309,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -327,8 +328,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AbsoluteSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            AbsoluteSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -354,8 +355,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -369,8 +371,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AbsoluteTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            AbsoluteTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -396,8 +398,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -411,8 +414,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AbsoluteTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            AbsoluteTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -438,8 +441,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -453,8 +457,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AbsoluteTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            AbsoluteTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -480,8 +484,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -495,8 +500,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AccelerationConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            AccelerationConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -522,8 +527,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -544,7 +550,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -563,8 +569,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AcquirePositionActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            AcquirePositionActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -590,8 +596,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -611,7 +618,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementManeuverGroupsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementManeuverGroupsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -636,7 +643,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -661,7 +668,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -680,8 +687,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ActXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ActXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -707,8 +714,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -729,7 +737,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementGlobalActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementGlobalActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -754,7 +762,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementUserDefinedActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementUserDefinedActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -779,7 +787,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPrivateActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPrivateActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -798,8 +806,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -825,8 +833,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -840,8 +849,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ActivateControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ActivateControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -867,8 +876,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -888,7 +898,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -907,8 +917,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ActorsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ActorsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -934,8 +944,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -956,7 +967,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -975,8 +986,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AddEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            AddEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1002,8 +1013,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -1024,7 +1036,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1049,7 +1061,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1068,8 +1080,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AssignControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            AssignControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1095,8 +1107,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -1117,7 +1130,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1142,7 +1155,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1161,8 +1174,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AssignRouteActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            AssignRouteActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1188,8 +1201,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -1203,8 +1217,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AxleXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            AxleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1230,8 +1244,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -1251,7 +1266,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFrontAxleParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFrontAxleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1276,7 +1291,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRearAxleParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRearAxleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1301,7 +1316,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAdditionalAxlesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAdditionalAxlesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1320,8 +1335,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            AxlesXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            AxlesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1347,8 +1362,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -1369,7 +1385,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCenterParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCenterParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1394,7 +1410,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDimensionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDimensionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1413,8 +1429,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            BoundingBoxXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            BoundingBoxXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1440,8 +1456,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -1462,7 +1479,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTriggeringEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTriggeringEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1487,7 +1504,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1506,8 +1523,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ByEntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ByEntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1533,8 +1550,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -1548,8 +1566,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ByObjectTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ByObjectTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1575,8 +1593,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -1590,8 +1609,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ByTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ByTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1617,8 +1636,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -1639,7 +1659,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1664,7 +1684,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTimeOfDayConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTimeOfDayConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1689,7 +1709,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSimulationTimeConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSimulationTimeConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1714,7 +1734,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStoryboardElementStateConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStoryboardElementStateConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1739,7 +1759,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementUserDefinedValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementUserDefinedValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1764,7 +1784,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSignalConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSignalConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1789,7 +1809,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSignalControllerConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSignalControllerConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1808,8 +1828,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ByValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ByValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -1835,8 +1855,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -1856,7 +1877,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementVehiclesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementVehiclesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1881,7 +1902,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllersParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllersParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1906,7 +1927,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPedestriansParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPedestriansParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1931,7 +1952,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementMiscObjectsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementMiscObjectsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1956,7 +1977,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEnvironmentsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEnvironmentsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -1981,7 +2002,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2006,7 +2027,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrajectoriesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrajectoriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2031,7 +2052,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRoutesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRoutesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2050,8 +2071,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CatalogXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            CatalogXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2076,8 +2097,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -2097,7 +2119,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2116,8 +2138,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CatalogDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            CatalogDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2143,8 +2165,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -2165,7 +2188,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementVehicleCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementVehicleCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2190,7 +2213,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllerCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllerCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2215,7 +2238,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPedestrianCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPedestrianCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2240,7 +2263,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementMiscObjectCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementMiscObjectCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2265,7 +2288,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEnvironmentCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEnvironmentCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2290,7 +2313,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementManeuverCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementManeuverCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2315,7 +2338,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrajectoryCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrajectoryCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2340,7 +2363,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRouteCatalogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRouteCatalogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2359,8 +2382,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CatalogLocationsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            CatalogLocationsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2386,8 +2409,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -2407,7 +2431,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterAssignmentsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterAssignmentsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2426,8 +2450,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CatalogReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            CatalogReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2453,8 +2477,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -2468,8 +2493,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CenterXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            CenterXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2495,8 +2520,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -2510,8 +2536,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CentralSwarmObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            CentralSwarmObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2537,8 +2563,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -2558,7 +2585,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2577,8 +2604,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ClothoidXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ClothoidXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2604,8 +2631,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -2626,7 +2654,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2651,7 +2679,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2670,8 +2698,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            CollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2697,8 +2725,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -2719,7 +2748,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementByEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementByEntityConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2744,7 +2773,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementByValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementByValueConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2763,8 +2792,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2790,8 +2819,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -2811,7 +2841,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementConditionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementConditionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2830,8 +2860,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ConditionGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ConditionGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2857,8 +2887,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -2878,7 +2909,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2897,8 +2928,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ControlPointXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ControlPointXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -2924,8 +2955,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -2946,7 +2978,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2971,7 +3003,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -2990,8 +3022,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3017,8 +3049,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -3039,7 +3072,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAssignControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAssignControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3064,7 +3097,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOverrideControllerValueActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOverrideControllerValueActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3089,7 +3122,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementActivateControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementActivateControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3108,8 +3141,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3135,8 +3168,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -3157,7 +3191,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3176,8 +3210,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ControllerCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ControllerCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3203,8 +3237,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3224,7 +3259,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllerDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllerDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3243,8 +3278,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ControllerDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ControllerDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3270,8 +3305,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -3292,7 +3328,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3317,7 +3353,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3336,8 +3372,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ControllerDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ControllerDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3363,8 +3399,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            CustomCommandActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            CustomCommandActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3390,8 +3426,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3405,8 +3442,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DeleteEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DeleteEntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3432,8 +3469,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3453,7 +3491,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDeterministicParameterDistributionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDeterministicParameterDistributionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3472,8 +3510,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DeterministicXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DeterministicXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3499,8 +3537,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3520,7 +3559,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDeterministicMultiParameterDistributionTypeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDeterministicMultiParameterDistributionTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3539,8 +3578,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DeterministicMultiParameterDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DeterministicMultiParameterDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3565,8 +3604,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3586,7 +3626,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementValueSetDistributionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementValueSetDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3605,8 +3645,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DeterministicMultiParameterDistributionTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DeterministicMultiParameterDistributionTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3631,8 +3671,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -3653,7 +3694,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDeterministicMultiParameterDistributionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDeterministicMultiParameterDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3678,7 +3719,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDeterministicSingleParameterDistributionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDeterministicSingleParameterDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3697,8 +3738,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DeterministicParameterDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DeterministicParameterDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3724,8 +3765,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3745,7 +3787,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDeterministicSingleParameterDistributionTypeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDeterministicSingleParameterDistributionTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3764,8 +3806,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DeterministicSingleParameterDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DeterministicSingleParameterDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3790,8 +3832,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -3812,7 +3855,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDistributionSetParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDistributionSetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3837,7 +3880,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDistributionRangeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDistributionRangeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3862,7 +3905,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementUserDefinedDistributionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementUserDefinedDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -3881,8 +3924,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DeterministicSingleParameterDistributionTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DeterministicSingleParameterDistributionTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3908,8 +3951,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3923,8 +3967,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DimensionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DimensionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3950,8 +3994,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -3965,8 +4010,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DirectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DirectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -3992,8 +4037,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -4014,7 +4060,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4033,8 +4079,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4059,8 +4105,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -4081,7 +4128,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDeterministicParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDeterministicParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4106,7 +4153,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStochasticParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStochasticParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4125,8 +4172,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DistributionDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DistributionDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4152,8 +4199,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -4174,7 +4222,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4193,8 +4241,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DistributionRangeXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DistributionRangeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4220,8 +4268,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -4241,7 +4290,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementElementsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementElementsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4260,8 +4309,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DistributionSetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DistributionSetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4287,8 +4336,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -4303,8 +4353,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DistributionSetElementXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DistributionSetElementXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4330,8 +4380,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -4345,8 +4396,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            DynamicConstraintsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            DynamicConstraintsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4372,8 +4423,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -4387,8 +4439,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EndOfRoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            EndOfRoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4414,8 +4466,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -4435,7 +4488,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementScenarioObjectsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementScenarioObjectsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4460,7 +4513,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntitySelectionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntitySelectionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4479,8 +4532,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            EntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4506,8 +4559,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -4528,7 +4582,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAddEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAddEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4553,7 +4607,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDeleteEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDeleteEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4572,8 +4626,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            EntityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4599,8 +4653,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -4621,7 +4676,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEndOfRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEndOfRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4646,7 +4701,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4671,7 +4726,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOffroadConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOffroadConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4696,7 +4751,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTimeHeadwayConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTimeHeadwayConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4721,7 +4776,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTimeToCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTimeToCollisionConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4746,7 +4801,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAccelerationConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAccelerationConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4771,7 +4826,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStandStillConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStandStillConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4796,7 +4851,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4821,7 +4876,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeSpeedConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4846,7 +4901,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTraveledDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTraveledDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4871,7 +4926,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementReachPositionConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementReachPositionConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4896,7 +4951,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4921,7 +4976,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeDistanceConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -4940,8 +4995,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            EntityConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -4966,8 +5021,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -4988,7 +5044,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5013,7 +5069,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementVehicleParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementVehicleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5038,7 +5094,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPedestrianParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPedestrianParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5063,7 +5119,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementMiscObjectParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementMiscObjectParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5088,7 +5144,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementExternalObjectReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementExternalObjectReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5107,8 +5163,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EntityObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            EntityObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5134,8 +5190,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -5149,8 +5206,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EntityRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            EntityRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5176,8 +5233,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -5197,7 +5255,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementMembersParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementMembersParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5216,8 +5274,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EntitySelectionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            EntitySelectionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5243,8 +5301,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -5265,7 +5324,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5290,7 +5349,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTimeOfDayParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTimeOfDayParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5315,7 +5374,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementWeatherParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementWeatherParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5340,7 +5399,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRoadConditionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5359,8 +5418,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EnvironmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            EnvironmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5386,8 +5445,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -5408,7 +5468,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEnvironmentParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEnvironmentParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5433,7 +5493,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5452,8 +5512,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EnvironmentActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            EnvironmentActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5479,8 +5539,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -5501,7 +5562,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5520,8 +5581,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EnvironmentCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            EnvironmentCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5547,8 +5608,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -5568,7 +5630,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5593,7 +5655,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStartTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5612,8 +5674,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            EventXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            EventXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5639,8 +5701,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -5655,8 +5718,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ExternalObjectReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ExternalObjectReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5682,8 +5745,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -5697,8 +5761,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            FileXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            FileXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5724,8 +5788,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -5745,7 +5810,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLicenseParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLicenseParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5764,8 +5829,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            FileHeaderXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            FileHeaderXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5791,8 +5856,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -5813,7 +5879,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAbsoluteSpeedParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAbsoluteSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5838,7 +5904,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeSpeedToMasterParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeSpeedToMasterParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5857,8 +5923,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            FinalSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            FinalSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5884,8 +5950,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -5906,7 +5973,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5925,8 +5992,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            FogXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            FogXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -5952,8 +6019,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -5974,7 +6042,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrajectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrajectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -5999,7 +6067,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6024,7 +6092,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTimeReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTimeReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6049,7 +6117,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrajectoryFollowingModeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrajectoryFollowingModeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6074,7 +6142,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrajectoryRefParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrajectoryRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6093,8 +6161,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            FollowTrajectoryActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            FollowTrajectoryActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6120,8 +6188,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -6142,7 +6211,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6161,8 +6230,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            GeoPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            GeoPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6188,8 +6257,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -6210,7 +6280,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEnvironmentActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEnvironmentActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6235,7 +6305,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6260,7 +6330,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6285,7 +6355,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementInfrastructureActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementInfrastructureActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6310,7 +6380,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6329,8 +6399,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            GlobalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            GlobalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6356,8 +6426,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -6377,7 +6448,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementBinsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementBinsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6396,8 +6467,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            HistogramXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            HistogramXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6423,8 +6494,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -6444,7 +6516,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6463,8 +6535,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            HistogramBinXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            HistogramBinXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6490,8 +6562,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -6512,7 +6585,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFromCurrentEntityParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFromCurrentEntityParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6537,7 +6610,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFromRoadCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFromRoadCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6562,7 +6635,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFromLaneCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFromLaneCoordinatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6581,8 +6654,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            InRoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            InRoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6608,8 +6681,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -6630,7 +6704,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSignalActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSignalActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6649,8 +6723,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            InfrastructureActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            InfrastructureActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6676,8 +6750,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -6697,7 +6772,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6716,8 +6791,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            InitXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            InitXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6743,8 +6818,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -6764,7 +6840,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementGlobalActionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementGlobalActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6789,7 +6865,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementUserDefinedActionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementUserDefinedActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6814,7 +6890,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPrivatesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPrivatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6833,8 +6909,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            InitActionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            InitActionsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6860,8 +6936,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -6875,8 +6952,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            KnotXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            KnotXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6902,8 +6979,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -6924,7 +7002,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLaneChangeActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLaneChangeActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6949,7 +7027,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLaneChangeTargetParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLaneChangeTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -6968,8 +7046,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LaneChangeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            LaneChangeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -6995,8 +7073,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -7017,7 +7096,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7042,7 +7121,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAbsoluteTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAbsoluteTargetLaneParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7061,8 +7140,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LaneChangeTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            LaneChangeTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7088,8 +7167,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -7110,7 +7190,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLaneOffsetActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLaneOffsetActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7135,7 +7215,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLaneOffsetTargetParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLaneOffsetTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7154,8 +7234,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LaneOffsetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            LaneOffsetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7181,8 +7261,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -7196,8 +7277,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LaneOffsetActionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            LaneOffsetActionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7223,8 +7304,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -7245,7 +7327,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7270,7 +7352,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAbsoluteTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAbsoluteTargetLaneOffsetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7289,8 +7371,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LaneOffsetTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            LaneOffsetTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7316,8 +7398,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -7338,7 +7421,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7357,8 +7440,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            LanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7384,8 +7467,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -7406,7 +7490,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLaneChangeActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLaneChangeActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7431,7 +7515,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLaneOffsetActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLaneOffsetActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7456,7 +7540,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLateralDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLateralDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7475,8 +7559,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LateralActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            LateralActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7502,8 +7586,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -7524,7 +7609,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7543,8 +7628,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LateralDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            LateralDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7570,8 +7655,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LicenseXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            LicenseXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7597,8 +7682,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -7619,7 +7705,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSpeedActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSpeedActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7644,7 +7730,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLongitudinalDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLongitudinalDistanceActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7663,8 +7749,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LongitudinalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            LongitudinalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7690,8 +7776,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -7712,7 +7799,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDynamicConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7731,8 +7818,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            LongitudinalDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            LongitudinalDistanceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7758,8 +7845,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -7779,7 +7867,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7804,7 +7892,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEventsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEventsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7823,8 +7911,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ManeuverXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ManeuverXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7850,8 +7938,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -7872,7 +7961,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7891,8 +7980,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ManeuverCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ManeuverCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -7918,8 +8007,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -7939,7 +8029,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementActorsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementActorsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7964,7 +8054,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferencesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferencesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -7989,7 +8079,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementManeuversParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8008,8 +8098,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ManeuverGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ManeuverGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8035,8 +8125,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -8057,7 +8148,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8082,7 +8173,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8107,7 +8198,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8126,8 +8217,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            MiscObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            MiscObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8153,8 +8244,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -8175,7 +8267,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8194,8 +8286,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            MiscObjectCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            MiscObjectCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8221,8 +8313,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -8243,7 +8336,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAddValueParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAddValueParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8268,7 +8361,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementMultiplyByValueParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementMultiplyByValueParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8287,8 +8380,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ModifyRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ModifyRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8314,8 +8407,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8329,8 +8423,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            NoneXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            NoneXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8356,8 +8450,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8377,7 +8472,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8396,8 +8491,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            NormalDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            NormalDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8423,8 +8518,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8444,7 +8540,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControlPointsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControlPointsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8469,7 +8565,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementKnotsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementKnotsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8488,8 +8584,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            NurbsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            NurbsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8515,8 +8611,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -8537,7 +8634,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8562,7 +8659,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8581,8 +8678,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ObjectControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ObjectControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8608,8 +8705,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8623,8 +8721,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OffroadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            OffroadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8650,8 +8748,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8671,7 +8770,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFileHeaderParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFileHeaderParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8696,7 +8795,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOpenScenarioCategoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOpenScenarioCategoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8715,8 +8814,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OpenScenarioXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            OpenScenarioXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8741,8 +8840,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -8763,7 +8863,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementScenarioDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementScenarioDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8788,7 +8888,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8813,7 +8913,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterValueDistributionDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterValueDistributionDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -8832,8 +8932,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OpenScenarioCategoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            OpenScenarioCategoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8859,8 +8959,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8874,8 +8975,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OrientationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            OrientationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8901,8 +9002,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8916,8 +9018,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OverrideBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            OverrideBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8943,8 +9045,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -8958,8 +9061,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OverrideClutchActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            OverrideClutchActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -8985,8 +9088,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -9007,7 +9111,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementThrottleParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementThrottleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9032,7 +9136,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementBrakeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementBrakeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9057,7 +9161,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementClutchParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementClutchParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9082,7 +9186,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParkingBrakeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParkingBrakeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9107,7 +9211,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSteeringWheelParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSteeringWheelParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9132,7 +9236,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementGearParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementGearParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9151,8 +9255,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OverrideControllerValueActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            OverrideControllerValueActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9178,8 +9282,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9193,8 +9298,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OverrideGearActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            OverrideGearActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9220,8 +9325,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9235,8 +9341,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OverrideParkingBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            OverrideParkingBrakeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9262,8 +9368,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9277,8 +9384,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OverrideSteeringWheelActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            OverrideSteeringWheelActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9304,8 +9411,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9319,8 +9427,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            OverrideThrottleActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            OverrideThrottleActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9346,8 +9454,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -9368,7 +9477,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSetActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSetActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9393,7 +9502,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementModifyActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementModifyActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9412,8 +9521,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ParameterActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9439,8 +9548,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9454,8 +9564,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterAddValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ParameterAddValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9481,8 +9591,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9496,8 +9607,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterAssignmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ParameterAssignmentXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9523,8 +9634,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9538,8 +9650,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ParameterConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9565,8 +9677,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9586,7 +9699,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementConstraintGroupsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementConstraintGroupsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9605,8 +9718,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterDeclarationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ParameterDeclarationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9632,8 +9745,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -9654,7 +9768,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRuleParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRuleParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9673,8 +9787,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterModifyActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ParameterModifyActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9700,8 +9814,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9715,8 +9830,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterMultiplyByValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ParameterMultiplyByValueRuleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9742,8 +9857,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9757,8 +9873,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterSetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ParameterSetActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9784,8 +9900,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9805,7 +9922,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementScenarioFileParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementScenarioFileParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9830,7 +9947,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDistributionDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDistributionDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9849,8 +9966,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterValueDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ParameterValueDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9875,8 +9992,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9896,7 +10014,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterValueDistributionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterValueDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9915,8 +10033,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterValueDistributionDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ParameterValueDistributionDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -9942,8 +10060,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -9963,7 +10082,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterAssignmentsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterAssignmentsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -9982,8 +10101,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ParameterValueSetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ParameterValueSetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10009,8 +10128,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -10031,7 +10151,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10056,7 +10176,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10081,7 +10201,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10100,8 +10220,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PedestrianXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PedestrianXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10127,8 +10247,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -10149,7 +10270,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10168,8 +10289,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PedestrianCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PedestrianCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10195,8 +10316,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10210,8 +10332,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PerformanceXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PerformanceXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10237,8 +10359,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10258,7 +10381,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSignalStatesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSignalStatesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10277,8 +10400,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PhaseXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PhaseXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10304,8 +10427,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10325,7 +10449,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10344,8 +10468,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PoissonDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PoissonDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10371,8 +10495,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10392,7 +10517,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementVerticesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementVerticesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10411,8 +10536,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PolylineXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PolylineXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10438,8 +10563,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -10460,7 +10586,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10485,7 +10611,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeWorldPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10510,7 +10636,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeObjectPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeObjectPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10535,7 +10661,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10560,7 +10686,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeRoadPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10585,7 +10711,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10610,7 +10736,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeLanePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10635,7 +10761,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10660,7 +10786,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementGeoPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementGeoPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10685,7 +10811,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrajectoryPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrajectoryPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10704,8 +10830,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10731,8 +10857,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10746,8 +10873,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PositionInLaneCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PositionInLaneCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10773,8 +10900,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10788,8 +10916,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PositionInRoadCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PositionInRoadCoordinatesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10815,8 +10943,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10830,8 +10959,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PositionOfCurrentEntityXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PositionOfCurrentEntityXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10857,8 +10986,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10872,8 +11002,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PrecipitationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PrecipitationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10899,8 +11029,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -10920,7 +11051,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPrivateActionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPrivateActionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -10939,8 +11070,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PrivateXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PrivateXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -10966,8 +11097,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -10988,7 +11120,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLongitudinalActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLongitudinalActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11013,7 +11145,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLateralActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLateralActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11038,7 +11170,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementVisibilityActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementVisibilityActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11063,7 +11195,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSynchronizeActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSynchronizeActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11088,7 +11220,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementActivateControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementActivateControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11113,7 +11245,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11138,7 +11270,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTeleportActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTeleportActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11163,7 +11295,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRoutingActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRoutingActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11182,8 +11314,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PrivateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PrivateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11209,8 +11341,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11230,7 +11363,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementElementsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementElementsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11249,8 +11382,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ProbabilityDistributionSetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ProbabilityDistributionSetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11276,8 +11409,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -11292,8 +11426,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ProbabilityDistributionSetElementXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ProbabilityDistributionSetElementXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11319,8 +11453,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11340,7 +11475,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11365,7 +11500,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFilesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFilesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11384,8 +11519,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PropertiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PropertiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11411,8 +11546,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11426,8 +11562,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            PropertyXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            PropertyXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11453,8 +11589,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11468,8 +11605,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RangeXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RangeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11495,8 +11632,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -11517,7 +11655,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11536,8 +11674,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ReachPositionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ReachPositionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11563,8 +11701,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11578,8 +11717,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RelativeDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11605,8 +11744,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -11627,7 +11767,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11646,8 +11786,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeLanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RelativeLanePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11673,8 +11813,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -11695,7 +11836,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11714,8 +11855,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeObjectPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RelativeObjectPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11741,8 +11882,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -11763,7 +11905,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11782,8 +11924,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeRoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RelativeRoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11809,8 +11951,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11824,8 +11967,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeSpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RelativeSpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11851,8 +11994,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11872,7 +12016,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -11891,8 +12035,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeSpeedToMasterXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RelativeSpeedToMasterXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11918,8 +12062,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11933,8 +12078,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RelativeTargetLaneXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -11960,8 +12105,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -11975,8 +12121,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RelativeTargetLaneOffsetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12002,8 +12148,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -12017,8 +12164,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RelativeTargetSpeedXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12044,8 +12191,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -12066,7 +12214,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12085,8 +12233,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RelativeWorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RelativeWorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12112,8 +12260,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -12133,7 +12282,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12152,8 +12301,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RoadConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12179,8 +12328,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -12200,7 +12350,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementLogicFileParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementLogicFileParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12225,7 +12375,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSceneGraphFileParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSceneGraphFileParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12250,7 +12400,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSignalsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSignalsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12275,7 +12425,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementUsedAreaParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementUsedAreaParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12294,8 +12444,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RoadNetworkXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RoadNetworkXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12321,8 +12471,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -12343,7 +12494,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12362,8 +12513,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RoadPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12389,8 +12540,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -12410,7 +12562,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12435,7 +12587,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementWaypointsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementWaypointsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12454,8 +12606,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RouteXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RouteXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12481,8 +12633,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -12503,7 +12656,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12522,8 +12675,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RouteCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RouteCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12549,8 +12702,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -12571,7 +12725,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRouteRefParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRouteRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12596,7 +12750,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12621,7 +12775,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementInRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementInRoutePositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12640,8 +12794,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RoutePositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12667,8 +12821,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -12689,7 +12844,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRouteParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12714,7 +12869,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12733,8 +12888,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RouteRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RouteRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12760,8 +12915,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -12782,7 +12938,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAssignRouteActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAssignRouteActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12807,7 +12963,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFollowTrajectoryActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFollowTrajectoryActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12832,7 +12988,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAcquirePositionActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAcquirePositionActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12851,8 +13007,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            RoutingActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            RoutingActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -12877,8 +13033,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -12898,7 +13055,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12923,7 +13080,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogLocationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogLocationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12948,7 +13105,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRoadNetworkParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRoadNetworkParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12973,7 +13130,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntitiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -12998,7 +13155,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStoryboardParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStoryboardParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13017,8 +13174,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ScenarioDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ScenarioDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13044,8 +13201,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13065,7 +13223,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityObjectParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityObjectParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13090,7 +13248,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementObjectControllerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementObjectControllerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13109,8 +13267,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ScenarioObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ScenarioObjectXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13136,8 +13294,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -13158,7 +13317,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13183,7 +13342,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementByTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13202,8 +13361,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SelectedEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            SelectedEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13229,8 +13388,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -13251,7 +13411,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPolylineParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPolylineParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13276,7 +13436,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementClothoidParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementClothoidParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13301,7 +13461,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementNurbsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementNurbsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13320,8 +13480,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ShapeXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ShapeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13347,8 +13507,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13362,8 +13523,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SimulationTimeConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            SimulationTimeConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13389,8 +13550,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -13411,7 +13573,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSpeedActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSpeedActionDynamicsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13436,7 +13598,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSpeedActionTargetParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSpeedActionTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13455,8 +13617,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SpeedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            SpeedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13482,8 +13644,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -13504,7 +13667,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRelativeTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRelativeTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13529,7 +13692,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAbsoluteTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAbsoluteTargetSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13548,8 +13711,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SpeedActionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            SpeedActionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13575,8 +13738,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13590,8 +13754,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            SpeedConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13617,8 +13781,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13632,8 +13797,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            StandStillConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            StandStillConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13658,8 +13823,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -13680,7 +13846,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTargetDistanceSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTargetDistanceSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13705,7 +13871,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTargetTimeSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTargetTimeSteadyStateParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13724,8 +13890,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SteadyStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            SteadyStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13751,8 +13917,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13772,7 +13939,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStochasticDistributionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStochasticDistributionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13791,8 +13958,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            StochasticXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            StochasticXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13818,8 +13985,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -13839,7 +14007,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStochasticDistributionTypeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStochasticDistributionTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13858,8 +14026,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            StochasticDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            StochasticDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -13884,8 +14052,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -13906,7 +14075,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementProbabilityDistributionSetParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementProbabilityDistributionSetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13931,7 +14100,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementNormalDistributionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementNormalDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13956,7 +14125,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementUniformDistributionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementUniformDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -13981,7 +14150,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPoissonDistributionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPoissonDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14006,7 +14175,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementHistogramParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementHistogramParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14031,7 +14200,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementUserDefinedDistributionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementUserDefinedDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14050,8 +14219,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            StochasticDistributionTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            StochasticDistributionTypeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14077,8 +14246,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14098,7 +14268,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14123,7 +14293,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementActsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementActsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14142,8 +14312,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            StoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            StoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14169,8 +14339,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14190,7 +14361,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementInitParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementInitParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14215,7 +14386,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStoriesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStoriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14240,7 +14411,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementStopTriggerParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14259,8 +14430,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            StoryboardXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            StoryboardXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14286,8 +14457,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14301,8 +14473,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            StoryboardElementStateConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            StoryboardElementStateConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14328,8 +14500,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14343,8 +14516,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SunXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            SunXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14370,8 +14543,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -14392,7 +14566,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTargetPositionMasterParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTargetPositionMasterParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14417,7 +14591,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTargetPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTargetPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14442,7 +14616,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFinalSpeedParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFinalSpeedParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14461,8 +14635,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            SynchronizeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            SynchronizeActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14488,8 +14662,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -14504,8 +14679,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TargetDistanceSteadyStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TargetDistanceSteadyStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14531,8 +14706,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -14547,8 +14723,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TargetTimeSteadyStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TargetTimeSteadyStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14574,8 +14750,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14595,7 +14772,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14614,8 +14791,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TeleportActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TeleportActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14641,8 +14818,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14656,8 +14834,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TimeHeadwayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TimeHeadwayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14683,8 +14861,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14698,8 +14877,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TimeOfDayXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TimeOfDayXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14725,8 +14904,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -14740,8 +14920,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TimeOfDayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TimeOfDayConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14767,8 +14947,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -14789,7 +14970,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementNoneParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementNoneParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14814,7 +14995,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTimingParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTimingParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14833,8 +15014,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TimeReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TimeReferenceXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14860,8 +15041,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -14882,7 +15064,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTimeToCollisionConditionTargetParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTimeToCollisionConditionTargetParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14901,8 +15083,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TimeToCollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TimeToCollisionConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -14928,8 +15110,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -14950,7 +15133,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14975,7 +15158,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -14994,8 +15177,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TimeToCollisionConditionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TimeToCollisionConditionTargetXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15021,8 +15204,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -15036,8 +15220,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TimingXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TimingXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15063,8 +15247,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -15085,7 +15270,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSourceActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSourceActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15110,7 +15295,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSinkActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSinkActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15135,7 +15320,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSwarmActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSwarmActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15160,7 +15345,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficStopActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficStopActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15179,8 +15364,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrafficActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15206,8 +15391,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -15228,7 +15414,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementVehicleCategoryDistributionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementVehicleCategoryDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15253,7 +15439,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementControllerDistributionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementControllerDistributionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15272,8 +15458,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrafficDefinitionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15299,8 +15485,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -15321,7 +15508,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSignalControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSignalControllerActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15346,7 +15533,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficSignalStateActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficSignalStateActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15365,8 +15552,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSignalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrafficSignalActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15392,8 +15579,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -15407,8 +15595,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSignalConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrafficSignalConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15434,8 +15622,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -15455,7 +15644,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPhasesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPhasesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15474,8 +15663,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSignalControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrafficSignalControllerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15501,8 +15690,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -15516,8 +15706,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSignalControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrafficSignalControllerActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15543,8 +15733,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -15558,8 +15749,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSignalControllerConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrafficSignalControllerConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15585,8 +15776,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -15600,8 +15792,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSignalStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrafficSignalStateXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15627,8 +15819,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -15642,8 +15835,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSignalStateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrafficSignalStateActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15669,8 +15862,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -15691,7 +15885,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15716,7 +15910,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15735,8 +15929,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSinkActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrafficSinkActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15762,8 +15956,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -15784,7 +15979,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15809,7 +16004,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15828,8 +16023,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSourceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrafficSourceActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15855,8 +16050,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -15870,8 +16066,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficStopActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrafficStopActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15897,8 +16093,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -15919,7 +16116,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCentralObjectParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCentralObjectParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15944,7 +16141,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrafficDefinitionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -15963,8 +16160,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrafficSwarmActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrafficSwarmActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -15990,8 +16187,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -16011,7 +16209,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -16036,7 +16234,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementShapeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementShapeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -16055,8 +16253,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrajectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrajectoryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16082,8 +16280,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -16104,7 +16303,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -16123,8 +16322,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrajectoryCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrajectoryCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16150,8 +16349,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -16165,8 +16365,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrajectoryFollowingModeXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrajectoryFollowingModeXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16192,8 +16392,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -16214,7 +16415,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementOrientationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -16239,7 +16440,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrajectoryRefParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrajectoryRefParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -16258,8 +16459,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrajectoryPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrajectoryPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16285,8 +16486,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -16307,7 +16509,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementTrajectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementTrajectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -16332,7 +16534,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCatalogReferenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -16351,8 +16553,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TrajectoryRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TrajectoryRefXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16378,8 +16580,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -16393,8 +16596,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TransitionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TransitionDynamicsXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16420,8 +16623,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -16435,8 +16639,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TraveledDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TraveledDistanceConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16462,8 +16666,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -16483,7 +16688,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementConditionGroupsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementConditionGroupsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -16502,8 +16707,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TriggerXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TriggerXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16529,8 +16734,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -16550,7 +16756,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementEntityRefsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -16569,8 +16775,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            TriggeringEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            TriggeringEntitiesXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16596,8 +16802,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -16617,7 +16824,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementRangeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -16636,8 +16843,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            UniformDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            UniformDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16663,8 +16870,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -16684,7 +16892,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -16703,8 +16911,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            UsedAreaXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            UsedAreaXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16730,8 +16938,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -16751,7 +16960,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementCustomCommandActionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementCustomCommandActionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -16770,8 +16979,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            UserDefinedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            UserDefinedActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16797,8 +17006,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            UserDefinedDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            UserDefinedDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16824,8 +17033,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -16839,8 +17049,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            UserDefinedValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            UserDefinedValueConditionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16866,8 +17076,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -16882,8 +17093,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ValueConstraintXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ValueConstraintXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16909,8 +17120,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -16930,7 +17142,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementConstraintsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -16949,8 +17161,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ValueConstraintGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ValueConstraintGroupXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -16976,8 +17188,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -16997,7 +17210,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterValueSetsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterValueSetsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -17016,8 +17229,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            ValueSetDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            ValueSetDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -17043,8 +17256,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -17065,7 +17279,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParameterDeclarationsParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -17090,7 +17304,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementBoundingBoxParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -17115,7 +17329,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPerformanceParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPerformanceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -17140,7 +17354,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementAxlesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementAxlesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -17165,7 +17379,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPropertiesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -17184,8 +17398,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            VehicleXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            VehicleXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -17211,8 +17425,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -17233,7 +17448,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementDirectoryParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -17252,8 +17467,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            VehicleCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            VehicleCatalogLocationXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -17279,8 +17494,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -17300,7 +17516,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementVehicleCategoryDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementVehicleCategoryDistributionEntriesParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -17319,8 +17535,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            VehicleCategoryDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            VehicleCategoryDistributionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -17346,8 +17562,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -17361,8 +17578,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            VehicleCategoryDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            VehicleCategoryDistributionEntryXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -17388,8 +17605,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -17409,7 +17627,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -17428,8 +17646,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            VertexXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            VertexXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -17455,8 +17673,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -17470,8 +17689,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            VisibilityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            VisibilityActionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -17497,8 +17716,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -17518,7 +17738,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPositionParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -17537,8 +17757,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            WaypointXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            WaypointXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -17564,8 +17784,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
             protected:
                 /*
@@ -17586,7 +17807,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementSunParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementSunParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -17611,7 +17832,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementFogParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementFogParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -17636,7 +17857,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementPrecipitationParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementPrecipitationParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -17661,7 +17882,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElementWindParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementWindParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -17680,8 +17901,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            WeatherXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            WeatherXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -17707,8 +17928,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -17722,8 +17944,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            WindXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            WindXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 
@@ -17749,8 +17971,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
             protected:
                 /*
                 * Creates a list of parser
@@ -17764,8 +17987,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            WorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            WorldPositionXmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
     }

--- a/cpp/openScenarioLib/src/parser/ParserOptions.cpp
+++ b/cpp/openScenarioLib/src/parser/ParserOptions.cpp
@@ -15,19 +15,18 @@
  * limitations under the License.
  */
 
-#include "XmlScenarioLoaderFactoryV1_1.h"
-#include "XmlScenarioLoaderV1_1.h"
-#include "MemLeakDetection.h"
+
+#include  "ParserOptions.h"
 
 namespace NET_ASAM_OPENSCENARIO
 {
-    namespace v1_1
-    {
-		XmlScenarioLoaderFactory::XmlScenarioLoaderFactory(const std::string filename, bool supressDeprecationWarnings) : _filename(filename), _supressDeprecationWarnings(supressDeprecationWarnings){}
+	void ParserOptions::SetOptionSupressDeprecationWarnings(bool setOption)
+	{
+		_optionSupressDeprecationWarnings = setOption;
+	}
 
-	    std::shared_ptr<IScenarioLoader> XmlScenarioLoaderFactory::CreateLoader(std::shared_ptr<IResourceLocator> resourceLocator)
-	    {
-	        return std::make_shared<XmlScenarioLoader>(_filename, resourceLocator, _supressDeprecationWarnings);
-	    }
-    }
+	bool ParserOptions::IsOptionSetSupressDeprecationWarnings()
+	{
+		return _optionSupressDeprecationWarnings;
+	}
 }

--- a/cpp/openScenarioLib/src/parser/ParserOptions.h
+++ b/cpp/openScenarioLib/src/parser/ParserOptions.h
@@ -15,19 +15,33 @@
  * limitations under the License.
  */
 
-#include "XmlScenarioLoaderFactoryV1_1.h"
-#include "XmlScenarioLoaderV1_1.h"
-#include "MemLeakDetection.h"
+#pragma once
 
+
+
+/**
+ * Options for Parsing
+ * @author Andreas Hege - RA Consulting
+ *
+ */
 namespace NET_ASAM_OPENSCENARIO
 {
-    namespace v1_1
+    /**
+     * Provides options for the parsing process
+     * @author Andreas Hege - RA Consulting
+     *
+     */
+    class ParserOptions 
     {
-		XmlScenarioLoaderFactory::XmlScenarioLoaderFactory(const std::string filename, bool supressDeprecationWarnings) : _filename(filename), _supressDeprecationWarnings(supressDeprecationWarnings){}
 
-	    std::shared_ptr<IScenarioLoader> XmlScenarioLoaderFactory::CreateLoader(std::shared_ptr<IResourceLocator> resourceLocator)
-	    {
-	        return std::make_shared<XmlScenarioLoader>(_filename, resourceLocator, _supressDeprecationWarnings);
-	    }
-    }
+    private:
+		bool _optionSupressDeprecationWarnings = false;
+    	
+    public:
+		ParserOptions() = default;
+		void SetOptionSupressDeprecationWarnings(bool setOption);
+		bool IsOptionSetSupressDeprecationWarnings();
+
+
+    };
 }

--- a/cpp/openScenarioLib/src/parser/WrappedListParser.cpp
+++ b/cpp/openScenarioLib/src/parser/WrappedListParser.cpp
@@ -23,8 +23,8 @@
 
 namespace NET_ASAM_OPENSCENARIO
 {
-		WrappedListParser::WrappedListParser(IParserMessageLogger& messageLogger, std::string& filename, const std::shared_ptr<IElementParser> innerParser, const std::string wrapperTagName):
-            XmlParserBase(messageLogger, filename), _innerElementParser(innerParser), _wrapperTagName(wrapperTagName), _wrapperTagNameEndPosition(-1,-1) {}
+		WrappedListParser::WrappedListParser(IParserMessageLogger& messageLogger, std::string& filename, const std::shared_ptr<IElementParser> innerParser, const std::string wrapperTagName, ParserOptions& parserOptions):
+            XmlParserBase(messageLogger, filename, parserOptions), _innerElementParser(innerParser), _wrapperTagName(wrapperTagName), _wrapperTagNameEndPosition(-1,-1) {}
 
 		void WrappedListParser::ParseSubElements(std::vector<std::shared_ptr<IndexedElement>>& parentElements, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
         {

--- a/cpp/openScenarioLib/src/parser/WrappedListParser.h
+++ b/cpp/openScenarioLib/src/parser/WrappedListParser.h
@@ -45,8 +45,9 @@ namespace NET_ASAM_OPENSCENARIO
          * @param filename of the file the parser is operationg on.
          * @param innerParser the inner parser
          * @param wrapperTagName the tagname that wrapps the list.
+         * @param parserOptions options for the parser
          */
-		WrappedListParser(IParserMessageLogger& messageLogger, std::string& filename, const std::shared_ptr<IElementParser> innerParser, const std::string wrapperTagName);
+		WrappedListParser(IParserMessageLogger& messageLogger, std::string& filename, const std::shared_ptr<IElementParser> innerParser, const std::string wrapperTagName, ParserOptions& parserOptions);
            
 
 		void ParseSubElements(std::vector<std::shared_ptr<IndexedElement>>& parentElements, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;

--- a/cpp/openScenarioLib/src/parser/XmlModelGroupParser.cpp
+++ b/cpp/openScenarioLib/src/parser/XmlModelGroupParser.cpp
@@ -24,7 +24,7 @@ namespace NET_ASAM_OPENSCENARIO
             return {};
         }
 
-		XmlModelGroupParser::XmlModelGroupParser(IParserMessageLogger& messageLogger, std::string filename) :XmlParserBase(messageLogger, filename) {}
+		XmlModelGroupParser::XmlModelGroupParser(IParserMessageLogger& messageLogger, std::string filename, ParserOptions& parserOptions) :XmlParserBase(messageLogger, filename, parserOptions) {}
 		XmlModelGroupParser::~XmlModelGroupParser() = default;
 
         std::vector<std::shared_ptr<IElementParser>>& XmlModelGroupParser::GetParsers()

--- a/cpp/openScenarioLib/src/parser/XmlModelGroupParser.h
+++ b/cpp/openScenarioLib/src/parser/XmlModelGroupParser.h
@@ -42,8 +42,9 @@ namespace NET_ASAM_OPENSCENARIO
          * Constructor
          * @param messageLogger to log messages during parsing process
          * @param filename of the file the parser is operationg on.
+         * @param parserOptions options for the parser
          */
-		XmlModelGroupParser(IParserMessageLogger& messageLogger, std::string filename);
+		XmlModelGroupParser(IParserMessageLogger& messageLogger, std::string filename, ParserOptions& parserOptions);
 		virtual ~XmlModelGroupParser();
 
     protected:

--- a/cpp/openScenarioLib/src/parser/XmlParserBase.h
+++ b/cpp/openScenarioLib/src/parser/XmlParserBase.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include "ParserContext.h"
 #include "ParserHelper.h"
+#include "ParserOptions.h"
 #include "MemLeakDetection.h"
 
 namespace NET_ASAM_OPENSCENARIO
@@ -37,15 +38,19 @@ namespace NET_ASAM_OPENSCENARIO
     {
     public:
         IParserMessageLogger& _messageLogger;
-        std::string _filename;
+		std::string _filename;
+    	
+    public:
+		ParserOptions& _parserOptions;
 
     public:
-        /**
-         * Constructor
-         * @param messageLogger to log messages during parsing process
-         * @param filename of the file the parser is operationg on.
-         */
-        XmlParserBase(IParserMessageLogger& messageLogger, std::string& filename):_messageLogger(messageLogger), _filename(filename) {}
+		/**
+		 * Constructor
+		 * @param messageLogger to log messages during parsing process
+		 * @param filename of the file the parser is operationg on.
+		 * @param parserOptions options for the parser
+		 */
+		XmlParserBase(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions) :_messageLogger(messageLogger), _filename(filename), _parserOptions(parserOptions){}
 
         virtual ~XmlParserBase() = default;
 
@@ -152,7 +157,8 @@ namespace NET_ASAM_OPENSCENARIO
          * @param object the model object to be filled during the parsing process
          */
         virtual void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr <ParserContext>& parserContext, std::shared_ptr <BaseImpl> object) {}
-
+    	
+		
         /**
          * The defined min accur of the element
          * @return the defined min occur value

--- a/cpp/openScenarioLib/src/parser/modelgroup/XmlAllParser.cpp
+++ b/cpp/openScenarioLib/src/parser/modelgroup/XmlAllParser.cpp
@@ -26,7 +26,7 @@
 
 namespace NET_ASAM_OPENSCENARIO
 {
-	XmlAllParser::XmlAllParser(IParserMessageLogger& messageLogger, std::string& filename) : XmlModelGroupParser(messageLogger, filename) {}
+	XmlAllParser::XmlAllParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions) : XmlModelGroupParser(messageLogger, filename, parserOptions) {}
 	XmlAllParser::~XmlAllParser() = default;
 
 

--- a/cpp/openScenarioLib/src/parser/modelgroup/XmlAllParser.h
+++ b/cpp/openScenarioLib/src/parser/modelgroup/XmlAllParser.h
@@ -31,8 +31,9 @@ namespace NET_ASAM_OPENSCENARIO
          * Constructor
          * @param messageLogger to log messages during parsing process
          * @param filename of the file the parser is operating on.
+         * @param parserOptions options for the parser
          */
-		XmlAllParser(IParserMessageLogger& messageLogger, std::string& filename);
+		XmlAllParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 		virtual ~XmlAllParser();
 
 

--- a/cpp/openScenarioLib/src/parser/modelgroup/XmlChoiceParser.cpp
+++ b/cpp/openScenarioLib/src/parser/modelgroup/XmlChoiceParser.cpp
@@ -22,7 +22,7 @@
 
 namespace NET_ASAM_OPENSCENARIO
 {
-  	XmlChoiceParser::XmlChoiceParser(IParserMessageLogger& messageLogger, std::string& filename) : XmlModelGroupParser(messageLogger, filename) {}
+  	XmlChoiceParser::XmlChoiceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions) : XmlModelGroupParser(messageLogger, filename, parserOptions) {}
 	XmlChoiceParser::~XmlChoiceParser() = default;
 	
     void XmlChoiceParser::ParseSubElementsInternal(std::vector<std::shared_ptr<IndexedElement>>& indexedElements, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)

--- a/cpp/openScenarioLib/src/parser/modelgroup/XmlChoiceParser.h
+++ b/cpp/openScenarioLib/src/parser/modelgroup/XmlChoiceParser.h
@@ -36,8 +36,9 @@ namespace NET_ASAM_OPENSCENARIO
          * Constructor
          * @param messageLogger to log messages during parsing process
          * @param filename of the file the parser is operating on.
+         * @param parserOptions options for the parser
          */
-		XmlChoiceParser(IParserMessageLogger& messageLogger, std::string& filename);
+		XmlChoiceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 		virtual ~XmlChoiceParser();
 		void ParseSubElementsInternal(std::vector<std::shared_ptr<IndexedElement>>& indexedElements, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 

--- a/cpp/openScenarioLib/src/parser/modelgroup/XmlSequenceParser.cpp
+++ b/cpp/openScenarioLib/src/parser/modelgroup/XmlSequenceParser.cpp
@@ -19,7 +19,7 @@
 
 namespace NET_ASAM_OPENSCENARIO
 {
-	XmlSequenceParser::XmlSequenceParser(IParserMessageLogger& messageLogger, std::string& filename) : XmlModelGroupParser(messageLogger, filename) {}
+	XmlSequenceParser::XmlSequenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions) : XmlModelGroupParser(messageLogger, filename, parserOptions) {}
 	XmlSequenceParser::~XmlSequenceParser() = default;
 	
     void XmlSequenceParser::ParseSubElementsInternal(std::vector<std::shared_ptr<IndexedElement>>& indexedElements, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)

--- a/cpp/openScenarioLib/src/parser/modelgroup/XmlSequenceParser.h
+++ b/cpp/openScenarioLib/src/parser/modelgroup/XmlSequenceParser.h
@@ -35,8 +35,9 @@ namespace NET_ASAM_OPENSCENARIO
          * Constructor
          * @param messageLogger to log messages during parsing process
          * @param filename of the file the parser is operating on.
+         * @param parserOptions options for the parser
          */
-		XmlSequenceParser(IParserMessageLogger& messageLogger, std::string& filename);
+		XmlSequenceParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 		virtual ~XmlSequenceParser();
     	
 		void ParseSubElementsInternal(std::vector<std::shared_ptr<IndexedElement>>& indexedElements, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;

--- a/cpp/openScenarioLib/src/parser/type/XmlComplexTypeParser.cpp
+++ b/cpp/openScenarioLib/src/parser/type/XmlComplexTypeParser.cpp
@@ -27,7 +27,7 @@ namespace NET_ASAM_OPENSCENARIO
     }
 
 
-	XmlComplexTypeParser::XmlComplexTypeParser(IParserMessageLogger& messageLogger, std::string& filename): XmlParserBase(messageLogger, filename) {}
+	XmlComplexTypeParser::XmlComplexTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlParserBase(messageLogger, filename, parserOptions) {}
 	XmlComplexTypeParser::~XmlComplexTypeParser() = default;
 	
     void XmlComplexTypeParser::ParseAttributes(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr <BaseImpl> object)

--- a/cpp/openScenarioLib/src/parser/type/XmlComplexTypeParser.h
+++ b/cpp/openScenarioLib/src/parser/type/XmlComplexTypeParser.h
@@ -49,8 +49,9 @@ namespace NET_ASAM_OPENSCENARIO
          * Constructor
          * @param messageLogger to log messages during parsing process
          * @param filename of the file the parser is operating on.
+         * @param parserOptions options for the parser
          */
-		XmlComplexTypeParser(IParserMessageLogger& messageLogger, std::string& filename);
+		XmlComplexTypeParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 		virtual ~XmlComplexTypeParser();
     protected:
         /**

--- a/cpp/openScenarioLib/src/parser/type/XmlGroupParser.cpp
+++ b/cpp/openScenarioLib/src/parser/type/XmlGroupParser.cpp
@@ -20,7 +20,7 @@
 
 namespace NET_ASAM_OPENSCENARIO
 {
-	XmlGroupParser::XmlGroupParser(IParserMessageLogger& messageLogger, std::string& filename): XmlParserBase(messageLogger, filename) {}
+	XmlGroupParser::XmlGroupParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlParserBase(messageLogger, filename, parserOptions) {}
 	XmlGroupParser::~XmlGroupParser() = default;
 	
     void XmlGroupParser::ParseElement(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr <ParserContext>& parserContext, std::shared_ptr <BaseImpl> object)

--- a/cpp/openScenarioLib/src/parser/type/XmlGroupParser.h
+++ b/cpp/openScenarioLib/src/parser/type/XmlGroupParser.h
@@ -39,8 +39,9 @@ namespace NET_ASAM_OPENSCENARIO
          * Constructor
          * @param messageLogger to log messages during parsing process
          * @param filename of the file the parser is operating on.
+         * @param parserOptions options for the parser
          */
-		XmlGroupParser(IParserMessageLogger& messageLogger, std::string& filename);
+		XmlGroupParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 		virtual ~XmlGroupParser();
 
 		void ParseElement(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr <ParserContext>& parserContext, std::shared_ptr <BaseImpl> object) override;

--- a/cpp/openScenarioLib/src/parser/type/XmlSimpleContentParser.cpp
+++ b/cpp/openScenarioLib/src/parser/type/XmlSimpleContentParser.cpp
@@ -19,7 +19,7 @@
 
 namespace NET_ASAM_OPENSCENARIO
 {
-	XmlSimpleContentParser::XmlSimpleContentParser(IParserMessageLogger& messageLogger, std::string& filename) : XmlComplexTypeParser(messageLogger, filename) {}
+	XmlSimpleContentParser::XmlSimpleContentParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions) : XmlComplexTypeParser(messageLogger, filename, parserOptions) {}
 	XmlSimpleContentParser::~XmlSimpleContentParser() = default;
 
     void XmlSimpleContentParser::ParseElement(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr <ParserContext>& parserContext, std::shared_ptr <BaseImpl> object)

--- a/cpp/openScenarioLib/src/parser/type/XmlSimpleContentParser.h
+++ b/cpp/openScenarioLib/src/parser/type/XmlSimpleContentParser.h
@@ -31,8 +31,9 @@ namespace NET_ASAM_OPENSCENARIO
 		 * Constructor
 		 * @param messageLogger to log messages during parsing process
 		 * @param filename of the file the parser is operating on.
+		 * @param parserOptions options for the parser
 		 */
-		XmlSimpleContentParser(IParserMessageLogger& messageLogger, std::string& filename);
+		XmlSimpleContentParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 		virtual ~XmlSimpleContentParser();
 
 		void ParseElement(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr <ParserContext>& parserContext, std::shared_ptr <BaseImpl> object);

--- a/cpp/openScenarioLib/src/v1_0/loader/XmlScenarioLoaderV1_0.cpp
+++ b/cpp/openScenarioLib/src/v1_0/loader/XmlScenarioLoaderV1_0.cpp
@@ -125,7 +125,8 @@ namespace NET_ASAM_OPENSCENARIO
                 auto indexedElement = xmlToSimpleNodeConverter.Convert(doc);
 
                 // Finally do parsing from dom result
-                OpenScenarioXmlParser openScenarioXmlParser(*messageLogger.get(), _filename, ParserOptions());
+				ParserOptions parserOptions;
+                OpenScenarioXmlParser openScenarioXmlParser(*messageLogger.get(), _filename, parserOptions);
 
                 auto openScenarioImpl = std::make_shared<OpenScenarioImpl>();
                 auto parserContext = std::dynamic_pointer_cast<ParserContext>(std::make_shared<CatalogReferenceParserContext>());

--- a/cpp/openScenarioLib/src/v1_0/loader/XmlScenarioLoaderV1_0.cpp
+++ b/cpp/openScenarioLib/src/v1_0/loader/XmlScenarioLoaderV1_0.cpp
@@ -125,7 +125,7 @@ namespace NET_ASAM_OPENSCENARIO
                 auto indexedElement = xmlToSimpleNodeConverter.Convert(doc);
 
                 // Finally do parsing from dom result
-                OpenScenarioXmlParser openScenarioXmlParser(*messageLogger.get(), _filename);
+                OpenScenarioXmlParser openScenarioXmlParser(*messageLogger.get(), _filename, ParserOptions());
 
                 auto openScenarioImpl = std::make_shared<OpenScenarioImpl>();
                 auto parserContext = std::dynamic_pointer_cast<ParserContext>(std::make_shared<CatalogReferenceParserContext>());

--- a/cpp/openScenarioLib/src/v1_1/loader/XmlScenarioLoaderFactoryV1_1.h
+++ b/cpp/openScenarioLib/src/v1_1/loader/XmlScenarioLoaderFactoryV1_1.h
@@ -31,14 +31,15 @@ namespace NET_ASAM_OPENSCENARIO
         {
 
         private:
-            std::string _filename;
+			std::string _filename;
+			bool _supressDeprecationWarnings;
 
         public:
             /**
              * Constructor
              * @param filename for the created loader
              */
-			OPENSCENARIOLIB_EXP XmlScenarioLoaderFactory(const std::string filename);
+			OPENSCENARIOLIB_EXP XmlScenarioLoaderFactory(const std::string filename, bool supressDeprecationWarnings = false);
 			OPENSCENARIOLIB_EXP std::shared_ptr<IScenarioLoader> CreateLoader(std::shared_ptr<IResourceLocator> resourceLocator) override;
 
         };

--- a/cpp/openScenarioLib/src/v1_1/loader/XmlScenarioLoaderV1_1.cpp
+++ b/cpp/openScenarioLib/src/v1_1/loader/XmlScenarioLoaderV1_1.cpp
@@ -30,7 +30,7 @@ namespace NET_ASAM_OPENSCENARIO
 {
     namespace v1_1
     {
-		XmlScenarioLoader::XmlScenarioLoader(std::string& filename, std::shared_ptr<IResourceLocator>& resourceLocator) : _filename(filename), _resourceLocator(resourceLocator) {}
+		XmlScenarioLoader::XmlScenarioLoader(std::string& filename, std::shared_ptr<IResourceLocator>& resourceLocator, bool supressDeprecationWarnings) : _filename(filename), _resourceLocator(resourceLocator), _supressDeprecationWarnings(supressDeprecationWarnings){}
 
 		XmlScenarioLoader::~XmlScenarioLoader() = default;
 
@@ -125,7 +125,9 @@ namespace NET_ASAM_OPENSCENARIO
                 auto indexedElement = xmlToSimpleNodeConverter.Convert(doc);
 
                 // Finally do parsing from dom result
-                OpenScenarioXmlParser openScenarioXmlParser(*messageLogger.get(), _filename);
+				ParserOptions parserOptions;
+				parserOptions.SetOptionSupressDeprecationWarnings(_supressDeprecationWarnings);
+                OpenScenarioXmlParser openScenarioXmlParser(*messageLogger.get(), _filename, parserOptions);
 
                 auto openScenarioImpl = std::make_shared<OpenScenarioImpl>();
                 auto parserContext = std::dynamic_pointer_cast<ParserContext>(std::make_shared<CatalogReferenceParserContext>());
@@ -136,9 +138,6 @@ namespace NET_ASAM_OPENSCENARIO
                 {
                     // Check 
                     ScenarioCheckerImpl scenarioChecker;
-                    /*auto parameterDeclarationCheckerRule = std::make_shared<ParameterDeclarationChecker>();
-                    scenarioChecker.AddParameterDeclarationCheckerRule(parameterDeclarationCheckerRule);
-                    scenarioChecker.CheckScenarioInFileContext(messageLogger, openScenarioImpl);*/
                     OpenScenarioProcessingHelper::Resolve(messageLogger, openScenarioImpl, injectedParameters);
                     openScenarioImpl->AddAdapter(typeid(ICatalogReferenceProvider).name(), std::dynamic_pointer_cast<ICatalogReferenceProvider>(parserContext));
                     auto scenarioCheckerImpl = std::make_shared<ScenarioCheckerImpl>();

--- a/cpp/openScenarioLib/src/v1_1/loader/XmlScenarioLoaderV1_1.h
+++ b/cpp/openScenarioLib/src/v1_1/loader/XmlScenarioLoaderV1_1.h
@@ -37,14 +37,16 @@ namespace NET_ASAM_OPENSCENARIO
         private:
             std::string _filename;
             std::shared_ptr<IResourceLocator> _resourceLocator;
+			bool _supressDeprecationWarnings;
 
         public:
             /**
              * Constructor
              * @param filename symbolic filename of the scenario
              * @param resourceLocator locator abstracting from storage.
+             * @param supressDeprecationWarnings flag that supresses deprecation Warnung throught parsing
              */
-			XmlScenarioLoader(std::string& filename, std::shared_ptr<IResourceLocator>& resourceLocator);
+			XmlScenarioLoader(std::string& filename, std::shared_ptr<IResourceLocator>& resourceLocator, bool supressDeprecationWarnings = false);
             virtual ~XmlScenarioLoader();
 
             /**

--- a/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_0/XmlParserClass.tpl
+++ b/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_0/XmlParserClass.tpl
@@ -83,8 +83,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
         <%-}else if (element.isModelGroupChoice()){-%>
             class SubElementParser: public XmlChoiceParser
@@ -94,8 +95,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
         <%-}else if (element.isModelGroupSequence()){-%>
             class SubElementParser: public XmlSequenceParser
@@ -105,8 +107,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+				* @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         <%-}-%>
             protected:
                 /*
@@ -130,7 +133,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElement<%=property.name.toClassName()%>Parser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElement<%=property.name.toClassName()%>Parser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -150,8 +153,9 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            <%=element.name.toClassName()%>XmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser
+			*/
+            <%=element.name.toClassName()%>XmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 <%-}-%>

--- a/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_0/XmlParserClassSource.tpl
+++ b/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_0/XmlParserClassSource.tpl
@@ -41,13 +41,13 @@ namespace NET_ASAM_OPENSCENARIO
         }
     <%-}else{-%>
         <%- if (element.isModelGroupAll()){-%>
-            <%=element.name.toClassName()%>XmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            <%=element.name.toClassName()%>XmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
         <%-}else if (element.isModelGroupChoice()){-%>
-            <%=element.name.toClassName()%>XmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            <%=element.name.toClassName()%>XmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
         <%-}else if (element.isModelGroupSequence()){-%>
-            <%=element.name.toClassName()%>XmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            <%=element.name.toClassName()%>XmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
         <%-}-%>
     <%-}-%>
 
@@ -61,7 +61,7 @@ namespace NET_ASAM_OPENSCENARIO
             class Attribute<%=property.name.toClassName()%>: public IAttributeParser, public XmlParserBase
             {
             public:
-                Attribute<%=property.name.toClassName()%>(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                Attribute<%=property.name.toClassName()%>(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -122,7 +122,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return <%=property.lower%>;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__<%=property.name.toUpperNameFromMemberName()%>, std::make_shared<Attribute<%=property.name.toClassName()%>>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__<%=property.name.toUpperNameFromMemberName()%>, std::make_shared<Attribute<%=property.name.toClassName()%>>(_messageLogger, _filename, _parserOptions)));
             <%-}-%>
             return result;
         }
@@ -141,9 +141,9 @@ namespace NET_ASAM_OPENSCENARIO
             <%-properties = element.getXmlElementProperties();-%>
             <%-properties.each{ property -> -%>
                 <%- if (property.isWrappedList()){-%>
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElement<%=property.name.toClassName()%>Parser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__<%=property.name.toClassName().toUpperNameFromMemberName()%>) );
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElement<%=property.name.toClassName()%>Parser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__<%=property.name.toClassName().toUpperNameFromMemberName()%>, _parserOptions) );
                 <%-} else { -%>
-            result.push_back(std::make_shared<SubElement<%=property.name.toClassName()%>Parser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElement<%=property.name.toClassName()%>Parser>(_messageLogger, _filename, _parserOptions));
                 <%-}-%>
             <%-}-%>
             return result;
@@ -152,9 +152,9 @@ namespace NET_ASAM_OPENSCENARIO
     <%-}-%>
         <%-properties = element.getXmlElementProperties();-%>
         <%-properties.each{ property -> -%>
-        <%=element.name.toClassName()%>XmlParser::SubElement<%=property.name.toClassName()%>Parser::SubElement<%=property.name.toClassName()%>Parser(IParserMessageLogger& messageLogger, std::string& filename)
+        <%=element.name.toClassName()%>XmlParser::SubElement<%=property.name.toClassName()%>Parser::SubElement<%=property.name.toClassName()%>Parser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _<%=property.type.name.toMemberName()%>XmlParser = std::make_shared<<%=property.type.name.toClassName()%>XmlParser>(messageLogger, filename);
+            _<%=property.type.name.toMemberName()%>XmlParser = std::make_shared<<%=property.type.name.toClassName()%>XmlParser>(messageLogger, filename, parserOptions);
         }
 
         void <%=element.name.toClassName()%>XmlParser::SubElement<%=property.name.toClassName()%>Parser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -212,18 +212,18 @@ namespace NET_ASAM_OPENSCENARIO
         }
         <%-}-%>
   
-        <%=element.name.toClassName()%>XmlParser::<%=element.name.toClassName()%>XmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
+        <%=element.name.toClassName()%>XmlParser::<%=element.name.toClassName()%>XmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
         <%- if (element.isComplexType()){-%>
-        XmlComplexTypeParser(messageLogger, filename)
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         <%-}else if (element.isSimpleContent()){-%>
-        XmlSimpleContentParser(messageLogger, filename) {}
+        XmlSimpleContentParser(messageLogger, filename, parserOptions) {}
         <%-}else if (element.isGroup()){-%>
-        XmlGroupParser(messageLogger, filename)
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         <%-}-%>
         

--- a/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_1/XmlParserClass.tpl
+++ b/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_1/XmlParserClass.tpl
@@ -83,8 +83,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
         <%-}else if (element.isModelGroupChoice()){-%>
             class SubElementParser: public XmlChoiceParser
@@ -94,8 +95,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                 SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
         <%-}else if (element.isModelGroupSequence()){-%>
             class SubElementParser: public XmlSequenceParser
@@ -105,8 +107,9 @@ namespace NET_ASAM_OPENSCENARIO
                 * Constructor
                 * @param messageLogger to log messages during parsing
                 * @param filename to locate the messages in a file
+                * @param parserOptions options for the parser
                 */
-                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         <%-}-%>
             protected:
                 /*
@@ -130,7 +133,7 @@ namespace NET_ASAM_OPENSCENARIO
                 /**
                 * Constructor
                 */
-                SubElement<%=property.name.toClassName()%>Parser(IParserMessageLogger& messageLogger, std::string& filename);
+                SubElement<%=property.name.toClassName()%>Parser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
 
                 void Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object) override;
 
@@ -150,8 +153,8 @@ namespace NET_ASAM_OPENSCENARIO
             * Constructor
             * @param messageLogger to log messages during parsing
             * @param filename to locate the messages in a file
-            */
-            <%=element.name.toClassName()%>XmlParser(IParserMessageLogger& messageLogger, std::string& filename);
+            * @param parserOptions options for the parser            */
+            <%=element.name.toClassName()%>XmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions);
         };
 
 <%-}-%>

--- a/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_1/XmlParserClassSource.tpl
+++ b/generator/de.rac.openscenario.generator/src/main/resources/templates/cpp/v1_1/XmlParserClassSource.tpl
@@ -41,13 +41,13 @@ namespace NET_ASAM_OPENSCENARIO
         }
     <%-}else{-%>
         <%- if (element.isModelGroupAll()){-%>
-            <%=element.name.toClassName()%>XmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlAllParser(messageLogger, filename) {}
+            <%=element.name.toClassName()%>XmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlAllParser(messageLogger, filename, parserOptions) {}
 
         <%-}else if (element.isModelGroupChoice()){-%>
-            <%=element.name.toClassName()%>XmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlChoiceParser(messageLogger, filename) {}
+            <%=element.name.toClassName()%>XmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlChoiceParser(messageLogger, filename, parserOptions) {}
 
         <%-}else if (element.isModelGroupSequence()){-%>
-            <%=element.name.toClassName()%>XmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename): XmlSequenceParser(messageLogger, filename) {}
+            <%=element.name.toClassName()%>XmlParser::SubElementParser::SubElementParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): XmlSequenceParser(messageLogger, filename, parserOptions) {}
         <%-}-%>
     <%-}-%>
 
@@ -61,7 +61,7 @@ namespace NET_ASAM_OPENSCENARIO
             class Attribute<%=property.name.toClassName()%>: public IAttributeParser, public XmlParserBase
             {
             public:
-                Attribute<%=property.name.toClassName()%>(IParserMessageLogger& messageLogger, std::string& filename):XmlParserBase(messageLogger, filename) {}
+                Attribute<%=property.name.toClassName()%>(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions):XmlParserBase(messageLogger, filename, parserOptions) {}
 
                 void Parse(Position& startPosition, Position& endPosition, Position& startValuePosition, std::string& attributeName, std::string& attributeValue, std::shared_ptr<BaseImpl> object) override
                 {
@@ -105,7 +105,7 @@ namespace NET_ASAM_OPENSCENARIO
                             auto msg = FileContentMessage("Value '" + attributeValue + "' is not allowed.", ERROR, startMarker);
                             _messageLogger.LogMessage(msg);
                         }
-                        if (<%=property.type.name.toClassName()%>::IsDeprecated(kResult))
+                        if (<%=property.type.name.toClassName()%>::IsDeprecated(kResult) && !_parserOptions.IsOptionSetSupressDeprecationWarnings())
 				    	{
 							auto msg = FileContentMessage("Enumeration literal '" + attributeValue + "' is deprecated since standard version '" +  <%=property.type.name.toClassName()%>::GetDeprecatedVersion(kResult) +"'. " + <%=property.type.name.toClassName()%>::GetDeprecatedComment(kResult) + "'.", WARNING, Textmarker(startValuePosition.GetLine(), startValuePosition.GetColumn(), this->_filename));
 							this->_messageLogger.LogMessage(msg);
@@ -129,14 +129,17 @@ namespace NET_ASAM_OPENSCENARIO
                     <%-}-%>
                     
                     <%-if (property.isDeprecated()){-%>
-                    // This element is deprecated
-                	<%-String version = property.getDeprecatedVersion();-%>
-                	<%- version = version? version.replaceAll("\"", "\\\\\""):"n/a";-%>
-                	<%-String comment = property.getDeprecatedComment();-%>
-                	<%- comment = comment? comment.replaceAll("\"", "\\\\\""):"n/a";-%>	
-					auto msg = FileContentMessage("Attribute '" + attributeName + "' is deprecated since standard version '<%=version%>'. Comment: '<%=comment%>'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), this->_filename));
-					this->_messageLogger.LogMessage(msg);
-			    	<%-}-%>
+					if (!_parserOptions.IsOptionSetSupressDeprecationWarnings())
+					{
+						// This element is deprecated
+						<%-String version = property.getDeprecatedVersion();-%>
+						<%- version = version? version.replaceAll("\"", "\\\\\""):"n/a";-%>
+						<%-String comment = property.getDeprecatedComment();-%>
+						<%- comment = comment? comment.replaceAll("\"", "\\\\\""):"n/a";-%>	
+						auto msg = FileContentMessage("Attribute '" + attributeName + "' is deprecated since standard version '<%=version%>'. Comment: '<%=comment%>'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), this->_filename));
+						this->_messageLogger.LogMessage(msg);
+					}
+					<%-}-%>
                 }
 
                 int GetMinOccur() override
@@ -144,7 +147,7 @@ namespace NET_ASAM_OPENSCENARIO
                     return <%=property.lower%>;
                 }
             };
-            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__<%=property.name.toUpperNameFromMemberName()%>, std::make_shared<Attribute<%=property.name.toClassName()%>>(_messageLogger, _filename)));
+            result.emplace(std::make_pair(OSC_CONSTANTS::ATTRIBUTE__<%=property.name.toUpperNameFromMemberName()%>, std::make_shared<Attribute<%=property.name.toClassName()%>>(_messageLogger, _filename, _parserOptions)));
             <%-}-%>
             return result;
         }
@@ -163,9 +166,9 @@ namespace NET_ASAM_OPENSCENARIO
             <%-properties = element.getXmlElementProperties();-%>
             <%-properties.each{ property -> -%>
                 <%- if (property.isWrappedList()){-%>
-            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElement<%=property.name.toClassName()%>Parser>(_messageLogger, _filename), OSC_CONSTANTS::ELEMENT__<%=property.name.toClassName().toUpperNameFromMemberName()%>) );
+            result.push_back(std::make_shared<WrappedListParser>(_messageLogger, _filename, std::make_shared<SubElement<%=property.name.toClassName()%>Parser>(_messageLogger, _filename, _parserOptions), OSC_CONSTANTS::ELEMENT__<%=property.name.toClassName().toUpperNameFromMemberName()%>, _parserOptions) );
                 <%-} else { -%>
-            result.push_back(std::make_shared<SubElement<%=property.name.toClassName()%>Parser>(_messageLogger, _filename));
+            result.push_back(std::make_shared<SubElement<%=property.name.toClassName()%>Parser>(_messageLogger, _filename, _parserOptions));
                 <%-}-%>
             <%-}-%>
             return result;
@@ -174,9 +177,9 @@ namespace NET_ASAM_OPENSCENARIO
     <%-}-%>
         <%-properties = element.getXmlElementProperties();-%>
         <%-properties.each{ property -> -%>
-        <%=element.name.toClassName()%>XmlParser::SubElement<%=property.name.toClassName()%>Parser::SubElement<%=property.name.toClassName()%>Parser(IParserMessageLogger& messageLogger, std::string& filename)
+        <%=element.name.toClassName()%>XmlParser::SubElement<%=property.name.toClassName()%>Parser::SubElement<%=property.name.toClassName()%>Parser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions)
         {
-            _<%=property.type.name.toMemberName()%>XmlParser = std::make_shared<<%=property.type.name.toClassName()%>XmlParser>(messageLogger, filename);
+            _<%=property.type.name.toMemberName()%>XmlParser = std::make_shared<<%=property.type.name.toClassName()%>XmlParser>(messageLogger, filename, parserOptions);
         }
 
         void <%=element.name.toClassName()%>XmlParser::SubElement<%=property.name.toClassName()%>Parser::Parse(std::shared_ptr<IndexedElement>& indexedElement, std::shared_ptr<ParserContext>& parserContext, std::shared_ptr<BaseImpl> object)
@@ -198,16 +201,19 @@ namespace NET_ASAM_OPENSCENARIO
             <%-}-%>
             
             
-            <%-if (property.isDeprecated()){-%>         
-            // This element is deprecated
-            std::string name = indexedElement->GetElement()->Name();
-        	<%-String version = property.getDeprecatedVersion();-%>
-        	<%-version = version? version.replaceAll("\"", "\\\\\""):"n/a";-%>
-        	<%-String comment = property.getDeprecatedComment();-%>
-        	<%- comment = comment? comment.replaceAll("\"", "\\\\\""):"n/a";-%>	
-        	Position startPosition = indexedElement->GetStartElementLocation();
-			auto msg = FileContentMessage("Element '" + name + "' is deprecated since standard version '<%=version%>'. Comment: '<%=comment%>'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), _<%=property.type.name.toMemberName()%>XmlParser->_filename));
-			_<%=property.type.name.toMemberName()%>XmlParser->_messageLogger.LogMessage(msg);
+            <%-if (property.isDeprecated()){-%> 
+			if (!_<%=property.type.name.toMemberName()%>XmlParser->_parserOptions.IsOptionSetSupressDeprecationWarnings())
+			{
+				// This element is deprecated
+				std::string name = indexedElement->GetElement()->Name();
+				<%-String version = property.getDeprecatedVersion();-%>
+				<%-version = version? version.replaceAll("\"", "\\\\\""):"n/a";-%>
+				<%-String comment = property.getDeprecatedComment();-%>
+				<%- comment = comment? comment.replaceAll("\"", "\\\\\""):"n/a";-%>	
+				Position startPosition = indexedElement->GetStartElementLocation();
+				auto msg = FileContentMessage("Element '" + name + "' is deprecated since standard version '<%=version%>'. Comment: '<%=comment%>'.", WARNING, Textmarker(startPosition.GetLine(), startPosition.GetColumn(), _<%=property.type.name.toMemberName()%>XmlParser->_filename));
+				_<%=property.type.name.toMemberName()%>XmlParser->_messageLogger.LogMessage(msg);
+			}
 			<%-}-%>
         }
         
@@ -247,18 +253,18 @@ namespace NET_ASAM_OPENSCENARIO
         }
         <%-}-%>
   
-        <%=element.name.toClassName()%>XmlParser::<%=element.name.toClassName()%>XmlParser(IParserMessageLogger& messageLogger, std::string& filename): 
+        <%=element.name.toClassName()%>XmlParser::<%=element.name.toClassName()%>XmlParser(IParserMessageLogger& messageLogger, std::string& filename, ParserOptions& parserOptions): 
         <%- if (element.isComplexType()){-%>
-        XmlComplexTypeParser(messageLogger, filename)
+        XmlComplexTypeParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         <%-}else if (element.isSimpleContent()){-%>
-        XmlSimpleContentParser(messageLogger, filename) {}
+        XmlSimpleContentParser(messageLogger, filename, parserOptions) {}
         <%-}else if (element.isGroup()){-%>
-        XmlGroupParser(messageLogger, filename)
+        XmlGroupParser(messageLogger, filename, parserOptions)
         {
-            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename);
+            _subElementParser = std::make_shared<SubElementParser>(messageLogger, filename, parserOptions);
         }
         <%-}-%>
         


### PR DESCRIPTION
Signed-off-by: ahege <a.hege@rac.de>

#### Reference to a related issue in the repository
#116

#### Add a description
added ParserOptions to the XML parsers and a flag supressDeprecationWarnings (default=false) to the XmlScenarioLoaderFactory.

How has it been tested? See Unit TestDeprecated::TestDeprecatedSupress(). No Warnings are given back despite of using deprecated elements.


- [x] My code follows the [contributors guidelines](https://github.com/ahege/openscenario.api.test/blob/master/doc/howtocontribute.rst) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/ahege/openscenario.api.test/blob/master/doc).
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.
