### PR TITLE
Dev

### DIFF
--- a/.github/workflows/buildAndTestRuns.yml
+++ b/.github/workflows/buildAndTestRuns.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: update system
       run:  sudo apt-get update
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: update system
       run:  sudo apt-get update
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: update system
       run:  sudo apt-get update
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: update system
       run:  sudo apt-get update
@@ -136,7 +136,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: cmake generate solution Debug
       run: cmake -S ./cpp --preset="VS2022-Win32-shared"
@@ -157,7 +157,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: cmake generate solution Release
       run: cmake -S ./cpp --preset="VS2022-Win32-shared"
@@ -178,7 +178,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: cmake generate solution Debug
       run: cmake -S ./cpp --preset="VS2022-x64-shared"
@@ -199,7 +199,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: cmake generate solution Release
       run: cmake -S ./cpp --preset="VS2022-x64-shared"
@@ -220,7 +220,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: cmake generate solution Debug
       run: cmake -S ./cpp --preset="VS2022-Win32-static"
@@ -241,7 +241,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: cmake generate solution Release
       run: cmake -S ./cpp --preset="VS2022-Win32-static"
@@ -262,7 +262,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: cmake generate solution Debug
       run: cmake -S ./cpp --preset="VS2022-x64-static"
@@ -283,7 +283,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: cmake generate solution Release
       run: cmake -S ./cpp --preset="VS2022-x64-static"

--- a/.github/workflows/buildArtifactsForPackage.yml
+++ b/.github/workflows/buildArtifactsForPackage.yml
@@ -22,7 +22,7 @@ jobs:
 
     # Linux builds
     # - name: get artifacts LinuxSharedDebug
-    #   uses: actions/download-artifact@v2
+    #   uses: actions/download-artifact@v3
     #   with:
     #     name: LinuxSharedDebug
     #     path: ./cpp/build
@@ -34,7 +34,7 @@ jobs:
     #     rm out.tgz
 
     - name: get artifacts LinuxSharedRelease
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: LinuxSharedRelease
         path: ./cpp/build
@@ -46,7 +46,7 @@ jobs:
         rm out.tgz
 
     # - name: get artifacts LinuxStaticDebug
-    #   uses: actions/download-artifact@v2
+    #   uses: actions/download-artifact@v3
     #   with:
     #     name: LinuxStaticDebug
     #     path: ./cpp/build
@@ -58,7 +58,7 @@ jobs:
     #     rm out.tgz
 
     - name: get artifacts LinuxStaticRelease
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: LinuxStaticRelease
         path: ./cpp/build
@@ -71,7 +71,7 @@ jobs:
 
     # Win32 builds
     # - name: get artifacts Win32SharedDebug
-    #   uses: actions/download-artifact@v2
+    #   uses: actions/download-artifact@v3
     #   with:
     #     name: Win32SharedDebug
     #     path: ./cpp/build
@@ -83,7 +83,7 @@ jobs:
     #     rm out.tgz
 
     - name: get artifacts Win32SharedRelease
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: Win32SharedRelease
         path: ./cpp/build
@@ -95,7 +95,7 @@ jobs:
         rm out.tgz
 
     # - name: get artifacts Win32StaticDebug
-    #   uses: actions/download-artifact@v2
+    #   uses: actions/download-artifact@v3
     #   with:
     #     name: Win32StaticDebug
     #     path: ./cpp/build
@@ -107,7 +107,7 @@ jobs:
     #     rm out.tgz
 
     - name: get artifacts Win32StaticRelease
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: Win32StaticRelease
         path: ./cpp/build
@@ -120,7 +120,7 @@ jobs:
 
     # x64 builds
     # - name: get artifacts x64SharedDebug
-    #   uses: actions/download-artifact@v2
+    #   uses: actions/download-artifact@v3
     #   with:
     #     name: x64SharedDebug
     #     path: ./cpp/build
@@ -132,7 +132,7 @@ jobs:
     #     rm out.tgz
 
     - name: get artifacts x64SharedRelease
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: x64SharedRelease
         path: ./cpp/build
@@ -144,7 +144,7 @@ jobs:
         rm out.tgz
 
     # - name: get artifacts x64StaticDebug
-    #   uses: actions/download-artifact@v2
+    #   uses: actions/download-artifact@v3
     #   with:
     #     name: x64StaticDebug
     #     path: ./cpp/build
@@ -156,7 +156,7 @@ jobs:
     #     rm out.tgz
 
     - name: get artifacts x64StaticRelease
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: x64StaticRelease
         path: ./cpp/build
@@ -200,7 +200,7 @@ jobs:
       run: ls ./cpp/buildArtifact/OpenSCENARIO*
 
     - name: publish artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ github.event.inputs.name }}
         path: ./cpp/buildArtifact/OpenSCENARIO*
@@ -235,7 +235,7 @@ jobs:
   #      tar -zcf out.tgz cg*
 
   #   - name: publish artifact
-  #     uses: actions/upload-artifact@v2
+  #     uses: actions/upload-artifact@v3
   #     with: 
   #       name: LinuxSharedDebug
   #       path: ./cpp/build/out.tgz
@@ -269,7 +269,7 @@ jobs:
         tar -zcf out.tgz cg*
 
     - name: publish artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with: 
         name: LinuxSharedRelease
         path: ./cpp/build/out.tgz
@@ -304,7 +304,7 @@ jobs:
   #       tar -zcf out.tgz cg*
 
   #     - name: publish artifact
-  #       uses: actions/upload-artifact@v2
+  #       uses: actions/upload-artifact@v3
   #       with:
   #         name: LinuxStaticDebug
   #         path: ./cpp/build/out.tgz
@@ -338,7 +338,7 @@ jobs:
         tar -zcf out.tgz cg*
 
     - name: publish artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: LinuxStaticRelease
         path: ./cpp/build/out.tgz
@@ -366,7 +366,7 @@ jobs:
   #       tar -zcf out.tgz cg*
 
   #     - name: publish artifact
-  #       uses: actions/upload-artifact@v2
+  #       uses: actions/upload-artifact@v3
   #       with:
   #         name: Win32SharedDebug
   #         path: ./cpp/build/out.tgz
@@ -393,7 +393,7 @@ jobs:
         tar -zcf out.tgz cg*
 
     - name: publish artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Win32SharedRelease
         path: ./cpp/build/out.tgz
@@ -421,7 +421,7 @@ jobs:
   #       tar -zcf out.tgz cg*
 
   #     - name: publish artifact
-  #       uses: actions/upload-artifact@v2
+  #       uses: actions/upload-artifact@v3
   #       with:
   #         name: Win32StaticDebug
   #         path: ./cpp/build/out.tgz
@@ -448,7 +448,7 @@ jobs:
         tar -zcf out.tgz cg*
 
     - name: publish artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Win32StaticRelease
         path: ./cpp/build/out.tgz
@@ -476,7 +476,7 @@ jobs:
   #       tar -zcf out.tgz cg*
 
   #     - name: publish artifact
-  #       uses: actions/upload-artifact@v2
+  #       uses: actions/upload-artifact@v3
   #       with:
   #         name: x64SharedDebug
   #         path: ./cpp/build/out.tgz
@@ -503,7 +503,7 @@ jobs:
         tar -zcf out.tgz cg*
 
     - name: publish artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: x64SharedRelease
         path: ./cpp/build/out.tgz
@@ -531,7 +531,7 @@ jobs:
   #       tar -zcf out.tgz cg*
 
   #     - name: publish artifact
-  #       uses: actions/upload-artifact@v2
+  #       uses: actions/upload-artifact@v3
   #       with:
   #         name: x64StaticDebug
   #         path: ./cpp/build/out.tgz
@@ -558,7 +558,7 @@ jobs:
         tar -zcf out.tgz cg*
 
     - name: publish artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: x64StaticRelease
         path: ./cpp/build/out.tgz

--- a/.github/workflows/buildArtifactsForPackage.yml
+++ b/.github/workflows/buildArtifactsForPackage.yml
@@ -14,7 +14,7 @@ jobs:
     needs: [LinuxSharedReleaseBuild, LinuxStaticReleaseBuild, Win32SharedReleaseBuild, Win32StaticReleaseBuild, x64SharedReleaseBuild, x64StaticReleaseBuild]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: update system
       run:  sudo apt-get update
@@ -211,7 +211,7 @@ jobs:
   #   runs-on: ubuntu-latest
     
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v3
 
   #   - name: update system
   #     run:  sudo apt-get update
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: update system
       run:  sudo apt-get update
@@ -280,7 +280,7 @@ jobs:
   #   runs-on: ubuntu-latest
     
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v3
 
   #   - name: update system
   #     run:  sudo apt-get update
@@ -314,7 +314,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: update system
       run:  sudo apt-get update
@@ -349,7 +349,7 @@ jobs:
   #   runs-on: windows-latest
     
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v3
     
   #   - name: cmake generate solution Debug
   #     run: cmake -S ./cpp --preset="VS2022-Win32-shared"
@@ -376,7 +376,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: cmake generate solution Release
       run: cmake -S ./cpp --preset="VS2022-Win32-shared"
@@ -404,7 +404,7 @@ jobs:
   #   runs-on: windows-latest
     
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v3
     
   #   - name: cmake generate solution Debug
   #     run: cmake -S ./cpp --preset="VS2022-Win32-static"
@@ -431,7 +431,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: cmake generate solution Release
       run: cmake -S ./cpp --preset="VS2022-Win32-static"
@@ -459,7 +459,7 @@ jobs:
   #   runs-on: windows-latest
     
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v3
     
   #   - name: cmake generate solution Debug
   #     run: cmake -S ./cpp --preset="VS2022-x64-shared"
@@ -486,7 +486,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: cmake generate solution Release
       run: cmake -S ./cpp --preset="VS2022-x64-shared"
@@ -514,7 +514,7 @@ jobs:
   #   runs-on: windows-latest
     
   #   steps:
-  #   - uses: actions/checkout@v2
+  #   - uses: actions/checkout@v3
     
   #   - name: cmake generate solution Debug
   #     run: cmake -S ./cpp --preset="VS2022-x64-static"
@@ -541,7 +541,7 @@ jobs:
     runs-on: windows-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: cmake generate solution Release
       run: cmake -S ./cpp --preset="VS2022-x64-static"

--- a/.github/workflows/buildLinuxSharedReleaseAndTest.yml
+++ b/.github/workflows/buildLinuxSharedReleaseAndTest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: update system
       run:  sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 * Extensive library for reading and checking scenarios.
-* Fully compliant to [OpenSCENARIO 1.1](https://www.asam.net/standards/detail/openscenario/)
+* Fully compliant to [OpenSCENARIO 1.2](https://www.asam.net/standards/detail/openscenario/)
 * Includes an executable checker (See [Getting Started](./doc/main.adoc#getting-started-on-c)).
 * Implementation platform is C++
 

--- a/cpp/buildArtifact/clean.sh
+++ b/cpp/buildArtifact/clean.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # get script folder
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 cd "${SCRIPT_DIR}"
 
 echo "rm -rf ../build/cg*"

--- a/cpp/buildArtifact/collectHeaderFiles.sh
+++ b/cpp/buildArtifact/collectHeaderFiles.sh
@@ -1,22 +1,20 @@
 #!/bin/bash
 
-
 ################################################################
 # setup some variables
 ################################################################
 # get script folder
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # cd to project root
 cd "${SCRIPT_DIR}/../"
 # set openSCENARIO API folder, e.g. openScenario.API
 # check for parameter
-if [[ $1 == "" ]] ; then
+if [[ $1 == "" ]]; then
     echo "Parameter missing."
     echo "Usage: $0 <openSCENARIO API folder>"
     exit -1
 fi
 OPEN_SCEANARIO_API=$1
-
 
 ################################################################
 # prepare include files
@@ -29,16 +27,15 @@ FIND_HEADERS_SH=${FIND_HEADERS_SH_PATH}/${FIND_HEADERS_SH_FILE}
 
 # prepare inlude paths for C++ compiler in order to extract ALL necessary non-system include files
 # this has to be done outside the openScenarioReader project folder to also reach all referenced external dependencies
-echo "#!/bin/bash" > ${FIND_HEADERS_SH}
-echo "cpp -DCOLLECT_HEADERS -DSUPPORT_OSC_1_0 -DSUPPORT_OSC_1_1 -DSUPPORT_OSC_1_2 -MM \\" >> ${FIND_HEADERS_SH}
-for i in `find . -type d -print` ; do
-    if [[ $i == *"CMake"* ]] || [[ $i == *"antlr_runtime"* ]] || [[ $i == *"ython"* ]] || [[ $i == *"java"* ]] || [[ $i == *".dir"* ]] || [[ $i == "./build"* ]] ;
-    then
-        continue ;
+echo "#!/bin/bash" >${FIND_HEADERS_SH}
+echo "cpp -DCOLLECT_HEADERS -DSUPPORT_OSC_1_0 -DSUPPORT_OSC_1_1 -DSUPPORT_OSC_1_2 -MM \\" >>${FIND_HEADERS_SH}
+for i in $(find . -type d -print); do
+    if [[ $i == *"CMake"* ]] || [[ $i == *"antlr_runtime"* ]] || [[ $i == *"ython"* ]] || [[ $i == *"java"* ]] || [[ $i == *".dir"* ]] || [[ $i == "./build"* ]]; then
+        continue
     fi
-    echo "-I $i \\" >> ${FIND_HEADERS_SH} ;
+    echo "-I $i \\" >>${FIND_HEADERS_SH}
 done
-echo ${FIND_HEADERS_SH_PATH}/OpenScenarioReader.cpp -std=c++11 >> ${FIND_HEADERS_SH}
+echo ${FIND_HEADERS_SH_PATH}/OpenScenarioReader.cpp -std=c++11 >>${FIND_HEADERS_SH}
 
 # give the findHeaders.sh exec rights
 chmod a+x ${FIND_HEADERS_SH}
@@ -50,12 +47,11 @@ mkdir -p "${SCRIPT_DIR}/${OPEN_SCEANARIO_API}/include"
 
 # and now let the compiler collect all necessary dependent header files
 # and copy them preserving their directory structure
-for i in `./${FIND_HEADERS_SH}` ; do
-    if [[ $i != "\\" ]] && [[ $i != *".cpp"* ]] && \
-       [[ $i != *".o"* ]] && [[ $i != *"openScenarioReader"* ]] ; then
-        cp -i --parents $i  "${SCRIPT_DIR}/${OPEN_SCEANARIO_API}/include" ;
-    fi ;
+for i in $(./${FIND_HEADERS_SH}); do
+    if [[ $i != "\\" ]] && [[ $i != *".cpp"* ]] \
+        && [[ $i != *".o"* ]] && [[ $i != *"openScenarioReader"* ]]; then
+        cp -i --parents $i "${SCRIPT_DIR}/${OPEN_SCEANARIO_API}/include"
+    fi
 done
 
 cd "${SCRIPT_DIR}"
-

--- a/cpp/buildArtifact/copyExamples.sh
+++ b/cpp/buildArtifact/copyExamples.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # get script folder
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 cd ${SCRIPT_DIR}
 
 # available configurations binary and build dirs

--- a/cpp/buildArtifact/createCMakeLists.sh
+++ b/cpp/buildArtifact/createCMakeLists.sh
@@ -1,21 +1,18 @@
 #!/bin/bash
 
-
 ################################################################
 # get script folder
 ################################################################
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 ################################################################
 # Check for parameters; print help
 ################################################################
-if [ "$1" == "" ] && [ "$2" == "" ] ; then
+if [ "$1" == "" ] && [ "$2" == "" ]; then
     echo "Parameters missing."
     echo "Usage: $0 <OpenSCENARIO API folder> shared|static"
     exit -1
 fi
-
 
 ################################################################
 # Parse cmd line params
@@ -26,25 +23,23 @@ BINDING_TYPE="ON"
 BINDING_TYPE_CAP="SHARED"
 for i in $*; do
     case "$i" in
-    "debug")
-        BUILD_TYPE="debug"
-        BUILD_TYPE_CAP="Debug"
-        ;;
-    "static")
-        BINDING_TYPE="OFF"
-        BINDING_TYPE_CAP="STATIC"
-        ;;
-    *) ;;
+        "debug")
+            BUILD_TYPE="debug"
+            BUILD_TYPE_CAP="Debug"
+            ;;
+        "static")
+            BINDING_TYPE="OFF"
+            BINDING_TYPE_CAP="STATIC"
+            ;;
+        *) ;;
     esac
 done
-
 
 ################################################################
 # cd to artifact folder
 ################################################################
 OPEN_SCEANARIO_API=$1
 cd "${SCRIPT_DIR}/${OPEN_SCEANARIO_API}"
-
 
 ################################################################
 # CMakeLists.txt prefix
@@ -114,12 +109,12 @@ message ( \"Building all into: \${CMAKE_BINARY_DIR}\" )
 
 
 ################################################################
-# Include folders" > CMakeLists.txt
+# Include folders" >CMakeLists.txt
 
 # CMakeLists.txt includes
-for i in `find ./include -type d -print` ; do
-    j=`echo $i | cut -c3-`
-    echo "include_directories( \${CMAKE_SOURCE_DIR}/$j )" >> CMakeLists.txt
+for i in $(find ./include -type d -print); do
+    j=$(echo $i | cut -c3-)
+    echo "include_directories( \${CMAKE_SOURCE_DIR}/$j )" >>CMakeLists.txt
 done
 
 # CMakeLists.txt sources, headers, target def
@@ -245,4 +240,4 @@ if( BUILD_SHARED_LIBS )
             )
     endif()
 endif()
-" >> CMakeLists.txt
+" >>CMakeLists.txt

--- a/cpp/buildArtifact/createHeaderWithExports.sh
+++ b/cpp/buildArtifact/createHeaderWithExports.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Include all header files exporting symbols created with the Linux bash command (execute in cpp/applications/openScenarioReader/src):
-cwd=`pwd`
+cwd=$(pwd)
 cd ../applications/openScenarioReader/src
-echo "#pragma once" > headerWithExports.h ; for fullfile in `find ../../../ -name "*.h" -exec grep -l -h -e "OPENSCENARIOLIB_EXP" \{\} \;` ; do echo "#include \"${fullfile##*/}\"" >> headerWithExports.h ; done
+echo "#pragma once" >headerWithExports.h
+for fullfile in $(find ../../../ -name "*.h" -exec grep -l -h -e "OPENSCENARIOLIB_EXP" \{\} \;); do echo "#include \"${fullfile##*/}\"" >>headerWithExports.h; done
 cd "${cwd}"

--- a/cpp/buildArtifact/createLinuxWindowsBinPackage.sh
+++ b/cpp/buildArtifact/createLinuxWindowsBinPackage.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-
 ################################################################
 # get script folder
 ################################################################
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 ################################################################
 # Check for parameters; print help
@@ -15,7 +13,6 @@ if [ "$1" == "" ] || [ "$1" == "h" ] || [ "$1" == "help" ] || [ "$1" == "-h" ] |
     echo "  release and Linux are default."
     exit 0
 fi
-
 
 ################################################################
 # Parse cmd line params
@@ -29,26 +26,25 @@ PLATFORM_NAME="Linux"
 PLATFORM_PATH=
 for i in $*; do
     case "$i" in
-    "debug")
-        BUILD_TYPE="debug"
-        BUILD_TYPE_CAP="Debug"
-        ;;
-    "static")
-        BINDING_TYPE="static"
-        BINDING_TYPE_CAP="Static"
-        ;;
-    "Win32")
-        PLATFORM_NAME="Win32"
-        PLATFORM_PATH="Windows/"
-        ;;
-    "x64")
-        PLATFORM_NAME="x64"
-        PLATFORM_PATH="Windows/"
-        ;;
-    *) ;;
+        "debug")
+            BUILD_TYPE="debug"
+            BUILD_TYPE_CAP="Debug"
+            ;;
+        "static")
+            BINDING_TYPE="static"
+            BINDING_TYPE_CAP="Static"
+            ;;
+        "Win32")
+            PLATFORM_NAME="Win32"
+            PLATFORM_PATH="Windows/"
+            ;;
+        "x64")
+            PLATFORM_NAME="x64"
+            PLATFORM_PATH="Windows/"
+            ;;
+        *) ;;
     esac
 done
-
 
 ################################################################
 # setup some variables anf prepare target dir
@@ -63,7 +59,6 @@ OSC_LIBS="expressionsLib openScenarioLib antlr4_runtime/src/antlr4_runtime/runti
 rm -rf "${SCRIPT_DIR}/${OPEN_SCEANARIO_API}"/*
 mkdir -p "${SCRIPT_DIR}/${OPEN_SCEANARIO_API}"
 
-
 ################################################################
 # prepare includes and copy source(s)
 ################################################################
@@ -75,34 +70,34 @@ ${SCRIPT_DIR}/collectHeaderFiles.sh ${OPEN_SCEANARIO_API}
 mkdir -p "${SCRIPT_DIR}/${OPEN_SCEANARIO_API}/src/"
 cp -r "${SCRIPT_DIR}/../applications/openScenarioReader/src/OpenScenarioReader.cpp" "${SCRIPT_DIR}/${OPEN_SCEANARIO_API}/src/"
 
-
 ################################################################
 # prepare CMakeLists.txt
 ################################################################
 cp -f "${SCRIPT_DIR}/../CMakeHelpers.cmake" "${SCRIPT_DIR}/${OPEN_SCEANARIO_API}"
 "${SCRIPT_DIR}/createCMakeLists.sh" ${OPEN_SCEANARIO_API} ${BINDING_TYPE} ${BUILD_TYPE}
 
-
 ################################################################
 # copy examples
 ################################################################
 cp -r "${SCRIPT_DIR}/../applications/openScenarioTester/res" "${SCRIPT_DIR}/${OPEN_SCEANARIO_API}"
 
-
 ################################################################
 # prepare lib files
 ################################################################
 # check if libraries are already compiled
-if [ ${PLATFORM_NAME} == "Linux" ] ; then
-    if [ ! -d "${SCRIPT_DIR}/../build/cg${BUILD_TYPE_CAP}Make${BINDING_TYPE_CAP}/" ] ; then
+if [ ${PLATFORM_NAME} == "Linux" ]; then
+    if [ ! -d "${SCRIPT_DIR}/../build/cg${BUILD_TYPE_CAP}Make${BINDING_TYPE_CAP}/" ]; then
         echo "Please run './generateLinux.sh ${BUILD_TYPE} ${BINDING_TYPE} make' to compile the OpenSCENARIO libraries!"
         exit -1
     fi
 else
     VISUAL_STUDIO=""
     # determine Visual Studio version
-    for j in 2010 2012 2013 2015 2017 2019 2022; do if [[ -d "${SCRIPT_DIR}/../build/cgMultiVS${j}${PLATFORM_NAME}${BINDING_TYPE_CAP}" ]]; then VISUAL_STUDIO=${j}; break; fi; done
-    if [ "${VISUAL_STUDIO}" == "" ] || [ ! -d "${SCRIPT_DIR}/../build/cgMultiVS${VISUAL_STUDIO}${PLATFORM_NAME}${BINDING_TYPE_CAP}/" ] ; then
+    for j in 2010 2012 2013 2015 2017 2019 2022; do if [[ -d "${SCRIPT_DIR}/../build/cgMultiVS${j}${PLATFORM_NAME}${BINDING_TYPE_CAP}" ]]; then
+        VISUAL_STUDIO=${j}
+        break
+    fi; done
+    if [ "${VISUAL_STUDIO}" == "" ] || [ ! -d "${SCRIPT_DIR}/../build/cgMultiVS${VISUAL_STUDIO}${PLATFORM_NAME}${BINDING_TYPE_CAP}/" ]; then
         echo "Please run './generateWindows.bat (VS2010|...|VS2022) ${BUILD_TYPE} ${BINDING_TYPE} ${PLATFORM_NAME} make' to compile the OpenSCENARIO libraries!"
         exit -1
     fi
@@ -112,27 +107,27 @@ fi
 mkdir -p "${OPEN_SCEANARIO_API}/lib/${PLATFORM_PATH}${PLATFORM_NAME}"
 
 # determine libs extension
-if [ ${PLATFORM_NAME} == "Linux" ] ; then
+if [ ${PLATFORM_NAME} == "Linux" ]; then
     LIB_SHST="lib*.a"
-    if [ ${BINDING_TYPE} == "shared" ] ; then
+    if [ ${BINDING_TYPE} == "shared" ]; then
         LIB_SHST="lib*.so*"
     fi
 fi
 
 # platform dependent build folder
 PLATFORM_SPECIFIC_PATH="cgMultiVS${VISUAL_STUDIO}${PLATFORM_NAME}${BINDING_TYPE_CAP}"
-if [ ${PLATFORM_NAME} == "Linux" ] ; then
+if [ ${PLATFORM_NAME} == "Linux" ]; then
     PLATFORM_SPECIFIC_PATH="cg${BUILD_TYPE_CAP}Make${BINDING_TYPE_CAP}"
 fi
 
 # copy all osc libs
-for LIB in ${OSC_LIBS} ; do
-    if [ ${PLATFORM_NAME} == "Linux" ] ; then
+for LIB in ${OSC_LIBS}; do
+    if [ ${PLATFORM_NAME} == "Linux" ]; then
         cp -r "${SCRIPT_DIR}"/../build/${PLATFORM_SPECIFIC_PATH}/${LIB}/${LIB_SHST} "${OPEN_SCEANARIO_API}/lib/${PLATFORM_PATH}${PLATFORM_NAME}"
     fi
-    if [ ${PLATFORM_NAME} == "Win32" ] || [ ${PLATFORM_NAME} == "x64" ] ; then
+    if [ ${PLATFORM_NAME} == "Win32" ] || [ ${PLATFORM_NAME} == "x64" ]; then
         cp -r "${SCRIPT_DIR}"/../build/${PLATFORM_SPECIFIC_PATH}/${LIB}/${BUILD_TYPE_CAP}/*.lib "${OPEN_SCEANARIO_API}/lib/${PLATFORM_PATH}${PLATFORM_NAME}"
-        if [ ${BINDING_TYPE} == "shared" ] ; then
+        if [ ${BINDING_TYPE} == "shared" ]; then
             cp -r "${SCRIPT_DIR}"/../build/${PLATFORM_SPECIFIC_PATH}/${LIB}/${BUILD_TYPE_CAP}/*.dll "${OPEN_SCEANARIO_API}/lib/${PLATFORM_PATH}${PLATFORM_NAME}"
             cp -r "${SCRIPT_DIR}"/../build/${PLATFORM_SPECIFIC_PATH}/${LIB}/${BUILD_TYPE_CAP}/*.exp "${OPEN_SCEANARIO_API}/lib/${PLATFORM_PATH}${PLATFORM_NAME}"
         fi
@@ -142,13 +137,12 @@ done
 # strip debug infos
 #strip -s "${OPEN_SCEANARIO_API}"/lib/Linux/*
 
-
 ################################################################
 # create package
 ################################################################
 # tar and gzip
-CUR_DATE=`date '+%Y.%m.%d'`
-if [ ${PLATFORM_NAME} == "Linux" ] ; then
+CUR_DATE=$(date '+%Y.%m.%d')
+if [ ${PLATFORM_NAME} == "Linux" ]; then
     tar -zcf "${OPEN_SCEANARIO_API}_${CUR_DATE}.tgz" "${OPEN_SCEANARIO_API}"
 else
     zip -rq "${OPEN_SCEANARIO_API}_${CUR_DATE}.zip" "${OPEN_SCEANARIO_API}"

--- a/cpp/buildArtifact/d2u.sh
+++ b/cpp/buildArtifact/d2u.sh
@@ -1,1 +1,1 @@
-for i in `ls *.sh`; do sed -i $'s/\r$//' $i; done
+for i in $(ls *.sh); do sed -i $'s/\r$//' $i; done

--- a/cpp/buildArtifact/generateLinux.sh
+++ b/cpp/buildArtifact/generateLinux.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-
 ################################
 # Script-Dir: https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-
 
 ################################
 # Print help
@@ -19,14 +17,12 @@ if [ "$1" == "" ] || [ $1 == "h" ] || [ $1 == "help" ] || [ $1 == "-h" ] || [ $1
     exit 0
 fi
 
-
 ################################
 # Check if cmake is installed
 command -v cmake >/dev/null 2>&1 || {
     echo >&2 "cmake is required to build the software. Please install cmake and add its bin path to the PATH environment variable. Aborting"
     exit 1
 }
-
 
 ################################
 # Parse cmd line params
@@ -38,16 +34,16 @@ if [ $1 == "all" ]; then
     MAKE_TEXT=" and compiling"
     for i in $*; do
         case "$i" in
-        "release")
-            BUILD_TYPES="release"
-            ;;
-        "shared")
-            BINDING_TYPES="shared"
-            ;;
-        "parallel")
-            PAR="-j 4"
-            ;;
-        *) ;;
+            "release")
+                BUILD_TYPES="release"
+                ;;
+            "shared")
+                BINDING_TYPES="shared"
+                ;;
+            "parallel")
+                PAR="-j 4"
+                ;;
+            *) ;;
         esac
     done
 # Single config build
@@ -58,29 +54,27 @@ else
     MAKE_TEXT=""
     for i in $*; do
         case "$i" in
-        "debug")
-            BUILD_TYPES="debug"
-            ;;
-        "static")
-            BINDING_TYPES="static"
-            ;;
-        "make")
-            MAKE="yes"
-            MAKE_TEXT=" and compiling"
-            ;;
-        "parallel")
-            PAR="-j 4"
-            ;;
-        *) ;;
+            "debug")
+                BUILD_TYPES="debug"
+                ;;
+            "static")
+                BINDING_TYPES="static"
+                ;;
+            "make")
+                MAKE="yes"
+                MAKE_TEXT=" and compiling"
+                ;;
+            "parallel")
+                PAR="-j 4"
+                ;;
+            *) ;;
         esac
     done
 fi
 
-
 ################################
 # Remember user dir
 USER_DIR="$(pwd)"
-
 
 ################################
 # Root-Dir
@@ -96,13 +90,11 @@ echo "OpenSCENARIO root dir: $ROOT_DIR"
 cd "$ROOT_DIR/cpp"
 echo "Entering $ROOT_DIR/cpp"
 
-
 ################################
 # Get cmake version
 CMV=$(cmake --version | egrep -o "[0-9]+\.[0-9]+")
 CMV_MAJOR=$(echo $CMV | cut -d '.' -f1 -)
 CMV_MINOR=$(echo $CMV | cut -d '.' -f2 -)
-
 
 ################################################################################
 # Build the release binaries cmake version dependent
@@ -158,7 +150,6 @@ else
         done
     done
 fi
-
 
 ################################
 # Return to user dir

--- a/generator/docker/commands/generate.sh
+++ b/generator/docker/commands/generate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 cd /opt/osc-generator/de.rac.openscenario.generator/target
-export CLASSPATH=de.rac.openscenario.generator-1.2.2-jar-with-dependencies.jar 
+export CLASSPATH=de.rac.openscenario.generator-1.2.2-jar-with-dependencies.jar
 
 java de.rac.openscenario.generator.cpp.GeneratorCpp /outputDir


### PR DESCRIPTION
#### Reference to a related issue in the repository
#189 #191 #193 

#### Add a description
Updated bash scripts which are now formatted by shfmt.
Updated action workflow scripts to use Node.js 16.

**Some questions to ask**:
What is this change?
bash scripts formatted with shfmt
workflow scripts replaced ...@v2 by ...v3

What does it fix?
bash scripts are now consistent and easier to maintain.
workflow scripts don't show a deprecated warning any longer.

Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
How has it been tested?
Only scripts were updated, main code was not touched.

#### Mention a member
@Deakon997 

#### Check the checklist

- [x] My code follows the [contributors guidelines](htxps://github.com/ahege/openscenario.api.test/blob/master/doc/howtocontribute.rst) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/ahege/openscenario.api.test/blob/master/doc).
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests / travis ci pass locally with my changes.
