### PR TITLE
Fix increment of _occuredElementList in XmlSequenceParser.cpp

### DIFF
--- a/cpp/applications/openScenarioTester/res/exampleFilesVersion1_2/FollowTrajectory_Nurbs.xosc
+++ b/cpp/applications/openScenarioTester/res/exampleFilesVersion1_2/FollowTrajectory_Nurbs.xosc
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Copyright 2024 by ASAM e.V.
+ *
+ * ASAM licenses this file under the Apache License, 
+ * Version 2.0 (the "License"); you may not use this file except 
+ * in compliance with the License. 
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *-->
+ <OpenSCENARIO>
+  <FileHeader revMajor="1" revMinor="2" date="2024-06-14T18:15:00" description="FollowTrajectory" author="RGourova"/>
+  <CatalogLocations>
+    <VehicleCatalog>
+      <Directory path="Catalogs/Vehicles"/>
+    </VehicleCatalog>
+  </CatalogLocations>
+  <RoadNetwork>
+    <LogicFile filepath="Databases/SampleDatabase.xodr"/>
+  </RoadNetwork>
+  <Entities>
+    <ScenarioObject name="Ego">
+      <CatalogReference catalogName="VehicleCatalog" entryName="car1"/>
+    </ScenarioObject>
+  </Entities>
+  <Storyboard>
+    <Init>
+      <Actions>
+        <Private entityRef="Ego">
+          <PrivateAction>
+            <TeleportAction>
+              <Position>
+                <WorldPosition x="1.7024039832784507e+02" y="3.4330477905273438e+02" z="0.0000000000000000e+00" h="1.5707963267948966e+00" p="0.0000000000000000e+00" r="0.0000000000000000e+00"/>
+              </Position>
+            </TeleportAction>
+          </PrivateAction>
+        </Private>
+      </Actions>
+    </Init>
+    <Story name="FollowTrajectoryStory">
+      <ParameterDeclarations>
+        <ParameterDeclaration parameterType="string" name="$owner" value="Ego"/>
+      </ParameterDeclarations>
+      <Act name="FollowTrajectoryAct">
+        <ManeuverGroup maximumExecutionCount="1" name="FollowTrajectorySequence">
+          <Actors selectTriggeringEntities="false">
+            <EntityRef entityRef="$owner"/>
+          </Actors>
+          <Maneuver name="FollowTrajectoryManeuver">
+            <Event name="FollowTrajectoryEvent" priority="override">
+              <Action name="FollowTrajectoryAction">
+                <PrivateAction>
+                  <RoutingAction>
+                    <FollowTrajectoryAction>
+                      <TrajectoryRef>
+                        <Trajectory name="trajectory1" closed="false">
+                          <Shape>
+                            <Nurbs order="3">
+                              <ControlPoint time="0.0" weight="1.0">
+                                <Position>
+                                  <RelativeRoadPosition dt="0" ds="0" entityRef="$owner"/>
+                                </Position>
+                              </ControlPoint>
+                              <ControlPoint time="1.25" weight="1.0">
+                                <Position>
+                                  <RelativeLanePosition dLane="0" ds="15" entityRef="$owner" offset="10.0"/>
+                                </Position>
+                              </ControlPoint>
+                              <ControlPoint time="2.5" weight="1.0">
+                                <Position>
+                                  <RelativeLanePosition dLane="2" ds="30" entityRef="$owner" offset="-5.0"/>
+                                </Position>
+                              </ControlPoint>
+                              <ControlPoint time="3.75" weight="1.0">
+                                <Position>
+                                  <RelativeLanePosition dLane="1" ds="60" entityRef="$owner" offset="0.0"/>
+                                </Position>
+                              </ControlPoint>
+                              <ControlPoint time="5.0" weight="1.0">
+                                <Position>
+                                  <RelativeLanePosition dLane="2" ds="100" entityRef="$owner" offset="0.0"/>
+                                </Position>
+                              </ControlPoint>
+                              <Knot value="0.0"/>
+                              <Knot value="0.0"/>
+                              <Knot value="0.0"/>
+                              <Knot value="1.0"/>
+                              <Knot value="2.0"/>
+                              <Knot value="3.0"/>
+                              <Knot value="3.0"/>
+                              <Knot value="3.0"/>
+                            </Nurbs>
+                          </Shape>
+                        </Trajectory>
+                      </TrajectoryRef>
+                      <TimeReference>
+                        <Timing domainAbsoluteRelative="absolute" scale="1" offset="0"/>
+                      </TimeReference>
+                      <TrajectoryFollowingMode followingMode="position"/>
+                    </FollowTrajectoryAction>
+                  </RoutingAction>
+                </PrivateAction>
+              </Action>
+              <StartTrigger/>
+            </Event>
+          </Maneuver>
+        </ManeuverGroup>
+        <StartTrigger>
+          <ConditionGroup>
+            <Condition name="FollowTrajectoryActStart" delay="0" conditionEdge="rising">
+              <ByValueCondition>
+                <SimulationTimeCondition value="0" rule="greaterThan"/>
+              </ByValueCondition>
+            </Condition>
+          </ConditionGroup>
+        </StartTrigger>
+      </Act>
+    </Story>
+    <StopTrigger>
+      <ConditionGroup>
+        <Condition name="FollowTrajectoryActEnd" delay="0" conditionEdge="rising">
+          <ByValueCondition>
+            <SimulationTimeCondition value="10" rule="greaterThan"/>
+          </ByValueCondition>
+        </Condition>
+      </ConditionGroup>
+    </StopTrigger>
+  </Storyboard>
+</OpenSCENARIO>

--- a/cpp/applications/openScenarioTester/src/TestExamplesOscV1_2.cpp
+++ b/cpp/applications/openScenarioTester/src/TestExamplesOscV1_2.cpp
@@ -82,6 +82,7 @@ namespace NET_ASAM_OPENSCENARIO
 				"SlowPrecedingVehicleStochasticParameterSet.xosc",
 				"SynchronizedArrivalToIntersection.xosc",
 				"TrafficJam.xosc",
+				"FollowTrajectory_Nurbs.xosc",
 			};
 			return TestFiles(scenarioFiles, pathNameScenarios);
 		}

--- a/cpp/openScenarioLib/src/parser/modelgroup/XmlSequenceParser.cpp
+++ b/cpp/openScenarioLib/src/parser/modelgroup/XmlSequenceParser.cpp
@@ -70,7 +70,15 @@ namespace NET_ASAM_OPENSCENARIO
                         parser->Parse(indexedElement, parserContext, object);
                         currentListIndex = this->MoveForwardToLastElementParsed(indexedElements, currentListIndex, parserContext->GetLastElementParsed());
                         lastElementParsed = parserContext->GetLastElementParsed();
-                        _occuredElementList.emplace(std::make_pair(parser, currentOccurs + 1));
+                        auto it = _occuredElementList.find(parser);
+                        if (it != _occuredElementList.end()) 
+                        {
+                            it->second = currentOccurs + 1;
+                        } 
+                        else 
+                        {
+                            _occuredElementList.emplace(parser, currentOccurs + 1);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
#### Reference to a related issue in the repository
Related to issue #209 

#### Add a description
The proposed changes fix a bug related to `_occuredElementList` in `XmlSequenceParser::XmlSequenceParser`. The change introduces a check if `_occuredElementList` contains a parser, and, if it does,  the number of times the parser has been encountered is incremented, otherwise a new key is created in `_occuredElementList` for the parser. 

Added a new scenario (cpp/applications/openScenarioTester/res/exampleFilesVersion1_2/FollowTrajectory_Nurbs.xosc) to test the changes.

#### Check the checklist

- [X] My code follows the [contributors guidelines](https://github.com/ahege/openscenario.api.test/blob/master/doc/howtocontribute.rst) of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the [documentation](https://github.com/ahege/openscenario.api.test/blob/master/doc).
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests / travis ci pass locally with my changes.
