### PR TITLE
Fixed missing v1_2 headers in artifacts

### DIFF
--- a/cpp/applications/openScenarioReader/src/OpenScenarioReader.cpp
+++ b/cpp/applications/openScenarioReader/src/OpenScenarioReader.cpp
@@ -467,7 +467,8 @@ int main(int argc, char** argv)
             if (argc == 6 && std::string(argv[5]) == "-v1_1")
             {
                 version = VERSION_1_1;
-            }else if (argc == 6 && std::string(argv[5]) == "-v1_2")
+            }
+            else if (argc == 6 && std::string(argv[5]) == "-v1_2")
 			{
 				version = VERSION_1_2;
 			}

--- a/cpp/applications/openScenarioTester/CMakeLists.txt
+++ b/cpp/applications/openScenarioTester/CMakeLists.txt
@@ -136,8 +136,6 @@ set( SOURCES
     ${SOURCES}
 	"src/TestBaseV1_0.cpp"
     "src/TestExamplesV1_0.cpp"
-    "src/TestExamplesV1_1.cpp"
-    "src/TestCardinalityV1_1.cpp"
     "src/TestFilesV1_0.cpp"
     "src/TestFlexInterfaceV1_0.cpp"
     "src/TestImportsV1_0.cpp"
@@ -151,11 +149,11 @@ set( SOURCES
 endif (SUPPORT_OSC_1_0)
 
 if (SUPPORT_OSC_1_1)
-
 set( SOURCES
     ${SOURCES}
 	"src/TestBaseV1_1.cpp"
     "src/TestExamplesV1_1.cpp"
+    "src/TestCardinalityV1_1.cpp"
     "src/TestFilesV1_1.cpp"
     "src/TestFlexInterfaceV1_1.cpp"
     "src/TestImportsV1_1.cpp"

--- a/cpp/applications/openScenarioTester/src/OpenScenarioTester.cpp
+++ b/cpp/applications/openScenarioTester/src/OpenScenarioTester.cpp
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-#include <TestExamplesOscV1_2.h>
-
 #include "TestVersionOptionsWithReader.h"
 
 #ifdef SUPPORT_OSC_1_0
@@ -47,7 +45,6 @@
 #include "TestFlexInterfaceV1_1.h"
 #include "TestInjectedParametersV1_1.h"
 #include "TestWriterApiV1_1.h"
-
 #endif
 
 #ifdef SUPPORT_OSC_1_2
@@ -57,6 +54,7 @@
 #include "TestAlksV1_2.h"
 #include "TestDeprecatedV1_2.h"
 #include "TestExamplesV1_2.h"
+#include <TestExamplesOscV1_2.h>
 #include "TestRangeCheckerV1_2.h"
 #include "TestFilesV1_2.h"
 #include "TestImportsV1_2.h"

--- a/cpp/buildArtifact/collectHeaderFiles.sh
+++ b/cpp/buildArtifact/collectHeaderFiles.sh
@@ -30,7 +30,7 @@ FIND_HEADERS_SH=${FIND_HEADERS_SH_PATH}/${FIND_HEADERS_SH_FILE}
 # prepare inlude paths for C++ compiler in order to extract ALL necessary non-system include files
 # this has to be done outside the openScenarioReader project folder to also reach all referenced external dependencies
 echo "#!/bin/bash" > ${FIND_HEADERS_SH}
-echo "cpp -DCOLLECT_HEADERS -MM \\" >> ${FIND_HEADERS_SH}
+echo "cpp -DCOLLECT_HEADERS -DSUPPORT_OSC_1_0 -DSUPPORT_OSC_1_1 -DSUPPORT_OSC_1_2 -MM \\" >> ${FIND_HEADERS_SH}
 for i in `find . -type d -print` ; do
     if [[ $i == *"CMake"* ]] || [[ $i == *"antlr_runtime"* ]] || [[ $i == *"ython"* ]] || [[ $i == *"java"* ]] || [[ $i == *".dir"* ]] || [[ $i == "./build"* ]] ;
     then

--- a/cpp/buildArtifact/createCMakeLists.sh
+++ b/cpp/buildArtifact/createCMakeLists.sh
@@ -80,6 +80,20 @@ set( ENV{CMAKE_BUILD_PARALLEL_LEVEL} 4 )
 
 ################################################################
 # Preprocessor settings
+option(SUPPORT_OSC_1_0 \"Build the artifacts supporting OSC standard version 1.0\" ON)
+option(SUPPORT_OSC_1_1 \"Build the artifacts supporting OSC standard version 1.1\" ON)
+option(SUPPORT_OSC_1_2 \"Build the artifacts supporting OSC standard version 1.2\" ON)
+
+if (SUPPORT_OSC_1_0)
+	add_definitions(-DSUPPORT_OSC_1_0)	
+endif (SUPPORT_OSC_1_0)
+if (SUPPORT_OSC_1_1)
+	add_definitions(-DSUPPORT_OSC_1_1)	
+endif (SUPPORT_OSC_1_1)
+if (SUPPORT_OSC_1_2)
+	add_definitions(-DSUPPORT_OSC_1_2)	
+endif (SUPPORT_OSC_1_2)
+
 if( WIN32 )
     add_definitions( -D_CRT_SECURE_NO_WARNINGS )
 else( WIN32 )


### PR DESCRIPTION
#### Reference to a related issue in the repository
#178 

#### Add a description
Artifacts now contain the v1_2 folder with headers.
Individual versions (v1_0, v1_1, v1_2) do compile now.

**Some questions to ask**:
What is this change?
Changes in the Linux bash scripts, CMakeLists.txt files, and code.

What does it fix?
Support options for v1_0, v1_1, v1_2 were missing in the script collecting the headers and in the generated example CMakeLists.txt.
Isolated versions v1_0, v1_1, v1_2 did not compile due missing or too much header and source entries in the CMakeLists.txt.
Also missing includes were fixed, too.

Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
It's a bug fix and existing functionality is kept.

How has it been tested?
Artifacts have been built on the build server and random checked on Linux and Windows locally.
The main project had been built on Linux and Windows locally and OpenScenarioTester was executed successfully.

#### Check the checklist

- [x] My code follows the [contributors guidelines](https://github.com/ahege/openscenario.api.test/blob/master/doc/howtocontribute.rst) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/ahege/openscenario.api.test/blob/master/doc).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.
