### PR TITLE
Support cross compilation

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -519,6 +519,42 @@
             "hidden": true
         },
         {
+            "name": "Cross-shared",
+            "cacheVariables": {
+                "BUILD_SHARED_LIBS": {
+                    "type": "BOOL",
+                    "value": "ON"
+                },
+                "CMAKE_C_COMPILER": {
+                    "type": "STRING",
+                    "value": "/usr/bin/x86_64-w64-mingw32-gcc"
+                },
+                "CMAKE_CXX_COMPILER": {
+                    "type": "STRING",
+                    "value": "/usr/bin/x86_64-w64-mingw32-g++"
+                },
+                "CMAKE_SYSTEM_NAME": {
+                    "type": "STRING",
+                    "value": "Windows"
+                },
+                "CMAKE_SYSTEM_VERSION": {
+                    "type": "STRING",
+                    "value": "10.0"
+                },
+                "CMAKE_CXX_STANDARD": {
+                    "type": "STRING",
+                    "value": "11"
+                }
+            },
+            "environment": {
+                "PR_ENV_BINDING": "Shared"
+            },
+            "inherits": [
+                "Unix-Makefiles"
+            ],
+            "hidden": true
+        },
+        {
             "name": "Linux-shared-debug",
             "displayName": "Linux shared debug",
             "description": "Build using Unix Makefiles",
@@ -576,9 +612,24 @@
                 "Build-type-relWithDebInfo"
             ],
             "hidden": true
+        },
+        {
+            "name": "Cross-shared-release",
+            "displayName": "Cross shared release",
+            "description": "Build using cross compilation",
+            "inherits": [
+                "Cross-shared",
+                "Build-type-release"
+            ]
         }
     ],
     "buildPresets": [
+        {
+            "name": "Build-Cross-shared-release",
+            "description": "Build the shared project with cross compilation",
+            "displayName": "Build Cross shared release",
+            "configurePreset": "Cross-shared-release"
+        },
         {
             "name": "Build-Linux-shared-release",
             "description": "Build shared release using Unix Makefiles",

--- a/cpp/buildAntlr4/ExternalAntlr4Cpp.cmake
+++ b/cpp/buildAntlr4/ExternalAntlr4Cpp.cmake
@@ -94,6 +94,10 @@ if(ANTLR4_ZIP_REPOSITORY)
           -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
           # -DCMAKE_CXX_STANDARD:STRING=17 # if desired, compile the runtime with a different C++ standard
           # -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD} # alternatively, compile the runtime with the same C++ standard as the outer project
+          -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
+          -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}
+          -DCMAKE_SYSTEM_NAME:STRING=${CMAKE_SYSTEM_NAME}
+          -DCMAKE_SYSTEM_VERSION:STRING=${CMAKE_SYSTEM_VERSION}
       INSTALL_COMMAND ""
       EXCLUDE_FROM_ALL 1)
 else()


### PR DESCRIPTION
This pull request addresses the issue [215](https://github.com/RA-Consulting-GmbH/openscenario.api.test/issues/215), which requests support for cross-compilation in CMakePresets.

#### Description
This PR introduces support for cross-compilation in CMakePresets. It allows developers to specify different compilers and target system configurations directly within the CMakePresets file, thereby enabling seamless cross-compilation.

This change addresses the lack of native support for cross-compilation in CMakePresets. Specifically, it enables developers to build Windows binaries on a Linux host using the MinGW toolchain, by allowing the configuration of the following compilers:

C Compiler: /usr/bin/x86_64-w64-mingw32-gcc
C++ Compiler: /usr/bin/x86_64-w64-mingw32-g++

This is a feature enhancement. It does not break any existing functionality nor does it force users to update to a new version. Existing CMakePresets configurations remain unaffected unless users choose to utilize the new cross-compilation capabilities.
